### PR TITLE
Fix prometheus path and add prometheus to bor.service

### DIFF
--- a/builder/files/bor.service
+++ b/builder/files/bor.service
@@ -10,14 +10,18 @@
     -chain=mumbai \
     # -chain=mainnet \
     -datadir /var/lib/bor/data \
+    -metrics \
+    -metrics.prometheus-addr="127.0.0.1:7071" \
     -bootnodes "enode://0cb82b395094ee4a2915e9714894627de9ed8498fb881cec6db7c65e8b9a5bd7f2f25cc84e71e89d0947e51c76e85d0847de848c7782b13c0255247a6758178c@44.232.55.71:30303,enode://88116f4295f5a31538ae409e4d44ad40d22e44ee9342869e7d68bdec55b0f83c1530355ce8b41fbec0928a7d75a5745d528450d30aec92066ab6ba1ee351d710@159.203.9.164:30303"
     # Validator params
-    # Uncomment and configure the following lines in case you run a validator
+    # Uncomment and configure the following lines in case you run a validator. Don't forget to add backslash (\) 
+    # to previous command line.
     # -keystore /var/lib/bor/keystore \
     # -unlock [VALIDATOR ADDRESS] \
     # -password /var/lib/bor/password.txt \
     # -allow-insecure-unlock \
     # -nodiscover -maxpeers 1 \
+    # -miner.etherbase [VALIDATOR ADDRESS] \
     # -mine
   Type=simple
   User=root

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -175,9 +175,7 @@ func (s *Server) setupMetrics(config *TelemetryConfig, serviceName string) error
 
 		prometheusMux := http.NewServeMux()
 
-		prometheusMux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
-			prometheus.Handler(metrics.DefaultRegistry)
-		})
+		prometheusMux.Handle("/debug/metrics/prometheus", prometheus.Handler(metrics.DefaultRegistry))
 
 		promServer := &http.Server{
 			Addr:    config.PrometheusAddr,


### PR DESCRIPTION
Prometheus metrics was not working for three reasons: 

1. path was set to `/metric`
2. we need to use `Handler` instead of `HandleFunc`. Also see the same fix in v3 https://github.com/maticnetwork/v3/pull/52
3. bor.service did not enable metrics and prometheus's address

This commit fixes these problems.