### PR TITLE
Do not attempt DNS discovery and change default sync flag

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -347,7 +347,7 @@ func setDefaultMumbaiGethConfig(ctx *cli.Context, config *gethConfig) {
 	config.Node.HTTPPort = 8545
 	config.Node.IPCPath = utils.MakeDataDir(ctx) + "/bor.ipc"
 	config.Node.HTTPModules = []string{"eth", "net", "web3", "txpool", "bor"}
-	config.Eth.SyncMode = downloader.SnapSync
+	config.Eth.SyncMode = downloader.FullSync
 	config.Eth.NetworkId = 80001
 	config.Eth.Miner.GasCeil = 20000000
 	//--miner.gastarget is depreceated, No longed used
@@ -370,7 +370,7 @@ func setDefaultBorMainnetGethConfig(ctx *cli.Context, config *gethConfig) {
 	config.Node.HTTPPort = 8545
 	config.Node.IPCPath = utils.MakeDataDir(ctx) + "/bor.ipc"
 	config.Node.HTTPModules = []string{"eth", "net", "web3", "txpool", "bor"}
-	config.Eth.SyncMode = downloader.SnapSync
+	config.Eth.SyncMode = downloader.FullSync
 	config.Eth.NetworkId = 137
 	config.Eth.Miner.GasCeil = 20000000
 	//--miner.gastarget is depreceated, No longed used

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1645,13 +1645,11 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			cfg.NetworkId = 80001
 		}
 		cfg.Genesis = core.DefaultMumbaiGenesisBlock()
-		SetDNSDiscoveryDefaults(cfg, params.MumbaiGenesisHash)
 	case ctx.GlobalBool(BorMainnetFlag.Name):
 		if !ctx.GlobalIsSet(BorMainnetFlag.Name) {
 			cfg.NetworkId = 137
 		}
 		cfg.Genesis = core.DefaultBorMainnetGenesisBlock()
-		SetDNSDiscoveryDefaults(cfg, params.BorMainnetGenesisHash)
 	case ctx.GlobalBool(DeveloperFlag.Name):
 		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 1337


### PR DESCRIPTION
* Polygon does not use DNS discovery so remove the cargo-culted init call
* Default sync should be `full`