### PR TITLE
eth/downloader: open telemetry tracing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	go.opentelemetry.io/otel v1.2.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.2.0
 	go.opentelemetry.io/otel/sdk v1.2.0
+	go.opentelemetry.io/otel/trace v1.2.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c


### PR DESCRIPTION
NOTE: This is still WIP
This PR adds open tracing for some of the major processes involved in the synchronisation phase (in eth/downloader) of bor.
This is the first iteration for traces added in the module. As per @ferranbt's comment, I'll try to reduce certain sub-tracers added in the code. The initial commit is just for the reference.