### PR TITLE
Remove unsafe eth endpoints

### DIFF
--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -101,7 +101,7 @@ type Backend interface {
 }
 
 func GetAPIs(apiBackend Backend) []rpc.API {
-	nonceLock := new(AddrLocker)
+	// nonceLock := new(AddrLocker)
 	return []rpc.API{
 		{
 			Namespace: "eth",
@@ -113,12 +113,16 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 			Version:   "1.0",
 			Service:   NewPublicBlockChainAPI(apiBackend),
 			Public:    true,
-		}, {
-			Namespace: "eth",
-			Version:   "1.0",
-			Service:   NewPublicTransactionPoolAPI(apiBackend, nonceLock),
-			Public:    true,
-		}, {
+		},
+		/*
+			{
+				Namespace: "eth",
+				Version:   "1.0",
+				Service:   NewPublicTransactionPoolAPI(apiBackend, nonceLock),
+				Public:    true,
+			},
+		*/
+		{
 			Namespace: "txpool",
 			Version:   "1.0",
 			Service:   NewPublicTxPoolAPI(apiBackend),
@@ -132,16 +136,22 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 			Namespace: "debug",
 			Version:   "1.0",
 			Service:   NewPrivateDebugAPI(apiBackend),
-		}, {
-			Namespace: "eth",
-			Version:   "1.0",
-			Service:   NewPublicAccountAPI(apiBackend.AccountManager()),
-			Public:    true,
-		}, {
-			Namespace: "personal",
-			Version:   "1.0",
-			Service:   NewPrivateAccountAPI(apiBackend, nonceLock),
-			Public:    false,
 		},
+		/*
+			{
+				Namespace: "eth",
+				Version:   "1.0",
+				Service:   NewPublicAccountAPI(apiBackend.AccountManager()),
+				Public:    true,
+			},
+		*/
+		/*
+			{
+				Namespace: "personal",
+				Version:   "1.0",
+				Service:   NewPrivateAccountAPI(apiBackend, nonceLock),
+				Public:    false,
+			},
+		*/
 	}
 }

--- a/node/api.go
+++ b/node/api.go
@@ -37,8 +37,7 @@ func (n *Node) apis() []rpc.API {
 			Namespace: "admin",
 			Version:   "1.0",
 			Service:   &privateAdminAPI{n},
-		},
-		{
+		}, {
 			Namespace: "admin",
 			Version:   "1.0",
 			Service:   &publicAdminAPI{n},

--- a/node/api.go
+++ b/node/api.go
@@ -37,7 +37,8 @@ func (n *Node) apis() []rpc.API {
 			Namespace: "admin",
 			Version:   "1.0",
 			Service:   &privateAdminAPI{n},
-		}, {
+		},
+		{
 			Namespace: "admin",
 			Version:   "1.0",
 			Service:   &publicAdminAPI{n},


### PR DESCRIPTION
Some Ethereum endpoints in the eth namespace like eth_sendTransaction use the local unlocked accounts to sign transactions and perform operations. This is unsafe for validator nodes that by default have to unlock their node. A misconfiguration might expose the node to many attack vectors.

This PR directly removes those endpoints since they are not used anymore in the community. These endpoints were useful back when the node was both the client and the wallet manager.