### PR TITLE
added service name in config and flags

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	// Chain is the chain to sync with
 	Chain string `hcl:"chain,optional"`
 
+	// Name, or identity of the node
+	Name string `hcl:"name,optional"`
+
 	// Whitelist is a list of required (block number, hash) pairs to accept
 	Whitelist map[string]string `hcl:"whitelist,optional"`
 
@@ -365,6 +368,7 @@ type AccountsConfig struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Chain:     "mainnet",
+		Name:      Hostname(),
 		Whitelist: map[string]string{},
 		LogLevel:  "INFO",
 		DataDir:   defaultDataDir(),
@@ -884,4 +888,12 @@ func defaultDataDir() string {
 	default:
 		return filepath.Join(home, ".bor")
 	}
+}
+
+func Hostname() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "bor"
+	}
+	return hostname
 }

--- a/command/server/flags.go
+++ b/command/server/flags.go
@@ -15,6 +15,11 @@ func (c *Command) Flags() *flagset.Flagset {
 		Value: &c.cliConfig.Chain,
 	})
 	f.StringFlag(&flagset.StringFlag{
+		Name:  "name",
+		Usage: "Name/Identity of the node",
+		Value: &c.cliConfig.Name,
+	})
+	f.StringFlag(&flagset.StringFlag{
 		Name:  "log-level",
 		Usage: "Set log level for the server",
 		Value: &c.cliConfig.LogLevel,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -111,7 +111,7 @@ func NewServer(config *Config) (*Server, error) {
 		}
 	}
 
-	if err := srv.setupMetrics(config.Telemetry); err != nil {
+	if err := srv.setupMetrics(config.Telemetry, config.Name); err != nil {
 		return nil, err
 	}
 
@@ -133,7 +133,7 @@ func (s *Server) Stop() {
 	}
 }
 
-func (s *Server) setupMetrics(config *TelemetryConfig) error {
+func (s *Server) setupMetrics(config *TelemetryConfig, serviceName string) error {
 	metrics.Enabled = config.Enabled
 	metrics.EnabledExpensive = config.Expensive
 
@@ -195,7 +195,7 @@ func (s *Server) setupMetrics(config *TelemetryConfig) error {
 		res, err := resource.New(ctx,
 			resource.WithAttributes(
 				// the service name used to display traces in backends
-				semconv.ServiceNameKey.String("bor"), // TODO: use the service name from the config
+				semconv.ServiceNameKey.String(serviceName),
 			),
 		)
 		if err != nil {


### PR DESCRIPTION
- Adds service name in config and flags.
- Sets `os.Hostname()` to default
- Used in OpenCollector Config
- [Linear](https://linear.app/matic/issue/POS-68/add-a-new-name-field-in-bor)