### PR TITLE
Ban block hashes for dead sides of recent hard-fork

### DIFF
--- a/core/blocks.go
+++ b/core/blocks.go
@@ -22,4 +22,10 @@ import "github.com/ethereum/go-ethereum/common"
 var BadHashes = map[common.Hash]bool{
 	common.HexToHash("05bef30ef572270f654746da22639a7a0c97dd97a7050b9e252391996aaeb689"): true,
 	common.HexToHash("7d05d08cbc596a2e5e4f13b80a743e53e09221b5323c3a61946b20873e58583f"): true,
+
+	// mumbai 22244000 fork - dead side
+	common.HexToHash("7c48202edfd27f96d5aa01fbcd2b48721753d5d9b2392e4b2e44f5de15b9a8dd"): true,
+
+	// mainnet 22156660 fork - dead side
+	common.HexToHash("f7f2fa4ea3e38f7de9ebaee4a7daf55b7743d027b5f3246a0136e3d5ab72da18"): true,
 }


### PR DESCRIPTION
Prevent upgraded nodes from syncing onto the dead-end "incorrect" side of the hard-fork produced by nodes that weren't upgraded before the hard-fork.