### PR TITLE
Bump maximum Gas Price Oracle gas price to 5000 Gwei

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -35,7 +35,7 @@ import (
 const sampleNumber = 3 // Number of transactions sampled in a block
 
 var (
-	DefaultMaxPrice    = big.NewInt(500 * params.GWei)
+	DefaultMaxPrice    = big.NewInt(5000 * params.GWei)
 	DefaultIgnorePrice = big.NewInt(2 * params.Wei)
 )
 


### PR DESCRIPTION
Right now, whenever you do `eth.gasPrice` it will return the gas price estimate that will be capped at 500 Gwei. In reality, the gas price required to broadcast transactions is somewhere around 600-700 Gwei, but the node is returning 500 Gwei just because it has inherited the go-ethereum's gas price limiter.