### PR TITLE
Decode big.int in config

### DIFF
--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"math/big"
 	"testing"
 	"time"
 
@@ -81,13 +82,20 @@ func TestConfigLoadFile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, config, &Config{
 			DataDir: "./data",
+			Whitelist: map[string]string{
+				"a": "b",
+			},
 			P2P: &P2PConfig{
 				MaxPeers: 30,
 			},
 			TxPool: &TxPoolConfig{
 				LifeTime: time.Duration(1 * time.Second),
 			},
-			Cache: &CacheConfig{},
+			Gpo: &GpoConfig{
+				MaxPrice: big.NewInt(100),
+			},
+			Sealer: &SealerConfig{},
+			Cache:  &CacheConfig{},
 		})
 	}
 

--- a/command/server/testdata/simple.hcl
+++ b/command/server/testdata/simple.hcl
@@ -1,9 +1,17 @@
 data-dir = "./data"
 
+whitelist = {
+	a = "b"
+}
+
 p2p {
 	max-peers = 30
 }
 
 txpool {
 	lifetime = "1s"
+}
+
+gpo {
+	max-price = "100"
 }

--- a/command/server/testdata/simple.json
+++ b/command/server/testdata/simple.json
@@ -1,9 +1,15 @@
 {
     "data-dir": "./data",
+    "whitelist": {
+        "a": "b"
+    },
     "p2p": {
         "max-peers": 30
     },
     "txpool": {
         "lifetime": "1s"
+    },
+    "gpo": {
+        "max-price": "100"
     }
 }


### PR DESCRIPTION
The Config struct/file would fail when trying to decode big.Int fields since it is not a type in the HCL library. This PR fixes it with the same strategy used in the time.Duration of having a raw string field that captures the value from HCL and then transforming it in another step.