### PR TITLE
Ferranbt/london fork governance burn

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -103,6 +103,12 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 		return nil, err
 	}
 
+	if result.BurnedAmount != nil {
+		// London fork enabled, send the burned amount to the governance contract that will burn the tokens
+		burntContractAddress := common.HexToAddress(evm.ChainConfig().Bor.CalculateBurntContract(evm.Context.BlockNumber.Uint64()))
+		evm.StateDB.AddBalance(burntContractAddress, result.BurnedAmount)
+	}
+
 	// Update the state with pending changes.
 	var root []byte
 	if config.IsByzantium(blockNumber) {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -55,7 +55,6 @@ type StateTransition struct {
 	gasPrice   *big.Int
 	gasFeeCap  *big.Int
 	gasTipCap  *big.Int
-	burnAmount *big.Int
 	initialGas uint64
 	value      *big.Int
 	data       []byte


### PR DESCRIPTION
This PR moves adding the governance burn tokens outside of the TransitionDB function. Everything inside the state_transition.go file should be kept as close as possible to upstream Geth since that is the core consensus logic to process transactions. As much as possible we should move logic to some post hook operations. Hopefully, in this case it was possible. 
