### PR TITLE
internal/cli/server, eth: add option to disable personal wallet endpoints

### DIFF
--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -36,6 +36,8 @@ The ```bor server``` command runs the Bor client.
 
 - ```gpo.ignoreprice```: Gas price below which gpo will ignore transactions
 
+- ```disable-bor-wallet```: Disable the personal wallet endpoints
+
 - ```grpc.addr```: Address and port to bind the GRPC server
 
 - ```dev```: Enable developer mode with ephemeral proof-of-authority network and a pre-funded developer account, mining enabled

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -82,6 +82,7 @@ type Ethereum struct {
 	eventMux       *event.TypeMux
 	engine         consensus.Engine
 	accountManager *accounts.Manager
+	authorized     bool // If consensus engine is authorized with keystore
 
 	bloomRequests     chan chan *bloombits.Retrieval // Channel receiving bloom data retrieval requests
 	bloomIndexer      *core.ChainIndexer             // Bloom indexer operating during block imports
@@ -153,6 +154,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		chainDb:           chainDb,
 		eventMux:          stack.EventMux(),
 		accountManager:    stack.AccountManager(),
+		authorized:        false,
 		engine:            nil,
 		closeBloomHandler: make(chan struct{}),
 		networkID:         config.NetworkId,
@@ -485,29 +487,34 @@ func (s *Ethereum) StartMining(threads int) error {
 			log.Error("Cannot start mining without etherbase", "err", err)
 			return fmt.Errorf("etherbase missing: %v", err)
 		}
-		var cli *clique.Clique
-		if c, ok := s.engine.(*clique.Clique); ok {
-			cli = c
-		} else if cl, ok := s.engine.(*beacon.Beacon); ok {
-			if c, ok := cl.InnerEngine().(*clique.Clique); ok {
+
+		// If personal endpoints are disabled, the server creating
+		// this Ethereum instance has already Authorized consensus.
+		if !s.authorized {
+			var cli *clique.Clique
+			if c, ok := s.engine.(*clique.Clique); ok {
 				cli = c
+			} else if cl, ok := s.engine.(*beacon.Beacon); ok {
+				if c, ok := cl.InnerEngine().(*clique.Clique); ok {
+					cli = c
+				}
 			}
-		}
-		if cli != nil {
-			wallet, err := s.accountManager.Find(accounts.Account{Address: eb})
-			if wallet == nil || err != nil {
-				log.Error("Etherbase account unavailable locally", "err", err)
-				return fmt.Errorf("signer missing: %v", err)
+			if cli != nil {
+				wallet, err := s.accountManager.Find(accounts.Account{Address: eb})
+				if wallet == nil || err != nil {
+					log.Error("Etherbase account unavailable locally", "err", err)
+					return fmt.Errorf("signer missing: %v", err)
+				}
+				cli.Authorize(eb, wallet.SignData)
 			}
-			cli.Authorize(eb, wallet.SignData)
-		}
-		if bor, ok := s.engine.(*bor.Bor); ok {
-			wallet, err := s.accountManager.Find(accounts.Account{Address: eb})
-			if wallet == nil || err != nil {
-				log.Error("Etherbase account unavailable locally", "err", err)
-				return fmt.Errorf("signer missing: %v", err)
+			if bor, ok := s.engine.(*bor.Bor); ok {
+				wallet, err := s.accountManager.Find(accounts.Account{Address: eb})
+				if wallet == nil || err != nil {
+					log.Error("Etherbase account unavailable locally", "err", err)
+					return fmt.Errorf("signer missing: %v", err)
+				}
+				bor.Authorize(eb, wallet.SignData)
 			}
-			bor.Authorize(eb, wallet.SignData)
 		}
 		// If mining is started, we can disable the transaction rejection mechanism
 		// introduced to speed sync times.
@@ -551,6 +558,14 @@ func (s *Ethereum) Merger() *consensus.Merger          { return s.merger }
 func (s *Ethereum) SyncMode() downloader.SyncMode {
 	mode, _ := s.handler.chainSync.modeAndLocalHead()
 	return mode
+}
+
+// SetAuthorized sets the authorized bool variable
+// denoting that consensus has been authorized while creation
+func (s *Ethereum) SetAuthorized(authorized bool) {
+	s.lock.Lock()
+	s.authorized = authorized
+	s.lock.Unlock()
 }
 
 // Protocols returns all the currently configured

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -368,6 +368,9 @@ type AccountsConfig struct {
 
 	// UseLightweightKDF enables a faster but less secure encryption of accounts
 	UseLightweightKDF bool `hcl:"use-lightweight-kdf,optional"`
+
+	// DisableBorWallet disables the personal wallet endpoints
+	DisableBorWallet bool `hcl:"disable-bor-wallet,optional"`
 }
 
 type DeveloperConfig struct {
@@ -496,6 +499,7 @@ func DefaultConfig() *Config {
 			PasswordFile:        "",
 			AllowInsecureUnlock: false,
 			UseLightweightKDF:   false,
+			DisableBorWallet:    false,
 		},
 		GRPC: &GRPCConfig{
 			Addr: ":3131",

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -615,7 +615,7 @@ func (c *Config) loadChain() error {
 	return nil
 }
 
-func (c *Config) buildEth(stack *node.Node) (*ethconfig.Config, error) {
+func (c *Config) buildEth(accountManager *accounts.Manager) (*ethconfig.Config, error) {
 	dbHandles, err := makeDatabaseHandles()
 	if err != nil {
 		return nil, err
@@ -671,7 +671,7 @@ func (c *Config) buildEth(stack *node.Node) (*ethconfig.Config, error) {
 	if c.Developer.Enabled {
 		// Get a keystore
 		var ks *keystore.KeyStore
-		if keystores := stack.AccountManager().Backends(keystore.KeyStoreType); len(keystores) > 0 {
+		if keystores := accountManager.Backends(keystore.KeyStoreType); len(keystores) > 0 {
 			ks = keystores[0].(*keystore.KeyStore)
 		}
 
@@ -696,6 +696,10 @@ func (c *Config) buildEth(stack *node.Node) (*ethconfig.Config, error) {
 			return nil, fmt.Errorf("failed to unlock developer account: %v", err)
 		}
 		log.Info("Using developer account", "address", developer.Address)
+
+		// Set the Etherbase
+		c.Sealer.Etherbase = developer.Address.Hex()
+		n.Miner.Etherbase = developer.Address
 
 		// get developer mode chain config
 		c.chain = chains.GetDeveloperChain(c.Developer.Period, developer.Address)

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -530,6 +530,11 @@ func (c *Command) Flags() *flagset.Flagset {
 		Value: &c.cliConfig.Accounts.UseLightweightKDF,
 		Group: "Account Management",
 	})
+	f.BoolFlag((&flagset.BoolFlag{
+		Name:  "disable-bor-wallet",
+		Usage: "Disable the personal wallet endpoints",
+		Value: &c.cliConfig.Accounts.DisableBorWallet,
+	}))
 
 	// grpc
 	f.StringFlag(&flagset.StringFlag{


### PR DESCRIPTION
This PR adds a new flag called disable-bor-wallet in the new-cli, which in-turn disables the rpc endpoints with personal namespace. Basically it won't allow the users to perform any wallet related operation. Incase it's a mining node, it will perform the authorisation using a dummy account manager.

Note: The endpoints will still exist and will also show up in the list of commands. It's just that the account manager has no keystore and hence those endpoints will be of no use.

The changes have been tested for developer mode as well as normal mode.
