### PR TITLE
Added bash to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build Geth in a stock Go builder container
 FROM golang:1.16-alpine as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers git && apk add --no-cache bash
+RUN apk add --no-cache make gcc musl-dev linux-headers git bash
 
 ADD . /bor
 RUN cd /bor && make bor-all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 # Build Geth in a stock Go builder container
 FROM golang:1.16-alpine as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers git
+RUN apk add --no-cache make gcc musl-dev linux-headers git && apk add --no-cache bash
 
 ADD . /bor
 RUN cd /bor && make bor-all
+
+CMD ["/bin/bash"]
 
 # Pull Bor into a second stage deploy alpine container
 FROM alpine:latest


### PR DESCRIPTION
In order to debug and navigate the file system within Bor while working in a docker container having bash will be useful. This addition will come in handy if people decide to orchestration their containers in clusters as well.

I faced the issue of not being able to peer into my Bor instance when it was containerized in a Monk.io cluster. This made it difficult to debug and run common commands such as sudo service bor restart

## Testing instructions: 
1. docker build -t dockerfile --target builder .
2. Run docker image to start container 
3. docker exec -it <container-name> /bin/bash
