### PR TITLE
Fix default attach endpoint

### DIFF
--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -139,7 +139,7 @@ func remoteConsole(ctx *cli.Context) error {
 				path = filepath.Join(homeDir, "/.bor/data")
 			}
 		}
-		endpoint = fmt.Sprintf("%s/geth.ipc", path)
+		endpoint = fmt.Sprintf("%s/bor.ipc", path)
 	}
 	client, err := dialRPC(endpoint)
 	if err != nil {


### PR DESCRIPTION
The default ipc file is `dor.ipc`, but attach command using `geth.ipc`.