### PR TITLE
Update default cli config

### DIFF
--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -443,11 +443,11 @@ func DefaultConfig() *Config {
 			GasCap:     ethconfig.Defaults.RPCGasCap,
 			TxFeeCap:   ethconfig.Defaults.RPCTxFeeCap,
 			Http: &APIConfig{
-				Enabled: false,
+				Enabled: true,
 				Port:    8545,
 				Prefix:  "",
 				Host:    "localhost",
-				Modules: []string{"web3", "net"},
+				Modules: []string{"eth", "web3", "net"},
 			},
 			Ws: &APIConfig{
 				Enabled: false,


### PR DESCRIPTION
This PR starts the http RPC server by default and also adds "eth" as default namespace. 