### PR TITLE
fix api GetTransactionReceiptsByBlock bug

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -658,6 +658,7 @@ func (s *PublicBlockChainAPI) GetTransactionReceiptsByBlock(ctx context.Context,
 			"contractAddress":   nil,
 			"logs":              receipt.Logs,
 			"logsBloom":         receipt.Bloom,
+			"type":              hexutil.Uint(tx.Type()),
 		}
 
 		// Assign receipt status or post state.
@@ -669,7 +670,7 @@ func (s *PublicBlockChainAPI) GetTransactionReceiptsByBlock(ctx context.Context,
 		if receipt.Logs == nil {
 			fields["logs"] = [][]*types.Log{}
 		}
-		if borReceipt != nil {
+		if borReceipt != nil && idx == len(receipts)-1 {
 			fields["transactionHash"] = txHash
 		}
 		// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation


### PR DESCRIPTION
https://github.com/maticnetwork/bor/pull/164/ when block has bor tx, all `transactionHash` as same
