### PR TITLE
Adapt Dockerfile for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,17 @@
-# Build Geth in a stock Go builder container
-FROM golang:1.17-alpine as builder
+FROM golang:latest
 
-RUN set -x \
-	&& buildDeps='bash build-base musl-dev linux-headers git' \
-	&& apk add --update $buildDeps \
-	&& rm -rf /var/cache/apk/* \
-    && mkdir -p /bor
+ARG BOR_DIR=/bor
+ENV BOR_DIR=$BOR_DIR
 
-WORKDIR /bor
+RUN apt-get update -y && apt-get upgrade -y \
+    && apt install build-essential git tini -y \
+    && mkdir -p /heimdall
+
+WORKDIR ${BOR_DIR}
 COPY . .
 RUN make bor-all
 
-CMD ["/bin/bash"]
-
-# Pull Bor into a second stage deploy alpine container
-FROM alpine:3.14
-
-RUN set -x \
-    && apk add --update --no-cache \
-       ca-certificates \
-    && rm -rf /var/cache/apk/*
-
-COPY --from=builder /bor/build/bin/bor /usr/local/bin/
-COPY --from=builder /bor/build/bin/bootnode /usr/local/bin/
-
+ENV SHELL /bin/bash
 EXPOSE 8545 8546 8547 30303 30303/udp
 
 ENTRYPOINT ["bor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV BOR_DIR=$BOR_DIR
 
 RUN apt-get update -y && apt-get upgrade -y \
     && apt install build-essential git tini -y \
-    && mkdir -p /heimdall
+    && mkdir -p /bor
 
 WORKDIR ${BOR_DIR}
 COPY . .


### PR DESCRIPTION
The Dockerfile for release using Alpine is in the included Dockerfile.release and this one was not used for release so doesn't make sense to have it using multistage nor Alpine.