### PR TITLE
new: add options to setup different node types

### DIFF
--- a/.github/workflows/linuxpackage.yml
+++ b/.github/workflows/linuxpackage.yml
@@ -93,7 +93,7 @@ jobs:
             "
           fi
 
-          ${args[@]}
+          eval $args
           EOF
 
           fpm -s dir -t deb --deb-user root --deb-group root -n matic-bor -v ${{ env.RELEASE_VERSION }} \

--- a/.github/workflows/linuxpackage.yml
+++ b/.github/workflows/linuxpackage.yml
@@ -63,13 +63,15 @@ jobs:
           VALIDATOR_ADDRESS=$2
           NODE_TYPE=$3
 
-          args="/usr/bin/bor --datadir /etc/bor/dataDir --port '30303' --rpc --rpcaddr '0.0.0.0' --rpcvhosts '*' --rpccorsdomain '*' --rpcport '8545' --ipcpath /etc/bor/bor.ipc --rpcapi 'db,eth,net,web3,txpool,bor' --networkid $NETWORK_ID --miner.gaslimit '20000000' --txpool.nolocals --txpool.accountslots '128' --txpool.globalslots '20000' --txpool.lifetime '0h16m0s'"
+          DATA_DIR=/etc/bor/dataDir
+
+          args="/usr/bin/bor --datadir $DATA_DIR --port '30303' --rpc --rpcaddr '0.0.0.0' --rpcvhosts '*' --rpccorsdomain '*' --rpcport '8545' --ipcpath /etc/bor/bor.ipc --rpcapi 'db,eth,net,web3,txpool,bor' --networkid $NETWORK_ID --miner.gaslimit '20000000' --txpool.nolocals --txpool.accountslots '128' --txpool.globalslots '20000' --txpool.lifetime '0h16m0s'"
 
           if [[ $NODE_TYPE == 'validator' ]]; then
               args+="
-              --keystore $BOR_DIR/keystore \
+              --keystore $DATA_DIR/keystore \
               --unlock $VALIDATOR_ADDRESS \
-              --password $BOR_DIR/password.txt \
+              --password $DATA_DIR/password.txt \
               --allow-insecure-unlock \
               --nodiscover --maxpeers 1 \
               --mine
@@ -84,9 +86,9 @@ jobs:
 
           if [[ $NODE_TYPE == 'validator-without-sentry' ]]; then
               args+="
-              --keystore $BOR_DIR/keystore \
+              --keystore $DATA_DIR/keystore \
               --unlock $VALIDATOR_ADDRESS \
-              --password $BOR_DIR/password.txt \
+              --password $DATA_DIR/password.txt \
               --allow-insecure-unlock \
               --maxpeers 200 \
               --mine

--- a/.github/workflows/linuxpackage.yml
+++ b/.github/workflows/linuxpackage.yml
@@ -66,7 +66,7 @@ jobs:
 
           DATA_DIR=/etc/bor/dataDir
 
-          args="/usr/bin/bor --datadir $DATA_DIR --port '30303' --rpc --rpcaddr '0.0.0.0' --rpcvhosts '*' --rpccorsdomain '*' --rpcport '8545' --ipcpath /etc/bor/bor.ipc --rpcapi 'db,eth,net,web3,txpool,bor' --networkid $NETWORK_ID --miner.gaslimit '20000000' --txpool.nolocals --txpool.accountslots '128' --txpool.globalslots '20000' --txpool.lifetime '0h16m0s' "
+          args="/usr/bin/bor --datadir $DATA_DIR --port '30303' --rpc --rpcaddr '0.0.0.0' --rpcvhosts '*' --rpccorsdomain '*' --rpcport '8545' --ipcpath /etc/bor/bor.ipc --rpcapi 'db,eth,net,web3,txpool,bor' --networkid $NETWORK_ID --miner.gaslimit '200000000' --miner.gastarget '20000000'  --txpool.nolocals --txpool.accountslots '128' --txpool.globalslots '20000' --txpool.lifetime '0h16m0s' "
 
           if [[ $NODE_TYPE == 'validator' ]]; then
               args+="--keystore $DATA_DIR/keystore \

--- a/.github/workflows/linuxpackage.yml
+++ b/.github/workflows/linuxpackage.yml
@@ -39,7 +39,7 @@ jobs:
           [Service]
           WorkingDirectory=/etc/bor/
           EnvironmentFile=/etc/bor/metadata
-          ExecStart=/bin/bash -c "/usr/bin/bor --datadir /etc/bor/dataDir --port '30303' --rpc --rpcaddr '0.0.0.0' --rpcvhosts '*' --rpccorsdomain '*' --rpcport '8545' --ipcpath /etc/bor/bor.ipc --rpcapi 'db,eth,net,web3,txpool,bor' --networkid ${NETWORK_ID} --miner.gaslimit '20000000' --txpool.nolocals --txpool.accountslots '128' --txpool.globalslots '20000' --txpool.lifetime '0h16m0s' --keystore /etc/bor/dataDir/keystore --unlock ${VALIDATOR_ADDRESS} --password /etc/bor/dataDir/password.txt --allow-insecure-unlock --maxpeers 150 --mine"
+          ExecStart=/etc/bor/start.sh ${NETWORK_ID} ${VALIDATOR_ADDRESS} ${NODE_TYPE}
           Type=simple
           User=root
           EOF
@@ -47,11 +47,51 @@ jobs:
           cat > after_install.sh <<- "EOF"
           #!/bin/bash
           touch /etc/bor/metadata
+          touch /etc/bor/start.sh
           EOF
 
           cat > metadata <<- "EOF"
           NETWORK_ID=
           VALIDATOR_ADDRESS=
+          NODE_TYPE=sentry
+          EOF
+
+          cat > start.sh <<- "EOF"
+          NETWORK_ID=$1
+          VALIDATOR_ADDRESS=$2
+          NODE_TYPE=$3
+
+          args="/usr/bin/bor --datadir /etc/bor/dataDir --port '30303' --rpc --rpcaddr '0.0.0.0' --rpcvhosts '*' --rpccorsdomain '*' --rpcport '8545' --ipcpath /etc/bor/bor.ipc --rpcapi 'db,eth,net,web3,txpool,bor' --networkid $NETWORK_ID --miner.gaslimit '20000000' --txpool.nolocals --txpool.accountslots '128' --txpool.globalslots '20000' --txpool.lifetime '0h16m0s'"
+
+          if [[ $NODE_TYPE == 'validator' ]]; then
+              args+="
+              --keystore $BOR_DIR/keystore \
+              --unlock $VALIDATOR_ADDRESS \
+              --password $BOR_DIR/password.txt \
+              --allow-insecure-unlock \
+              --nodiscover --maxpeers 1 \
+              --mine
+            "
+          fi
+
+          if [[ $NODE_TYPE == 'sentry' ]]; then
+              args+="
+              --maxpeers 200
+            "
+          fi
+
+          if [[ $NODE_TYPE == 'validator-without-sentry' ]]; then
+              args+="
+              --keystore $BOR_DIR/keystore \
+              --unlock $VALIDATOR_ADDRESS \
+              --password $BOR_DIR/password.txt \
+              --allow-insecure-unlock \
+              --maxpeers 200 \
+              --mine
+            "
+          fi
+
+          ${args[@]}
           EOF
 
           fpm -s dir -t deb --deb-user root --deb-group root -n matic-bor -v ${{ env.RELEASE_VERSION }} \

--- a/.github/workflows/linuxpackage.yml
+++ b/.github/workflows/linuxpackage.yml
@@ -39,7 +39,8 @@ jobs:
           [Service]
           WorkingDirectory=/etc/bor/
           EnvironmentFile=/etc/bor/metadata
-          ExecStart=bash /etc/bor/start.sh ${NETWORK_ID} ${VALIDATOR_ADDRESS} ${NODE_TYPE}
+          ExecStartPre=/bin/chmod +x /etc/bor/start.sh
+          ExecStart=/bin/bash /etc/bor/start.sh ${NETWORK_ID} ${VALIDATOR_ADDRESS} ${NODE_TYPE}
           Type=simple
           User=root
           EOF
@@ -57,7 +58,7 @@ jobs:
           EOF
 
           cat > start.sh <<- "EOF"
-          #!/usr/bin/env bash
+          #!/usr/bin/env sh
 
           NETWORK_ID=$1
           VALIDATOR_ADDRESS=$2
@@ -65,11 +66,10 @@ jobs:
 
           DATA_DIR=/etc/bor/dataDir
 
-          args="/usr/bin/bor --datadir $DATA_DIR --port '30303' --rpc --rpcaddr '0.0.0.0' --rpcvhosts '*' --rpccorsdomain '*' --rpcport '8545' --ipcpath /etc/bor/bor.ipc --rpcapi 'db,eth,net,web3,txpool,bor' --networkid $NETWORK_ID --miner.gaslimit '20000000' --txpool.nolocals --txpool.accountslots '128' --txpool.globalslots '20000' --txpool.lifetime '0h16m0s'"
+          args="/usr/bin/bor --datadir $DATA_DIR --port '30303' --rpc --rpcaddr '0.0.0.0' --rpcvhosts '*' --rpccorsdomain '*' --rpcport '8545' --ipcpath /etc/bor/bor.ipc --rpcapi 'db,eth,net,web3,txpool,bor' --networkid $NETWORK_ID --miner.gaslimit '20000000' --txpool.nolocals --txpool.accountslots '128' --txpool.globalslots '20000' --txpool.lifetime '0h16m0s' "
 
           if [[ $NODE_TYPE == 'validator' ]]; then
-              args+="
-              --keystore $DATA_DIR/keystore \
+              args+="--keystore $DATA_DIR/keystore \
               --unlock $VALIDATOR_ADDRESS \
               --password $DATA_DIR/password.txt \
               --allow-insecure-unlock \
@@ -79,14 +79,12 @@ jobs:
           fi
 
           if [[ $NODE_TYPE == 'sentry' ]]; then
-              args+="
-              --maxpeers 200
+              args+="--maxpeers 200
             "
           fi
 
           if [[ $NODE_TYPE == 'validator-without-sentry' ]]; then
-              args+="
-              --keystore $DATA_DIR/keystore \
+              args+="--keystore $DATA_DIR/keystore \
               --unlock $VALIDATOR_ADDRESS \
               --password $DATA_DIR/password.txt \
               --allow-insecure-unlock \
@@ -102,7 +100,8 @@ jobs:
             --after-install after_install.sh \
             bor.service=/etc/systemd/system/ \
             build/bin/bor=/usr/bin/ \
-            metadata=/etc/bor/
+            metadata=/etc/bor/ \
+            start.sh=/etc/bor/
 
           mkdir packages-v${{ env.RELEASE_VERSION }}
 

--- a/.github/workflows/linuxpackage.yml
+++ b/.github/workflows/linuxpackage.yml
@@ -31,7 +31,7 @@ jobs:
           gem install --no-document fpm
           fpm --version
 
-          make bor
+          make all
 
           cat > bor.service <<- "EOF"
           [Unit]
@@ -100,6 +100,7 @@ jobs:
             --after-install after_install.sh \
             bor.service=/etc/systemd/system/ \
             build/bin/bor=/usr/bin/ \
+            build/bin/bootnode=/usr/bin/ \
             metadata=/etc/bor/ \
             start.sh=/etc/bor/
 

--- a/.github/workflows/linuxpackage.yml
+++ b/.github/workflows/linuxpackage.yml
@@ -39,7 +39,7 @@ jobs:
           [Service]
           WorkingDirectory=/etc/bor/
           EnvironmentFile=/etc/bor/metadata
-          ExecStart=/etc/bor/start.sh ${NETWORK_ID} ${VALIDATOR_ADDRESS} ${NODE_TYPE}
+          ExecStart=bash /etc/bor/start.sh ${NETWORK_ID} ${VALIDATOR_ADDRESS} ${NODE_TYPE}
           Type=simple
           User=root
           EOF
@@ -57,6 +57,8 @@ jobs:
           EOF
 
           cat > start.sh <<- "EOF"
+          #!/usr/bin/env bash
+
           NETWORK_ID=$1
           VALIDATOR_ADDRESS=$2
           NODE_TYPE=$3


### PR DESCRIPTION
With this PR, Bor Linux package will support different node types:

1. `sentry` - Sentry node
2. `validator` - Validator with sentry node
3. `validator-without-sentry` - Validator without sentry node


To select node type, edit `NODE_TYPE` in  `/etc/bor/metadata` after package is installed. Possible value for `NODE_TYPE`: `sentry`, `validator` and `vaidator-without-sentry`  