### PR TITLE
increase underpricedTxSet memory and increase blockLimit max received per peer

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -42,8 +42,10 @@ const (
 	maxUncleDist = 7   // Maximum allowed backward distance from the chain head
 	maxQueueDist = 32  // Maximum allowed distance from the chain head to queue
 	hashLimit    = 256 // Maximum number of unique blocks or headers a peer may have announced
-	blockLimit   = 64  // Maximum number of unique blocks a peer may have delivered
+	blockLimit   = 128  // Maximum number of unique blocks a peer may have delivered
 )
+// blockLimit of 64 does not allow for situations in which the validator might be peered directly to bloxroute and propagate
+// a backup block from bloxroute to its sentry
 
 var (
 	blockAnnounceInMeter   = metrics.NewRegisteredMeter("eth/fetcher/block/announces/in", nil)

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -50,7 +50,10 @@ const (
 	// maxTxUnderpricedSetSize is the size of the underpriced transaction set that
 	// is used to track recent transactions that have been dropped so we don't
 	// re-request them.
-	maxTxUnderpricedSetSize = 32768
+	maxTxUnderpricedSetSize = 262144
+	//The previous value of 32768 was too low - many nodes had > 150,000 underpriced transactions in their txpool
+	//causing a vicious cycle of the same transactions being propagated and then forgotten
+	//this number may need to be increased again in the future
 
 	// txArriveTimeout is the time allowance before an announced transaction is
 	// explicitly requested.


### PR DESCRIPTION
Two slight tweaks that I've been running on my nodes. Should help with the issues that polygon is currently having re; tx spam. The rest of the changes on my nodes are pretty extensive and would require significant review, but these two are pretty clear cut and the results should be pretty straight forward.  I hate github and have no idea how to use it - apologies if I did the PR wrong. 