### PR TITLE
new: Add bor.getRootHash(start, end) api method (MAT-1302)

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -441,7 +441,7 @@ func (c *Bor) verifyCascadingFields(chain consensus.ChainReader, header *types.H
 			copy(validatorsBytes[i*validatorHeaderBytesLength:], validator.HeaderBytes())
 		}
 		// len(header.Extra) >= extraVanity+extraSeal has already been validated in validateHeaderExtraField, so this won't result in a panic
-		if !bytes.Equal(header.Extra[extraVanity : len(header.Extra)-extraSeal], validatorsBytes) {
+		if !bytes.Equal(header.Extra[extraVanity:len(header.Extra)-extraSeal], validatorsBytes) {
 			return errMismatchingSprintValidators
 		}
 	}

--- a/consensus/bor/bor_test/helper.go
+++ b/consensus/bor/bor_test/helper.go
@@ -107,13 +107,13 @@ func buildMinimalNextHeader(t *testing.T, block *types.Block, borConfig *params.
 	header.Time += bor.CalcProducerDelay(header.Number.Uint64(), borConfig.Period, borConfig.Sprint, borConfig.ProducerDelay)
 	isSprintEnd := (header.Number.Uint64()+1)%borConfig.Sprint == 0
 	if isSprintEnd {
-		header.Extra = make([]byte, 32 + 40 + 65) // vanity + validatorBytes + extraSeal
+		header.Extra = make([]byte, 32+40+65) // vanity + validatorBytes + extraSeal
 		// the genesis file was initialized with a validator 0x71562b71999873db5b286df957af199ec94617f7 with power 10
 		// So, if you change ./genesis.json, do change the following as well
 		validatorBytes, _ := hex.DecodeString("71562b71999873db5b286df957af199ec94617f7000000000000000000000000000000000000000a")
 		copy(header.Extra[32:72], validatorBytes)
 	} else {
-		header.Extra = make([]byte, 32 + 65) // vanity + extraSeal
+		header.Extra = make([]byte, 32+65) // vanity + extraSeal
 	}
 	_key, _ := hex.DecodeString(privKey)
 	sig, err := secp256k1.Sign(crypto.Keccak256(bor.BorRLP(header)), _key)

--- a/consensus/bor/errors.go
+++ b/consensus/bor/errors.go
@@ -40,3 +40,31 @@ func (e *TotalVotingPowerExceededError) Error() string {
 		e.Validators,
 	)
 }
+
+type InvalidStartEndBlockError struct {
+	Start         int64
+	End           int64
+	CurrentHeader int64
+}
+
+func (e *InvalidStartEndBlockError) Error() string {
+	return fmt.Sprintf(
+		"Invalid parameters start: %d and end block: %d params",
+		e.Start,
+		e.End,
+	)
+}
+
+type MaxCheckpointLengthExceededError struct {
+	Start int64
+	End   int64
+}
+
+func (e *MaxCheckpointLengthExceededError) Error() string {
+	return fmt.Sprintf(
+		"Start: %d and end block: %d exceed max allowed checkpoint length: %d",
+		e.Start,
+		e.End,
+		MaxCheckpointLength,
+	)
+}

--- a/consensus/bor/merkle.go
+++ b/consensus/bor/merkle.go
@@ -1,0 +1,48 @@
+package bor
+
+func appendBytes32(data ...[]byte) []byte {
+	var result []byte
+	for _, v := range data {
+		paddedV, err := convertTo32(v)
+		if err == nil {
+			result = append(result, paddedV[:]...)
+		}
+	}
+	return result
+}
+
+func nextPowerOfTwo(n uint64) uint64 {
+	if n == 0 {
+		return 1
+	}
+	// http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+	n--
+	n |= n >> 1
+	n |= n >> 2
+	n |= n >> 4
+	n |= n >> 8
+	n |= n >> 16
+	n |= n >> 32
+	n++
+	return n
+}
+
+func convertTo32(input []byte) (output [32]byte, err error) {
+	l := len(input)
+	if l > 32 || l == 0 {
+		return
+	}
+	copy(output[32-l:], input[:])
+	return
+}
+
+func convert(input []([32]byte)) [][]byte {
+	var output [][]byte
+	for _, in := range input {
+		newInput := make([]byte, len(in[:]))
+		copy(newInput, in[:])
+		output = append(output, newInput)
+
+	}
+	return output
+}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -248,3 +248,17 @@ func (b *EthAPIBackend) ServiceFilter(ctx context.Context, session *bloombits.Ma
 		go session.Multiplex(bloomRetrievalBatch, bloomRetrievalWait, b.eth.bloomRequests)
 	}
 }
+
+func (b *EthAPIBackend) GetRootHash(ctx context.Context, starBlockNr rpc.BlockNumber, endBlockNr rpc.BlockNumber) ([]byte, error) {
+	var api *bor.API
+	for _, _api := range b.eth.Engine().APIs(b.eth.BlockChain()) {
+		if _api.Namespace == "bor" {
+			api = _api.Service.(*bor.API)
+		}
+	}
+	root, err := api.GetRootHash(starBlockNr.Int64(), endBlockNr.Int64())
+	if err != nil {
+		return nil, err
+	}
+	return root, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef
 	github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208
+	github.com/xsleonard/go-merkle v1.1.0
 	golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef h1:wHSqTBrZ
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208 h1:1cngl9mPEoITZG8s8cVcUy5CeIBYhEESkOB7m6Gmkrk=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
+github.com/xsleonard/go-merkle v1.1.0 h1:fHe1fuhJjGH22ZzVTAH0jqHLhTGhOq3wQjJN+8P0jQg=
+github.com/xsleonard/go-merkle v1.1.0/go.mod h1:cW4z+UZ/4f2n9IJgIiyDCdYguchoDyDAPmpuOWGxdGg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4 h1:QmwruyY+bKbDDL0BaglrbZABEali68eoMFhTZpCjYVA=

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -716,6 +716,14 @@ func (s *PublicBlockChainAPI) GetStorageAt(ctx context.Context, address common.A
 	return res[:], state.Error()
 }
 
+func (s *PublicBlockChainAPI) GetRootHash(ctx context.Context, starBlockNr rpc.BlockNumber, endBlockNr rpc.BlockNumber) ([]byte, error) {
+	root, err := s.b.GetRootHash(ctx, starBlockNr, endBlockNr)
+	if err != nil {
+		return nil, err
+	}
+	return root, nil
+}
+
 // CallArgs represents the arguments for a call.
 type CallArgs struct {
 	From     *common.Address `json:"from"`

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -62,6 +62,7 @@ type Backend interface {
 	SubscribeStateEvent(ch chan<- core.NewStateChangeEvent) event.Subscription
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription
+	GetRootHash(ctx context.Context, starBlockNr rpc.BlockNumber, endBlockNr rpc.BlockNumber) ([]byte, error)
 
 	// Transaction pool API
 	SendTx(ctx context.Context, signedTx *types.Transaction) error

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -149,6 +149,11 @@ web3._extend({
 			call: 'bor_getCurrentValidators',
 			params: 0
 		}),
+		new web3._extend.Method({
+			name: 'getRootHash',
+			call: 'bor_getRootHash',
+			params: 2,
+		}),
 	]
 });
 `

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -223,3 +223,7 @@ func (b *LesApiBackend) ServiceFilter(ctx context.Context, session *bloombits.Ma
 		go session.Multiplex(bloomRetrievalBatch, bloomRetrievalWait, b.eth.bloomRequests)
 	}
 }
+
+func (b *LesApiBackend) GetRootHash(ctx context.Context, starBlockNr rpc.BlockNumber, endBlockNr rpc.BlockNumber) ([]byte, error) {
+	return nil, errors.New("Not implemented")
+}


### PR DESCRIPTION
JSON RPC API Reference:
```
curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_getRootHash","params":["0x1", "0xa"], "id":1}' http://localhost:8545

Over websocket,
wscat -c ws://localhost:8585
{"id":1, "method":"eth_getRootHash", "params":["0x1", "0xa"]}
```
Over IPC:
```
bor attach node1/bor.ipc
> bor.getRootHash(1, 10)
```

Expected response:
```
{"jsonrpc":"2.0","id":1,"result":"BXy0SRpYza0Uu42EOY8dIHXlW94HBjLBcLQu+XbIA7Q="}
```