### PR TITLE
Increase txfeecap - 10 ethers

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -93,7 +93,7 @@ var Defaults = Config{
 	RPCGasCap:     50000000,
 	RPCEVMTimeout: 5 * time.Second,
 	GPO:           FullNodeGPO,
-	RPCTxFeeCap:   1, // 1 ether
+	RPCTxFeeCap:   10, // 10 ethers
 }
 
 func init() {


### PR DESCRIPTION
Hi guys,

Recently the gas prices are so high, that it is quite easy to reach the 1 ether/matic limit.

I think "txfeecap" should be increased, I set it to 10.

Relates issue:
https://github.com/maticnetwork/bor/issues/289

Best,
Tamas