### PR TITLE
fix: delete check empty tx root hash

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -124,9 +124,6 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 	if head.UncleHash != types.EmptyUncleHash && len(body.UncleHashes) == 0 {
 		return nil, fmt.Errorf("server returned empty uncle list but block header indicates uncles")
 	}
-	if head.TxHash == types.EmptyRootHash && len(body.Transactions) > 0 {
-		return nil, fmt.Errorf("server returned non-empty transaction list but block header indicates no transactions")
-	}
 	if head.TxHash != types.EmptyRootHash && len(body.Transactions) == 0 {
 		return nil, fmt.Errorf("server returned empty transaction list but block header indicates transactions")
 	}


### PR DESCRIPTION
When i use ethclient to call BlockByHash or BlockByNumber at specify tx will get `server returned non-empty transaction list but block header indicates no transactions ` error,  like https://mumbai.polygonscan.com/block/17442944. That because if block only exist plasma deposit tx transaction will trigger this error. So if the block is legal, i think this check can be deleted.
