### PR TITLE
Changed syncmode from fast to full

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -393,7 +393,7 @@ func DefaultConfig() *Config {
 			URL:     "http://localhost:1317",
 			Without: false,
 		},
-		SyncMode: "fast",
+		SyncMode: "full",
 		GcMode:   "full",
 		Snapshot: true,
 		TxPool: &TxPoolConfig{


### PR DESCRIPTION
The default syncmode in the new CLI was changed from fast to full.