### PR TITLE
Include upper bound in binary search

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -815,7 +815,7 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 		return 0, err
 	}
 
-	ancestor, err = d.findAncestorBinarySearch(p, mode, localHeight, floor)
+	ancestor, err = d.findAncestorBinarySearch(p, mode, localHeight+1, floor)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This PR fixes an issue with the binary search ancestor introduced in #202. The binary search does not include the upper bound "localHeight" in the search but it is also a valid block number.