### PR TITLE
Split modules for cli

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,18 +19,4 @@ $ bor server
 $ bor server --config ./legacy.toml
 ```
 
-- Modules, vhost and Cors configuration are common for all jsonrpc endpoints.
-
-Before:
-
-```
-$ bor --http --http.modules "eth,web" --ws --ws.modules "eth,web"
-```
-
-Now: 
-
-```
-$ bor server --http --ws --jsonrpc.modules "eth,web"
-```
-
 - ```Admin```, ```Personal``` and account related endpoints in ```Eth``` are being removed from the JsonRPC interface. Some of this functionality will be moved to the new GRPC server for operational tasks.

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -109,8 +109,6 @@ The ```bor server``` command runs the Bor client.
 
 - ```jsonrpc.vhosts```: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.
 
-- ```jsonrpc.modules```: API's offered over the HTTP-RPC interface.
-
 - ```http```: Enable the HTTP-RPC server.
 
 - ```http.addr```: HTTP-RPC server listening interface.
@@ -119,6 +117,8 @@ The ```bor server``` command runs the Bor client.
         
 - ```http.rpcprefix```: HTTP path path prefix on which JSON-RPC is served. Use '/' to serve on all paths.
 
+- ```http.modules```: API's offered over the HTTP-RPC interface.
+
 - ```ws```: Enable the WS-RPC server.
 
 - ```ws.addr```: WS-RPC server listening interface.
@@ -126,6 +126,8 @@ The ```bor server``` command runs the Bor client.
 - ```ws.port```: WS-RPC server listening port.
 
 - ```ws.rpcprefix```: HTTP path prefix on which JSON-RPC is served. Use '/' to serve on all paths.
+
+- ```ws.modules```: API's offered over the WS-RPC interface.
 
 - ```graphql```: Enable GraphQL on the HTTP-RPC server. Note that GraphQL can only be started if an HTTP server is started as well.
 

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -209,9 +209,6 @@ type JsonRPCConfig struct {
 	// IPCPath is the path of the ipc endpoint
 	IPCPath string `hcl:"ipc-path,optional"`
 
-	// Modules is the list of enabled api modules
-	Modules []string `hcl:"modules,optional"`
-
 	// VHost is the list of valid virtual hosts
 	VHost []string `hcl:"vhost,optional"`
 
@@ -251,6 +248,9 @@ type APIConfig struct {
 
 	// Host is the address to bind the api
 	Host string `hcl:"host,optional"`
+
+	// Modules is the list of enabled api modules
+	Modules []string `hcl:"modules,optional"`
 }
 
 type GpoConfig struct {
@@ -425,7 +425,6 @@ func DefaultConfig() *Config {
 		JsonRPC: &JsonRPCConfig{
 			IPCDisable: false,
 			IPCPath:    "",
-			Modules:    []string{"web3", "net"},
 			Cors:       []string{"*"},
 			VHost:      []string{"*"},
 			GasCap:     ethconfig.Defaults.RPCGasCap,
@@ -435,12 +434,14 @@ func DefaultConfig() *Config {
 				Port:    8545,
 				Prefix:  "",
 				Host:    "localhost",
+				Modules: []string{"web3", "net"},
 			},
 			Ws: &APIConfig{
 				Enabled: false,
 				Port:    8546,
 				Prefix:  "",
 				Host:    "localhost",
+				Modules: []string{"web3", "net"},
 			},
 			Graphql: &APIConfig{
 				Enabled: false,
@@ -777,11 +778,11 @@ func (c *Config) buildNode() (*node.Config, error) {
 			ListenAddr:      c.P2P.Bind + ":" + strconv.Itoa(int(c.P2P.Port)),
 			DiscoveryV5:     c.P2P.Discovery.V5Enabled,
 		},
-		HTTPModules:         c.JsonRPC.Modules,
+		HTTPModules:         c.JsonRPC.Http.Modules,
 		HTTPCors:            c.JsonRPC.Cors,
 		HTTPVirtualHosts:    c.JsonRPC.VHost,
 		HTTPPathPrefix:      c.JsonRPC.Http.Prefix,
-		WSModules:           c.JsonRPC.Modules,
+		WSModules:           c.JsonRPC.Ws.Modules,
 		WSOrigins:           c.JsonRPC.Cors,
 		WSPathPrefix:        c.JsonRPC.Ws.Prefix,
 		GraphQLCors:         c.JsonRPC.Cors,

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -263,11 +263,6 @@ func (c *Command) Flags() *flagset.Flagset {
 		Usage: "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
 		Value: &c.cliConfig.JsonRPC.VHost,
 	})
-	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "jsonrpc.modules",
-		Usage: "API's offered over the HTTP-RPC interface",
-		Value: &c.cliConfig.JsonRPC.Modules,
-	})
 
 	// http options
 	f.BoolFlag(&flagset.BoolFlag{
@@ -290,6 +285,12 @@ func (c *Command) Flags() *flagset.Flagset {
 		Usage: "HTTP path path prefix on which JSON-RPC is served. Use '/' to serve on all paths.",
 		Value: &c.cliConfig.JsonRPC.Http.Prefix,
 	})
+	f.SliceStringFlag(&flagset.SliceStringFlag{
+		Name:  "http.modules",
+		Usage: "API's offered over the HTTP-RPC interface",
+		Value: &c.cliConfig.JsonRPC.Http.Modules,
+	})
+
 	// ws options
 	f.BoolFlag(&flagset.BoolFlag{
 		Name:  "ws",
@@ -311,6 +312,12 @@ func (c *Command) Flags() *flagset.Flagset {
 		Usage: "HTTP path prefix on which JSON-RPC is served. Use '/' to serve on all paths.",
 		Value: &c.cliConfig.JsonRPC.Ws.Prefix,
 	})
+	f.SliceStringFlag(&flagset.SliceStringFlag{
+		Name:  "ws.modules",
+		Usage: "API's offered over the WS-RPC interface",
+		Value: &c.cliConfig.JsonRPC.Ws.Modules,
+	})
+
 	// graphql options
 	f.BoolFlag(&flagset.BoolFlag{
 		Name:  "graphql",

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -85,7 +85,7 @@ func NewServer(config *Config) (*Server, error) {
 
 	// graphql is started from another place
 	if config.JsonRPC.Graphql.Enabled {
-		if err := graphql.New(stack, backend.APIBackend, config.JsonRPC.Cors, config.JsonRPC.Modules); err != nil {
+		if err := graphql.New(stack, backend.APIBackend, config.JsonRPC.Cors, config.JsonRPC.VHost); err != nil {
 			return nil, fmt.Errorf("failed to register the GraphQL service: %v", err)
 		}
 	}


### PR DESCRIPTION
This PR splits the jsonrpc module config into HTTP and WS modules. 