### PR TITLE
Reorder Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,6 @@ GO ?= latest
 GORUN = env GO111MODULE=on go run
 GOPATH = $(shell go env GOPATH)
 
-protoc:
-	protoc --go_out=. --go-grpc_out=. ./command/server/proto/*.proto
-
 bor:
 	$(GORUN) build/ci.go install ./cmd/geth
 	mkdir -p $(GOPATH)/bin/
@@ -27,6 +24,9 @@ bor-all:
 	mkdir -p $(GOPATH)/bin/
 	cp $(GOBIN)/geth $(GOBIN)/bor
 	cp $(GOBIN)/* $(GOPATH)/bin/
+
+protoc:
+	protoc --go_out=. --go-grpc_out=. ./command/server/proto/*.proto
 
 geth:
 	$(GORUN) build/ci.go install ./cmd/geth


### PR DESCRIPTION

Reviewer @vcastellm
Fixes https://github.com/maticnetwork/bor/issues/272
#### Changes
Reorders such that bor is the first and therefore default target.
#### Test Plan
`make` builds bor