### PR TITLE
fix: modify the comment of txlookuplimit

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -227,7 +227,7 @@ var (
 	}
 	TxLookupLimitFlag = cli.Uint64Flag{
 		Name:  "txlookuplimit",
-		Usage: "Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain)",
+		Usage: "Number of recent blocks to maintain transactions index for (default = about 56 days, 0 = entire chain)",
 		Value: ethconfig.Defaults.TxLookupLimit,
 	}
 	LightKDFFlag = cli.BoolFlag{

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -93,7 +93,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```cache.preimages```: Enable recording the SHA3/keccak preimages of trie keys.
 
-- ```txlookuplimit```: Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain).
+- ```txlookuplimit```: Number of recent blocks to maintain transactions index for (default = about 56 days, 0 = entire chain).
 
 ### JsonRPC Options
 

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -228,7 +228,7 @@ func (c *Command) Flags() *flagset.Flagset {
 	})
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:  "txlookuplimit",
-		Usage: "Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain)",
+		Usage: "Number of recent blocks to maintain transactions index for (default = about 56 days, 0 = entire chain)",
 		Value: &c.cliConfig.Cache.TxLookupLimit,
 	})
 


### PR DESCRIPTION
fix: modify the comment of txlookuplimit.

The comment of the txlookuplimit show as "Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain)". It is correct for the Eth, but for bor, the default time is about 56 days.