### PR TITLE
Reduce competitive spam by having sentries always send full transactions to validators

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -486,8 +486,13 @@ func (h *handler) BroadcastTransactions(txs types.Transactions) {
 			txset[peer] = append(txset[peer], tx.Hash())
 		}
 		// For the remaining peers, send announcement only
+		// If peer is static (sentry -> validator?), send the full tx
 		for _, peer := range peers[numDirect:] {
-			annos[peer] = append(annos[peer], tx.Hash())
+			if peer.IsStatic() {
+				txset[peer] = append(txset[peer], tx.Hash())
+			} else {
+				annos[peer] = append(annos[peer], tx.Hash())
+			}
 		}
 	}
 	for peer, hashes := range txset {

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -527,3 +527,7 @@ func (p *Peer) Info() *PeerInfo {
 	}
 	return info
 }
+
+func (p *Peer) IsStatic() bool {
+	return p.rw.is(staticDialedConn)
+}


### PR DESCRIPTION
**Competitive spam is a huge problem on Polygon.** There are many blocks where over 90% of the transactions are from arbitrageurs trying to get a "backrun", where they land immediately after a target transaction, by sending a transaction with the same exact gas price.

This is not a new thing. Geth has dealt with this before, which is why they implemented https://github.com/ethereum/go-ethereum/pull/21358. In addition, there have been similar issues opened for BSC https://github.com/binance-chain/bsc/issues/269, and here in the Polygon repo: https://github.com/maticnetwork/bor/issues/209 (cc @ferranbt @moneyoriented)

This has also been highlighted on Twitter by threads such as this one: https://twitter.com/bertcmiller/status/1412579402345586696 from @bertmiller

However, Polygon actually implements the geth PR already! So why does this continue to happen, only on Polygon much worse than other chains?

It's not entirely because of the low gas price, as many may think. 

**The reason that the geth solution doesn't work on polygon is because of the sentry / validator setup that most validators have.** I will explain more below:

Imagine you are an arbitrage trader and you see a target transaction in the mempool, and immediately broadcast your arbitrage tx at the same gas price.

Now imagine you happen to be connected to the current validator's sentry node.

It actually doesn't give you an advantage in terms of ordering, because the sentry node only broadcasts the full transaction to `numDirect := int(math.Sqrt(float64(len(peers))))`, and announcements to the rest of their peers, including their own validator!

This means that validators are essentially ordering transactions in a random order, hence, there is no way to get your desired outcome besides filling the mempool with more and more spam transactions. In fact, as you start to send more transactions, then so do your competitors, and you end up sending as many transactions as the current gas price will allow until it becomes unprofitable.

There are many different ways to address this, but the changes in this PR would perhaps be the easiest to implement from a theoretical standpoint -- it could just be included in a bor upgrade, with no config change for validators, since they should all have the sentry/validator set up as static peers already.

I'm not totally sure if this is a good idea -- I don't actually run a validator node or understand the exact resource consumption of bor for validators specifically .

But my guess is that if anything, it might *decrease* the amount of resources needed, since the validators won't have to deal with `GetPooledTransactionsMsg` / `PooledTransactionsMsg` if they are simply receiving direct transactions from the sentry.

I am opening this PR to see if there is any interest in addressing this issue, and to see what others think of the proposed solution.