### PR TITLE
Implement and enable 'unlock' flag

### DIFF
--- a/internal/cli/server/config_test.go
+++ b/internal/cli/server/config_test.go
@@ -153,3 +153,10 @@ func TestConfigBootnodesDefault(t *testing.T) {
 		assert.Len(t, cfg.P2P.BootstrapNodes, 1)
 	})
 }
+
+func TestMakePasswordListFromFile(t *testing.T) {
+	t.Run("ReadPasswordFile", func(t *testing.T) {
+		result, _ := MakePasswordListFromFile("./testdata/password.txt")
+		assert.Equal(t, []string{"test1", "test2"}, result)
+	})
+}

--- a/internal/cli/server/testdata/password.txt
+++ b/internal/cli/server/testdata/password.txt
@@ -1,0 +1,2 @@
+test1
+test2


### PR DESCRIPTION
Currently in v0.3.0, validator couldn't mine new blocks, because the mining account is locked even when passed to "-unlock" flag. This commit will respect the functionality of flags "-unlock", "-password", and "-allow-insecure-unlock".