### PR TITLE
Deprecate personal/wallet endpoints in bor

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
-	"github.com/ethereum/go-ethereum/consensus/bor"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
@@ -493,14 +492,8 @@ func (s *Ethereum) StartMining(threads int) error {
 			}
 			clique.Authorize(eb, wallet.SignData)
 		}
-		if bor, ok := s.engine.(*bor.Bor); ok {
-			wallet, err := s.accountManager.Find(accounts.Account{Address: eb})
-			if wallet == nil || err != nil {
-				log.Error("Etherbase account unavailable locally", "err", err)
-				return fmt.Errorf("signer missing: %v", err)
-			}
-			bor.Authorize(eb, wallet.SignData)
-		}
+		// BOR signer is set in server itself using keystore
+
 		// If mining is started, we can disable the transaction rejection mechanism
 		// introduced to speed sync times.
 		atomic.StoreUint32(&s.handler.acceptTxs, 1)

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -368,6 +368,9 @@ type AccountsConfig struct {
 
 	// UseLightweightKDF enables a faster but less secure encryption of accounts
 	UseLightweightKDF bool `hcl:"use-lightweight-kdf,optional"`
+
+	// DisableBorWallet disables the personal wallet endpoints
+	DisableBorWallet bool `hcl:"disable-bor-wallet,optional"`
 }
 
 type DeveloperConfig struct {
@@ -496,6 +499,7 @@ func DefaultConfig() *Config {
 			PasswordFile:        "",
 			AllowInsecureUnlock: false,
 			UseLightweightKDF:   false,
+			DisableBorWallet:    false,
 		},
 		GRPC: &GRPCConfig{
 			Addr: ":3131",

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -461,6 +461,11 @@ func (c *Command) Flags() *flagset.Flagset {
 		Usage: "Reduce key-derivation RAM & CPU usage at some expense of KDF strength",
 		Value: &c.cliConfig.Accounts.UseLightweightKDF,
 	})
+	f.BoolFlag((&flagset.BoolFlag{
+		Name:  "disable-bor-wallet",
+		Usage: "Disable the personal wallet endpoints",
+		Value: &c.cliConfig.Accounts.DisableBorWallet,
+	}))
 
 	// grpc
 	f.StringFlag(&flagset.StringFlag{

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/consensus/bor"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/ethstats"
@@ -106,6 +108,47 @@ func NewServer(config *Config) (*Server, error) {
 		if err := ethstats.New(stack, backend.APIBackend, backend.Engine(), config.Ethstats); err != nil {
 			return nil, err
 		}
+	}
+
+	// setup account manager (only keystore)
+	// Not used for RPC endpoints as personal/wallet endpoints will be deprecated
+	/*
+		{
+			keydir := stack.KeyStoreDir()
+			n, p := keystore.StandardScryptN, keystore.StandardScryptP
+			if config.Accounts.UseLightweightKDF {
+				n, p = keystore.LightScryptN, keystore.LightScryptP
+			}
+			stack.AccountManager().AddBackend(keystore.NewKeyStore(keydir, n, p))
+		}
+	*/
+
+	// create a new account manager, only for the scope of this function
+	accountManager := accounts.NewManager(&accounts.Config{})
+
+	// register backend to account manager with keystore for signing
+	keydir := stack.KeyStoreDir()
+	n, p := keystore.StandardScryptN, keystore.StandardScryptP
+	if config.Accounts.UseLightweightKDF {
+		n, p = keystore.LightScryptN, keystore.LightScryptP
+	}
+	accountManager.AddBackend(keystore.NewKeyStore(keydir, n, p))
+
+	// get the etherbase
+	eb, err := srv.backend.Etherbase()
+	if err != nil {
+		log.Error("Cannot start mining without etherbase", "err", err)
+		return nil, fmt.Errorf("etherbase missing: %v", err)
+	}
+
+	// Authorize the consensus to sign using wallet signer
+	if bor, ok := srv.backend.Engine().(*bor.Bor); ok {
+		wallet, err := accountManager.Find(accounts.Account{Address: eb})
+		if wallet == nil || err != nil {
+			log.Error("Etherbase account unavailable locally", "err", err)
+			return nil, fmt.Errorf("signer missing: %v", err)
+		}
+		bor.Authorize(eb, wallet.SignData)
 	}
 
 	// sealing (if enabled) or in dev mode

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -111,18 +111,6 @@ func NewServer(config *Config) (*Server, error) {
 	}
 
 	// setup account manager (only keystore)
-	// Not used for RPC endpoints as personal/wallet endpoints will be deprecated
-	/*
-		{
-			keydir := stack.KeyStoreDir()
-			n, p := keystore.StandardScryptN, keystore.StandardScryptP
-			if config.Accounts.UseLightweightKDF {
-				n, p = keystore.LightScryptN, keystore.LightScryptP
-			}
-			stack.AccountManager().AddBackend(keystore.NewKeyStore(keydir, n, p))
-		}
-	*/
-
 	// create a new account manager, only for the scope of this function
 	accountManager := accounts.NewManager(&accounts.Config{})
 

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -132,6 +132,13 @@ func NewServer(config *Config) (*Server, error) {
 	if config.Accounts.UseLightweightKDF {
 		n, p = keystore.LightScryptN, keystore.LightScryptP
 	}
+
+	if !config.Accounts.DisableBorWallet {
+		// add keystore globally to the node's account manager if personal wallet is enabled
+		stack.AccountManager().AddBackend(keystore.NewKeyStore(keydir, n, p))
+	}
+
+	// proceed to authorize in any case
 	accountManager.AddBackend(keystore.NewKeyStore(keydir, n, p))
 
 	// get the etherbase

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -142,7 +142,7 @@ func NewServer(config *Config) (*Server, error) {
 	accountManager.AddBackend(keystore.NewKeyStore(keydir, n, p))
 
 	// authorize for sealing only if mining
-	if config.Sealer.Etherbase != "0" {
+	if config.Sealer.Etherbase != "" {
 		// get the etherbase
 		eb, err := srv.backend.Etherbase()
 		if err != nil {


### PR DESCRIPTION
RFC: 21

This PR removes the usage of personal/wallet related RPC endpoints. This is achieved by removing the backend configuration using key store for the default account manager. The endpoints hence act as dummy with zero usability.
Moreover, it adds configuration of a local scoped account manager for signing/sealing the blocks while mining. This makes sure that the wallet is used only and only for signing/sealing the blocks and not anything else.

The signing/sealing changes are yet to be tested. Do not merge.