### PR TITLE
Enforce floor gas price

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -108,7 +108,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if !config.SyncMode.IsValid() {
 		return nil, fmt.Errorf("invalid sync mode %d", config.SyncMode)
 	}
-	if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(common.Big0) <= 0 {
+
+	// The configured gas price must be greater than or equal to the default floor gas price
+	if ethconfig.Defaults.Miner.GasPrice.Cmp(gasprice.DefaultFloorGasPrice) < 0 {
+		ethconfig.Defaults.Miner.GasPrice = new(big.Int).Set(gasprice.DefaultFloorGasPrice)
+	}
+	if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(common.Big0) <= 0 || config.Miner.GasPrice.Cmp(gasprice.DefaultFloorGasPrice) < 0 {
 		log.Warn("Sanitizing invalid miner gas price", "provided", config.Miner.GasPrice, "updated", ethconfig.Defaults.Miner.GasPrice)
 		config.Miner.GasPrice = new(big.Int).Set(ethconfig.Defaults.Miner.GasPrice)
 	}

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -37,6 +37,9 @@ const sampleNumber = 3 // Number of transactions sampled in a block
 var (
 	DefaultMaxPrice    = big.NewInt(5000 * params.GWei)
 	DefaultIgnorePrice = big.NewInt(2 * params.Wei)
+
+	// Floor gas price
+	DefaultFloorGasPrice = big.NewInt(30 * params.GWei)
 )
 
 type Config struct {


### PR DESCRIPTION
This change makes sure that the configured gas price is at least the default gas price of 30 Gwei, so that the recommended floor gas price will apply even if the validators forget to set the config.

### Rationale

Currently, not all validators are enforcing the 30 Gwei floor gas price, as recommended by the Polygon team. 

Among the top 20 validators, 14 validators have set the recommended gas price, but the following validators haven't:
* 0x67b94473d81d0cd00849d563c94d0432ac988b49 - 137 - Binance Node
* 0xef46d5fe753c988606e6f703260d816af53b03eb - 88 - Staked
* 0x742d13f0b2a19c823bdd362b16305e4704b97a38 - 70 - InfStones
* 0x4f856f79f54592a48c8a1a1fafa1b0a3ac053f99 - 43 - MANTRA DAO
* 0x448aa1665fe1fae6d1a00a9209ea62d7dcd81a4b - 20 - Blockops
* 0x5b106f49f30620a07b4fbdcebb1e08b70499c851 - 126 - Valis Labs

Whenever it's those validators' turn to mine blocks, the gas price dips below 30 Gwei, causing the gas tracker as well as the `eth_gasPrice`/`eth_feeHistory` endpoints to start suggesting gas prices lower than 30 Gwei.

<img width="508" alt="gastracker" src="https://user-images.githubusercontent.com/30173/153702421-36794755-3f69-4cf1-b763-4b71a6e6830b.png">

This causes new transactions created using popular clients like Metamask to be submitted with <30 Gwei gas price/priority fee.

This is problematic because as soon as other validators that enforce the recommended minimum 30 Gwei gas price start validating blocks, those underpriced transactions get stuck for a long time, until one of the aforementioned validators that did not set the minimum gas price starts mining again.

**This is leading to an extremely poor user experience, and people are mistakenly thinking that the network is unstable or slow when their underpriced transactions get stuck pending. Coinbase received many complaints that we ended up applying the 30 Gwei minimum gas price to the suggested gas prices in our wallet app.**

The 30 Gwei floor gas price is also important to deter bot/spam transactions that flood the mempool and cause legit transactions to get dropped. Take a look at this block created by a miner that is not enforcing the minimum gas price, it's filled with bot transactions, and each spam transaction is practically free: https://polygonscan.com/txs?block=24842473

If possible, please cherry-pick this change and include it in the next bor release. (0.2.15)