### PR TITLE
MAT-872: Fix import/export state with bor

### DIFF
--- a/cmd/bor/chaincmd.go
+++ b/cmd/bor/chaincmd.go
@@ -61,7 +61,7 @@ It expects the genesis file as argument.`,
 		Action:    utils.MigrateFlags(importChain),
 		Name:      "import",
 		Usage:     "Import a blockchain file",
-		ArgsUsage: "<filename> (<filename 2> ... <filename N>) ",
+		ArgsUsage: "<filename> (<filename 2> ... <filename N>) <genesisPath>",
 		Flags: []cli.Flag{
 			utils.DataDirFlag,
 			utils.CacheFlag,
@@ -228,8 +228,8 @@ func initGenesis(ctx *cli.Context) error {
 }
 
 func importChain(ctx *cli.Context) error {
-	if len(ctx.Args()) < 1 {
-		utils.Fatalf("This command requires an argument.")
+	if len(ctx.Args()) < 2 {
+		utils.Fatalf("This command requires atleast 2 arguments.")
 	}
 	stack := makeFullNode(ctx)
 	defer stack.Close()
@@ -255,12 +255,13 @@ func importChain(ctx *cli.Context) error {
 	// Import the chain
 	start := time.Now()
 
-	if len(ctx.Args()) == 1 {
+	// ArgsUsage: "<filename> (<filename 2> ... <filename N>) <genesisPath>",
+	if len(ctx.Args()) == 2 {
 		if err := utils.ImportChain(chain, ctx.Args().First()); err != nil {
 			log.Error("Import error", "err", err)
 		}
 	} else {
-		for _, arg := range ctx.Args() {
+		for _, arg := range ctx.Args()[:len(ctx.Args())-1] {
 			if err := utils.ImportChain(chain, arg); err != nil {
 				log.Error("Import error", "file", arg, "err", err)
 			}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1661,11 +1661,8 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 	return genesis
 }
 
-func getGenesis(ctx *cli.Context) *core.Genesis {
-	genesisPath := ctx.Args().Get(len(ctx.Args()) - 1)
-	if genesisPath == "" {
-		return nil
-	}
+func getGenesis(genesisPath string) *core.Genesis {
+	log.Info("Reading genesis at ", "file", genesisPath)
 	file, _ := os.Open(genesisPath)
 	defer file.Close()
 
@@ -1676,10 +1673,8 @@ func getGenesis(ctx *cli.Context) *core.Genesis {
 
 // MakeChain creates a chain manager from set command line flags.
 func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chainDb ethdb.Database) {
-	genesis := getGenesis(ctx)
-	if genesis == nil {
-		genesis = MakeGenesis(ctx)
-	}
+	// expecting the last argument to be the genesis file
+	genesis := getGenesis(ctx.Args().Get(len(ctx.Args()) - 1))
 
 	var err error
 	chainDb = MakeChainDatabase(ctx, stack)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -19,6 +19,7 @@ package utils
 
 import (
 	"crypto/ecdsa"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -34,6 +35,7 @@ import (
 	"github.com/maticnetwork/bor/common"
 	"github.com/maticnetwork/bor/common/fdlimit"
 	"github.com/maticnetwork/bor/consensus"
+
 	"github.com/maticnetwork/bor/consensus/bor"
 	"github.com/maticnetwork/bor/consensus/clique"
 	"github.com/maticnetwork/bor/consensus/ethash"
@@ -47,6 +49,8 @@ import (
 	"github.com/maticnetwork/bor/ethdb"
 	"github.com/maticnetwork/bor/ethstats"
 	"github.com/maticnetwork/bor/graphql"
+
+	pcsclite "github.com/gballet/go-libpcsclite"
 	"github.com/maticnetwork/bor/les"
 	"github.com/maticnetwork/bor/log"
 	"github.com/maticnetwork/bor/metrics"
@@ -61,7 +65,6 @@ import (
 	"github.com/maticnetwork/bor/params"
 	"github.com/maticnetwork/bor/rpc"
 	whisper "github.com/maticnetwork/bor/whisper/whisperv6"
-	pcsclite "github.com/gballet/go-libpcsclite"
 	cli "gopkg.in/urfave/cli.v1"
 )
 
@@ -1658,19 +1661,68 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 	return genesis
 }
 
+func getGenesis(ctx *cli.Context) *core.Genesis {
+	genesisPath := ctx.Args().Get(len(ctx.Args()) - 1)
+	if genesisPath == "" {
+		return nil
+	}
+	file, _ := os.Open(genesisPath)
+	defer file.Close()
+
+	genesis := new(core.Genesis)
+	json.NewDecoder(file).Decode(genesis)
+	return genesis
+}
+
 // MakeChain creates a chain manager from set command line flags.
 func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chainDb ethdb.Database) {
+	genesis := getGenesis(ctx)
+	if genesis == nil {
+		genesis = MakeGenesis(ctx)
+	}
+
 	var err error
 	chainDb = MakeChainDatabase(ctx, stack)
-	config, _, err := core.SetupGenesisBlock(chainDb, MakeGenesis(ctx))
+	config, _, err := core.SetupGenesisBlock(chainDb, genesis)
 	if err != nil {
 		Fatalf("%v", err)
 	}
+
 	var engine consensus.Engine
+	var ethereum *eth.Ethereum
 	if config.Clique != nil {
 		engine = clique.New(config.Clique, chainDb)
 	} else if config.Bor != nil {
-		engine = bor.New(config, chainDb, nil)
+		cfg := &eth.Config{Genesis: genesis}
+		workspace, err := ioutil.TempDir("", "console-tester-")
+		if err != nil {
+			Fatalf("failed to create temporary keystore: %v", err)
+		}
+
+		// Create a networkless protocol stack and start an Ethereum service within
+		stack, err := node.New(&node.Config{DataDir: workspace, UseLightweightKDF: true, Name: "console-tester"})
+		if err != nil {
+			Fatalf("failed to create node: %v", err)
+		}
+		err = stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
+			s, err := eth.New(ctx, cfg)
+			return s, err
+		})
+		if err != nil {
+			Fatalf("failed to register Ethereum protocol: %v", err)
+		}
+
+		// Start the node and assemble the JavaScript console around it
+		if err = stack.Start(); err != nil {
+			Fatalf("failed to start test stack: %v", err)
+		}
+		_, err = stack.Attach()
+		if err != nil {
+			Fatalf("failed to attach to node: %v", err)
+		}
+
+		stack.Service(&ethereum)
+		engine = ethereum.Engine().(*bor.Bor)
 	} else {
 		engine = ethash.NewFaker()
 		if !ctx.GlobalBool(FakePoWFlag.Name) {
@@ -1702,6 +1754,9 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 	}
 	vmcfg := vm.Config{EnablePreimageRecording: ctx.GlobalBool(VMEnableDebugFlag.Name)}
 	chain, err = core.NewBlockChain(chainDb, cache, config, engine, vmcfg, nil)
+	if ethereum != nil {
+		ethereum.SetBlockchain(chain)
+	}
 	if err != nil {
 		Fatalf("Can't create BlockChain: %v", err)
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -231,6 +231,10 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	return eth, nil
 }
 
+func (s *Ethereum) SetBlockchain(blockchain *core.BlockChain) {
+	s.blockchain = blockchain
+}
+
 func makeExtraData(extra []byte) []byte {
 	if len(extra) == 0 {
 		// create default extradata


### PR DESCRIPTION
Fixes #27 

Steps:
- Keep node1 running awhile, then kill it.
- Export state (all following commands from `bor-devnet` dir)
```
bor --datadir node1 export state.json ../genesis-contracts/genesis.json
```
- Create node and import state
```
bor --datadir node4 init ../genesis-contracts/genesis.json
cp keystore4/* node4/keystore/
bor --datadir node4 import state.json ../genesis-contracts/genesis.json
```