### PR TITLE
Build with the previous Dockerfile

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,8 +2,12 @@ name: Bor Docker Image CI
 
 on:
   push:
+    branches-ignore:
+      - '**'
     tags:
       - 'v*.*.*'
+      # to be used by fork patch-releases ^^
+      - 'v*.*.*-*'
   
 jobs:
   build:

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,25 @@
+name: Bor Docker Image CI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Bor Docker image
+      env:
+        DOCKERHUB: ${{ secrets.DOCKERHUB }}
+        DOCKERHUB_KEY: ${{ secrets.DOCKERHUB_KEY }}
+      run: |
+        ls -l
+        echo "Docker login"
+        docker login -u $DOCKERHUB -p $DOCKERHUB_KEY
+        echo "running build"
+        docker build -f Dockerfile.classic -t maticnetwork/bor:${GITHUB_REF/refs\/tags\//} .
+        echo "pushing image"
+        docker push maticnetwork/bor:${GITHUB_REF/refs\/tags\//}
+        echo "DONE!"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,7 +95,6 @@ dockers:
       - linux-amd64
     build_flag_templates:
       - --platform=linux/amd64
-    skip_push: true
   
   - image_templates:
       - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
@@ -106,7 +105,6 @@ dockers:
       - linux-arm64
     build_flag_templates:
       - --platform=linux/arm64
-    skip_push: true
 
 docker_manifests:
   - name_template: 0xpolygon/{{ .ProjectName }}:{{ .Version }}

--- a/Dockerfile.classic
+++ b/Dockerfile.classic
@@ -1,0 +1,18 @@
+# Build Geth in a stock Go builder container
+FROM golang:1.17-alpine as builder
+
+RUN apk add --no-cache make gcc musl-dev linux-headers git bash
+
+ADD . /bor
+RUN cd /bor && make bor-all
+
+CMD ["/bin/bash"]
+
+# Pull Bor into a second stage deploy alpine container
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /bor/build/bin/bor /usr/local/bin/
+COPY --from=builder /bor/build/bin/bootnode /usr/local/bin/
+
+EXPOSE 8545 8546 8547 30303 30303/udp


### PR DESCRIPTION
This will recover the classic maticnetwork build in parallel with the new images so the community can test both images.

Also fix the new build manifest.