### PR TITLE
Enable developer mode for new cli

### DIFF
--- a/internal/cli/server/chains/developer.go
+++ b/internal/cli/server/chains/developer.go
@@ -1,0 +1,47 @@
+package chains
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// GetDeveloperChain returns the developer mode configs.
+func GetDeveloperChain(period uint64, faucet common.Address) *Chain {
+	// Override the default period to the user requested one
+	config := *params.AllCliqueProtocolChanges
+	config.Clique = &params.CliqueConfig{
+		Period: period,
+		Epoch:  config.Clique.Epoch,
+	}
+
+	// Assemble and return the chain having genesis with the
+	// precompiles and faucet pre-funded
+	return &Chain{
+		Hash:      common.Hash{},
+		NetworkId: 1337,
+		Genesis: &core.Genesis{
+			Config:     &config,
+			ExtraData:  append(append(make([]byte, 32), faucet[:]...), make([]byte, crypto.SignatureLength)...),
+			GasLimit:   11500000,
+			BaseFee:    big.NewInt(params.InitialBaseFee),
+			Difficulty: big.NewInt(1),
+			Alloc: map[common.Address]core.GenesisAccount{
+				common.BytesToAddress([]byte{1}): {Balance: big.NewInt(1)}, // ECRecover
+				common.BytesToAddress([]byte{2}): {Balance: big.NewInt(1)}, // SHA256
+				common.BytesToAddress([]byte{3}): {Balance: big.NewInt(1)}, // RIPEMD
+				common.BytesToAddress([]byte{4}): {Balance: big.NewInt(1)}, // Identity
+				common.BytesToAddress([]byte{5}): {Balance: big.NewInt(1)}, // ModExp
+				common.BytesToAddress([]byte{6}): {Balance: big.NewInt(1)}, // ECAdd
+				common.BytesToAddress([]byte{7}): {Balance: big.NewInt(1)}, // ECScalarMul
+				common.BytesToAddress([]byte{8}): {Balance: big.NewInt(1)}, // ECPairing
+				common.BytesToAddress([]byte{9}): {Balance: big.NewInt(1)}, // BLAKE2b
+				faucet:                           {Balance: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9))},
+			},
+		},
+		Bootnodes: []string{},
+	}
+}

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -687,11 +687,11 @@ func (c *Config) buildEth(stack *node.Node) (*ethconfig.Config, error) {
 		} else {
 			developer, err = ks.NewAccount(passphrase)
 			if err != nil {
-				Fatalf("Failed to create developer account: %v", err)
+				return nil, fmt.Errorf("failed to create developer account: %v", err)
 			}
 		}
 		if err := ks.Unlock(developer, passphrase); err != nil {
-			Fatalf("Failed to unlock developer account: %v", err)
+			return nil, fmt.Errorf("failed to unlock developer account: %v", err)
 		}
 		log.Info("Using developer account", "address", developer.Address)
 

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -91,6 +91,9 @@ type Config struct {
 
 	// GRPC has the grpc server related settings
 	GRPC *GRPCConfig
+
+	// Developer has the developer mode related settings
+	Developer *DeveloperConfig
 }
 
 type P2PConfig struct {
@@ -365,6 +368,14 @@ type AccountsConfig struct {
 	UseLightweightKDF bool `hcl:"use-lightweight-kdf,optional"`
 }
 
+type DeveloperConfig struct {
+	// Enabled enables the developer mode
+	Enabled bool `hcl:"dev,optional"`
+
+	// Period is the block period to use in developer mode
+	Period uint64 `hcl:"period,optional"`
+}
+
 func DefaultConfig() *Config {
 	return &Config{
 		Chain:     "mainnet",
@@ -486,6 +497,10 @@ func DefaultConfig() *Config {
 		GRPC: &GRPCConfig{
 			Addr: ":3131",
 		},
+		Developer: &DeveloperConfig{
+			Enabled: false,
+			Period:  0,
+		},
 	}
 }
 
@@ -573,6 +588,9 @@ func readConfigFile(path string) (*Config, error) {
 }
 
 func (c *Config) loadChain() error {
+	if c.Developer.Enabled {
+		return nil
+	}
 	chain, ok := chains.GetChain(c.Chain)
 	if !ok {
 		return fmt.Errorf("chain '%s' not found", c.Chain)
@@ -585,7 +603,7 @@ func (c *Config) loadChain() error {
 	}
 
 	// depending on the chain we have different cache values
-	if c.Chain != "mainnet" {
+	if c.Chain == "mainnet" {
 		c.Cache.Cache = 4096
 	} else {
 		c.Cache.Cache = 1024
@@ -599,8 +617,13 @@ func (c *Config) buildEth() (*ethconfig.Config, error) {
 		return nil, err
 	}
 	n := ethconfig.Defaults
-	n.NetworkId = c.chain.NetworkId
-	n.Genesis = c.chain.Genesis
+
+	// only update for non-developer mode as we don't yet
+	// have the chain object for it.
+	if !c.Developer.Enabled {
+		n.NetworkId = c.chain.NetworkId
+		n.Genesis = c.chain.Genesis
+	}
 	n.HeimdallURL = c.Heimdall.URL
 	n.WithoutHeimdall = c.Heimdall.Without
 
@@ -637,6 +660,27 @@ func (c *Config) buildEth() (*ethconfig.Config, error) {
 				return nil, fmt.Errorf("etherbase is not an address: %s", etherbase)
 			}
 			n.Miner.Etherbase = common.HexToAddress(etherbase)
+		}
+	}
+
+	// update for developer mode
+	if c.Developer.Enabled {
+		// get developer mode chain config
+		c.chain = chains.GetDeveloperChain(c.Developer.Period, n.Miner.Etherbase)
+
+		// update the parameters
+		n.NetworkId = c.chain.NetworkId
+		n.Genesis = c.chain.Genesis
+
+		// Update cache
+		c.Cache.Cache = 1024
+
+		// Update sync mode
+		c.SyncMode = "full"
+
+		// update miner gas price
+		if n.Miner.GasPrice == nil {
+			n.Miner.GasPrice = big.NewInt(1)
 		}
 	}
 
@@ -786,6 +830,20 @@ func (c *Config) buildNode() (*node.Config, error) {
 		WSPathPrefix:        c.JsonRPC.Ws.Prefix,
 		GraphQLCors:         c.JsonRPC.Cors,
 		GraphQLVirtualHosts: c.JsonRPC.VHost,
+	}
+
+	// dev mode
+	if c.Developer.Enabled {
+		cfg.UseLightweightKDF = true
+
+		// disable p2p networking
+		c.P2P.NoDiscover = true
+		cfg.P2P.ListenAddr = ""
+		cfg.P2P.NoDial = true
+		cfg.P2P.DiscoveryV5 = false
+
+		// data dir
+		cfg.DataDir = ""
 	}
 
 	// enable jsonrpc endpoints

--- a/internal/cli/server/config_test.go
+++ b/internal/cli/server/config_test.go
@@ -16,7 +16,7 @@ func TestConfigDefault(t *testing.T) {
 	_, err := config.buildNode()
 	assert.NoError(t, err)
 
-	_, err = config.buildEth()
+	_, err = config.buildEth(nil)
 	assert.NoError(t, err)
 }
 

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -461,5 +461,17 @@ func (c *Command) Flags() *flagset.Flagset {
 		Usage: "Address and port to bind the GRPC server",
 		Value: &c.cliConfig.GRPC.Addr,
 	})
+
+	// developer
+	f.BoolFlag(&flagset.BoolFlag{
+		Name:  "dev",
+		Usage: "Enable developer mode with ephemeral proof-of-authority network and a pre-funded developer account, mining enabled",
+		Value: &c.cliConfig.Developer.Enabled,
+	})
+	f.Uint64Flag(&flagset.Uint64Flag{
+		Name:  "dev.period",
+		Usage: "Block period to use in developer mode (0 = mine only if transaction pending)",
+		Value: &c.cliConfig.Developer.Period,
+	})
 	return f
 }

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -107,8 +107,8 @@ func NewServer(config *Config) (*Server, error) {
 		stack.AccountManager().AddBackend(keystore.NewKeyStore(keydir, n, p))
 	}
 
-	// sealing (if enabled)
-	if config.Sealer.Enabled {
+	// sealing (if enabled) or in dev mode
+	if config.Sealer.Enabled || config.Developer.Enabled {
 		if err := backend.StartMining(1); err != nil {
 			return nil, err
 		}

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 
@@ -284,24 +283,4 @@ func setupLogger(logLevel string) {
 		glogger.Verbosity(log.LvlInfo)
 	}
 	log.Root().SetHandler(glogger)
-}
-
-// Fatalf formats a message to standard error and exits the program.
-// The message is also printed to standard output if standard error
-// is redirected to a different file.
-func Fatalf(format string, args ...interface{}) {
-	w := io.MultiWriter(os.Stdout, os.Stderr)
-	if runtime.GOOS == "windows" {
-		// The SameFile check below doesn't work on Windows.
-		// stdout is unlikely to get redirected though, so just print there.
-		w = os.Stdout
-	} else {
-		outf, _ := os.Stdout.Stat()
-		errf, _ := os.Stderr.Stat()
-		if outf != nil && errf != nil && os.SameFile(outf, errf) {
-			w = os.Stderr
-		}
-	}
-	fmt.Fprintf(w, "Fatal: "+format+"\n", args...)
-	os.Exit(1)
 }

--- a/internal/cli/server/server_test.go
+++ b/internal/cli/server/server_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServer_DeveloperMode(t *testing.T) {
+
+	// get the default config
+	config := DefaultConfig()
+
+	// enable developer mode
+	config.Developer.Enabled = true
+	config.Developer.Period = 2 // block time
+
+	// start the server
+	server, err1 := NewServer(config)
+	if err1 != nil {
+		t.Fatalf("failed to start server: %v", err1)
+	}
+
+	// record the initial block number
+	blockNumber := server.backend.BlockChain().CurrentBlock().Header().Number.Int64()
+
+	var i int64 = 0
+	for i = 0; i < 10; i++ {
+		// We expect the node to mine blocks every `config.Developer.Period` time period
+		time.Sleep(time.Duration(config.Developer.Period) * time.Second)
+		currBlock := server.backend.BlockChain().CurrentBlock().Header().Number.Int64()
+		expected := blockNumber + i + 1
+		if res := assert.Equal(t, currBlock, expected); res == false {
+			break
+		}
+	}
+
+	// stop the server
+	server.Stop()
+}


### PR DESCRIPTION
This PR enables the developer mode for the new cli.

It introduces 2 flags, `--dev` and `--dev.period` for testing purpose by starting a mining node with dummy account. 

Linear: [POS 151: Run new cli in dev mode](https://linear.app/matic/issue/POS-151/run-new-cli-in-dev-mode)