### PR TITLE
Fix linter issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,4 +17,6 @@ jobs:
       - run:
           command: make all
       - run:
+          command: make lint
+      - run:
           command: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,7 @@ jobs:
           go-version: 1.17
       - name: "Build binaries"
         run: make all
+      - name: "Run linter"
+        run: make lint
       - name: "Run tests"
         run: make test

--- a/consensus/bor/api.go
+++ b/consensus/bor/api.go
@@ -132,7 +132,7 @@ func (api *API) GetRootHash(start uint64, end uint64) (string, error) {
 	if root, known := api.rootHashCache.Get(key); known {
 		return root.(string), nil
 	}
-	length := uint64(end - start + 1)
+	length := end - start + 1
 	if length > MaxCheckpointLength {
 		return "", &MaxCheckpointLengthExceededError{start, end}
 	}
@@ -147,7 +147,7 @@ func (api *API) GetRootHash(start uint64, end uint64) (string, error) {
 		wg.Add(1)
 		concurrent <- true
 		go func(number uint64) {
-			blockHeaders[number-start] = api.chain.GetHeaderByNumber(uint64(number))
+			blockHeaders[number-start] = api.chain.GetHeaderByNumber(number)
 			<-concurrent
 			wg.Done()
 		}(i)

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -56,9 +56,6 @@ var (
 
 	uncleHash = types.CalcUncleHash(nil) // Always Keccak256(RLP([])) as uncles are meaningless outside of PoW.
 
-	diffInTurn = big.NewInt(2) // Block difficulty for in-turn signatures
-	diffNoTurn = big.NewInt(1) // Block difficulty for out-of-turn signatures
-
 	validatorHeaderBytesLength = common.AddressLength + 20 // address + power
 	systemAddress              = common.HexToAddress("0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE")
 )
@@ -71,18 +68,6 @@ var (
 	// errUnknownBlock is returned when the list of signers is requested for a block
 	// that is not part of the local blockchain.
 	errUnknownBlock = errors.New("unknown block")
-
-	// errInvalidCheckpointBeneficiary is returned if a checkpoint/epoch transition
-	// block has a beneficiary set to non-zeroes.
-	errInvalidCheckpointBeneficiary = errors.New("beneficiary in checkpoint block non-zero")
-
-	// errInvalidVote is returned if a nonce value is something else that the two
-	// allowed constants of 0x00..0 or 0xff..f.
-	errInvalidVote = errors.New("vote nonce not 0x00..0 or 0xff..f")
-
-	// errInvalidCheckpointVote is returned if a checkpoint/epoch transition block
-	// has a vote nonce set to non-zeroes.
-	errInvalidCheckpointVote = errors.New("vote nonce in checkpoint block non-zero")
 
 	// errMissingVanity is returned if a block's extra-data section is shorter than
 	// 32 bytes, which is required to store the signer vanity.
@@ -670,7 +655,7 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header) e
 
 	var succession int
 	// if signer is not empty
-	if bytes.Compare(c.signer.Bytes(), common.Address{}.Bytes()) != 0 {
+	if !bytes.Equal(c.signer.Bytes(), common.Address{}.Bytes()) {
 		succession, err = snap.GetSignerSuccessionNumber(c.signer)
 		if err != nil {
 			return err
@@ -1163,6 +1148,9 @@ func (c *Bor) CommitStates(
 		"fromID", lastStateID+1,
 		"to", to.Format(time.RFC3339))
 	eventRecords, err := c.HeimdallClient.FetchStateSyncEvents(lastStateID+1, to.Unix())
+	if err != nil {
+		return nil, err
+	}
 	if c.config.OverrideStateSyncRecords != nil {
 		if val, ok := c.config.OverrideStateSyncRecords[strconv.FormatUint(number, 10)]; ok {
 			eventRecords = eventRecords[0:val]
@@ -1331,7 +1319,7 @@ func applyMessage(
 
 func validatorContains(a []*Validator, x *Validator) (*Validator, bool) {
 	for _, n := range a {
-		if bytes.Compare(n.Address.Bytes(), x.Address.Bytes()) == 0 {
+		if bytes.Equal(n.Address.Bytes(), x.Address.Bytes()) {
 			return n, true
 		}
 	}

--- a/consensus/bor/clerk.go
+++ b/consensus/bor/clerk.go
@@ -23,7 +23,7 @@ type EventRecordWithTime struct {
 	Time time.Time `json:"record_time" yaml:"record_time"`
 }
 
-// String returns the string representatin of span
+// String returns the string representation of span
 func (e *EventRecordWithTime) String() string {
 	return fmt.Sprintf(
 		"id %v, contract %v, data: %v, txHash: %v, logIndex: %v, chainId: %v, time %s",

--- a/consensus/bor/rest.go
+++ b/consensus/bor/rest.go
@@ -38,7 +38,7 @@ func NewHeimdallClient(urlString string) (*HeimdallClient, error) {
 	h := &HeimdallClient{
 		urlString: urlString,
 		client: http.Client{
-			Timeout: time.Duration(5 * time.Second),
+			Timeout: 5 * time.Second,
 		},
 	}
 	return h, nil

--- a/consensus/bor/snapshot.go
+++ b/consensus/bor/snapshot.go
@@ -202,7 +202,7 @@ func (s *Snapshot) signers() []common.Address {
 // Difficulty returns the difficulty for a particular signer at the current snapshot number
 func (s *Snapshot) Difficulty(signer common.Address) uint64 {
 	// if signer is empty
-	if bytes.Compare(signer.Bytes(), common.Address{}.Bytes()) == 0 {
+	if bytes.Equal(signer.Bytes(), common.Address{}.Bytes()) {
 		return 1
 	}
 

--- a/core/blockchain_bor_test.go
+++ b/core/blockchain_bor_test.go
@@ -110,7 +110,7 @@ func TestChain2HeadEvent(t *testing.T) {
 		}})
 
 	// reorg event
-	//In this event the channel recieves an array of Blocks in NewChain and OldChain
+	//In this event the channel receives an array of Blocks in NewChain and OldChain
 	readEvent(&eventTest{
 		Type: Chain2HeadReorgEvent,
 		Added: []common.Hash{

--- a/core/bor_blockchain.go
+++ b/core/bor_blockchain.go
@@ -18,7 +18,7 @@ func (bc *BlockChain) GetBorReceiptByHash(hash common.Hash) *types.Receipt {
 		return nil
 	}
 
-	// read bor reciept by hash and number
+	// read bor receipt by hash and number
 	receipt := rawdb.ReadBorReceipt(bc.db, hash, *number)
 	if receipt == nil {
 		return nil

--- a/core/rawdb/bor_receipt.go
+++ b/core/rawdb/bor_receipt.go
@@ -14,9 +14,6 @@ var (
 	// bor receipt key
 	borReceiptKey = types.BorReceiptKey
 
-	// bor derived tx hash
-	getDerivedBorTxHash = types.GetDerivedBorTxHash
-
 	// borTxLookupPrefix + hash -> transaction/receipt lookup metadata
 	borTxLookupPrefix = []byte("matic-bor-tx-lookup-")
 

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -745,11 +745,11 @@ func (t *freezerTable) dumpIndex(w io.Writer, start, stop int64) {
 // Bor related changes
 //
 
-// Fill adds empty data till given number (convenience method for backward compatibilty)
+// Fill adds empty data till given number (convenience method for backward compatibility)
 func (t *freezerTable) Fill(number uint64) error {
 	if t.items < number {
 		b := t.newBatch()
-		log.Info("Filling all data into freezer for backward compatablity", "name", t.name, "items", t.items, "number", number)
+		log.Info("Filling all data into freezer for backward compatibility", "name", t.name, "items", t.items, "number", number)
 		for t.items < number {
 			if err := b.Append(t.items, nil); err != nil {
 				log.Error("Failed to fill data into freezer", "name", t.name, "items", t.items, "number", number, "err", err)

--- a/eth/filters/bor_api.go
+++ b/eth/filters/bor_api.go
@@ -66,7 +66,7 @@ func (api *PublicFilterAPI) NewDeposits(ctx context.Context, crit ethereum.State
 		for {
 			select {
 			case h := <-stateSyncData:
-				if crit.ID == h.ID || bytes.Compare(crit.Contract.Bytes(), h.Contract.Bytes()) == 0 ||
+				if crit.ID == h.ID || bytes.Equal(crit.Contract.Bytes(), h.Contract.Bytes()) ||
 					(crit.ID == 0 && crit.Contract == common.Address{}) {
 					notifier.Notify(rpcSub.ID, h)
 				}

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -413,14 +413,14 @@ func DefaultConfig() *Config {
 			Locals:       []string{},
 			NoLocals:     false,
 			Journal:      "",
-			Rejournal:    time.Duration(1 * time.Hour),
+			Rejournal:    1 * time.Hour,
 			PriceLimit:   1,
 			PriceBump:    10,
 			AccountSlots: 16,
 			GlobalSlots:  4096,
 			AccountQueue: 64,
 			GlobalQueue:  1024,
-			LifeTime:     time.Duration(3 * time.Hour),
+			LifeTime:     3 * time.Hour,
 		},
 		Sealer: &SealerConfig{
 			Enabled:   false,
@@ -751,7 +751,7 @@ func (c *Config) buildEth(stack *node.Node) (*ethconfig.Config, error) {
 				log.Warn("Lowering memory allowance on 32bit arch", "available", mem.Total/1024/1024, "addressable", 2*1024)
 				mem.Total = 2 * 1024 * 1024 * 1024
 			}
-			allowance := uint64(mem.Total / 1024 / 1024 / 3)
+			allowance := mem.Total / 1024 / 1024 / 3
 			if cache > allowance {
 				log.Warn("Sanitizing cache to Go's GC limits", "provided", cache, "updated", allowance)
 				cache = allowance

--- a/internal/cli/server/config_test.go
+++ b/internal/cli/server/config_test.go
@@ -89,7 +89,7 @@ func TestConfigLoadFile(t *testing.T) {
 				MaxPeers: 30,
 			},
 			TxPool: &TxPoolConfig{
-				LifeTime: time.Duration(1 * time.Second),
+				LifeTime: 1 * time.Second,
 			},
 			Gpo: &GpoConfig{
 				MaxPrice: big.NewInt(100),

--- a/internal/cli/server/server_test.go
+++ b/internal/cli/server/server_test.go
@@ -25,7 +25,7 @@ func TestServer_DeveloperMode(t *testing.T) {
 	// record the initial block number
 	blockNumber := server.backend.BlockChain().CurrentBlock().Header().Number.Int64()
 
-	var i int64 = 0
+	var i int64
 	for i = 0; i < 10; i++ {
 		// We expect the node to mine blocks every `config.Developer.Period` time period
 		time.Sleep(time.Duration(config.Developer.Period) * time.Second)

--- a/tests/bor/bor_test.go
+++ b/tests/bor/bor_test.go
@@ -25,9 +25,7 @@ import (
 )
 
 var (
-	spanPath         = "bor/span/1"
-	clerkPath        = "clerk/event-record/list"
-	clerkQueryParams = "from-time=%d&to-time=%d&page=%d&limit=50"
+	spanPath = "bor/span/1"
 )
 
 func TestInsertingSpanSizeBlocks(t *testing.T) {

--- a/tests/bor/helper.go
+++ b/tests/bor/helper.go
@@ -32,8 +32,6 @@ var (
 
 	// This account is one the validators for 1st span (0-indexed)
 	privKey2 = "9b28f36fbd67381120752d6172ecdcf10e06ab2d9a1367aac00cdcd6ac7855d3"
-	key2, _  = crypto.HexToECDSA(privKey2)
-	addr2    = crypto.PubkeyToAddress(key2.PublicKey) // 0x9fB29AAc15b9A4B7F17c3385939b007540f4d791
 
 	validatorHeaderBytesLength        = common.AddressLength + 20 // address + power
 	sprintSize                 uint64 = 4


### PR DESCRIPTION
This PR fixes a couple of issues reported by the linter (via `make lint` command) and enables it in the CI.

The reported errors were:
```
$ make lint
env GO111MODULE=on go run build/ci.go lint
build/cache/golangci-lint-1.42.0-linux-amd64.tar.gz is up-to-date
>>> build/cache/golangci-lint-1.42.0-linux-amd64/golangci-lint run --config .golangci.yml ./...
eth/filters/bor_api.go:69:27: S1004: should use bytes.Equal(crit.Contract.Bytes(), h.Contract.Bytes()) instead (gosimple)
				if crit.ID == h.ID || bytes.Compare(crit.Contract.Bytes(), h.Contract.Bytes()) == 0 ||
				                      ^
core/rawdb/bor_receipt.go:18:2: `getDerivedBorTxHash` is unused (deadcode)
	getDerivedBorTxHash = types.GetDerivedBorTxHash
	^
core/rawdb/freezer_table.go:748:76: `compatibilty` is a misspelling of `compatibility` (misspell)
// Fill adds empty data till given number (convenience method for backward compatibilty)
                                                                           ^
core/rawdb/freezer_table.go:752:56: `compatablity` is a misspelling of `compatibility` (misspell)
		log.Info("Filling all data into freezer for backward compatablity", "name", t.name, "items", t.items, "number", number)
		                                                     ^
internal/cli/server/config.go:416:31: unnecessary conversion (unconvert)
			Rejournal:    time.Duration(1 * time.Hour),
			                           ^
internal/cli/server/config.go:423:31: unnecessary conversion (unconvert)
			LifeTime:     time.Duration(3 * time.Hour),
			                           ^
internal/cli/server/config.go:754:23: unnecessary conversion (unconvert)
			allowance := uint64(mem.Total / 1024 / 1024 / 3)
			                   ^
internal/cli/server/server_test.go:28:6: ineffectual assignment to i (ineffassign)
	var i int64 = 0
	    ^
tests/bor/helper.go:36:2: `addr2` is unused (deadcode)
	addr2    = crypto.PubkeyToAddress(key2.PublicKey) // 0x9fB29AAc15b9A4B7F17c3385939b007540f4d791
	^
tests/bor/bor_test.go:29:2: `clerkPath` is unused (deadcode)
	clerkPath        = "clerk/event-record/list"
	^
tests/bor/bor_test.go:30:2: `clerkQueryParams` is unused (deadcode)
	clerkQueryParams = "from-time=%d&to-time=%d&page=%d&limit=50"
	^
core/bor_blockchain.go:21:14: `reciept` is a misspelling of `receipt` (misspell)
	// read bor reciept by hash and number
	            ^
core/blockchain_bor_test.go:113:30: `recieves` is a misspelling of `receives` (misspell)
	//In this event the channel recieves an array of Blocks in NewChain and OldChain
	                            ^
consensus/bor/bor.go:59:2: `diffInTurn` is unused (deadcode)
	diffInTurn = big.NewInt(2) // Block difficulty for in-turn signatures
	^
consensus/bor/bor.go:60:2: `diffNoTurn` is unused (deadcode)
	diffNoTurn = big.NewInt(1) // Block difficulty for out-of-turn signatures
	^
consensus/bor/bor.go:77:2: `errInvalidCheckpointBeneficiary` is unused (deadcode)
	errInvalidCheckpointBeneficiary = errors.New("beneficiary in checkpoint block non-zero")
	^
consensus/bor/bor.go:81:2: `errInvalidVote` is unused (deadcode)
	errInvalidVote = errors.New("vote nonce not 0x00..0 or 0xff..f")
	^
consensus/bor/bor.go:85:2: `errInvalidCheckpointVote` is unused (deadcode)
	errInvalidCheckpointVote = errors.New("vote nonce in checkpoint block non-zero")
	^
consensus/bor/clerk.go:26:30: `representatin` is a misspelling of `representations` (misspell)
// String returns the string representatin of span
                             ^
consensus/bor/bor.go:673:5: S1004: should use !bytes.Equal(c.signer.Bytes(), common.Address{}.Bytes()) instead (gosimple)
	if bytes.Compare(c.signer.Bytes(), common.Address{}.Bytes()) != 0 {
	   ^
consensus/bor/bor.go:1334:6: S1004: should use bytes.Equal(n.Address.Bytes(), x.Address.Bytes()) instead (gosimple)
		if bytes.Compare(n.Address.Bytes(), x.Address.Bytes()) == 0 {
		   ^
consensus/bor/snapshot.go:205:5: S1004: should use bytes.Equal(signer.Bytes(), common.Address{}.Bytes()) instead (gosimple)
	if bytes.Compare(signer.Bytes(), common.Address{}.Bytes()) == 0 {
	   ^
consensus/bor/bor.go:1165:16: ineffectual assignment to err (ineffassign)
	eventRecords, err := c.HeimdallClient.FetchStateSyncEvents(lastStateID+1, to.Unix())
	              ^
util.go:46: exit status 1
exit status 1
make: *** [Makefile:56: lint] Error 1
```