### PR TITLE
Rename whitelist to requiredblocks

### DIFF
--- a/docs/cli/bootnode.md
+++ b/docs/cli/bootnode.md
@@ -14,4 +14,4 @@
 
 - ```save-key```: path to save the ecdsa private key
 
-- ```dry-run```
+- ```dry-run```: validates parameters and prints bootnode configurations, but does not start bootnode

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -18,7 +18,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```gcmode```: Blockchain garbage collection mode ("full", "archive")
 
-- ```whitelist```: Comma separated block number-to-hash mappings to enforce (<number>=<hash>)
+- ```requiredblocks```: Comma separated block number-to-hash mappings to enforce (<number>=<hash>)
 
 - ```no-snapshot```: Disables the snapshot-database mode (default = false)
 
@@ -72,7 +72,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```cache.preimages```: Enable recording the SHA3/keccak preimages of trie keys
 
-- ```txlookuplimit```: Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain)
+- ```txlookuplimit```: Number of recent blocks to maintain transactions index for (default = about 56 days, 0 = entire chain)
 
 ### JsonRPC Options
 

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -43,8 +43,8 @@ type Config struct {
 	// Name, or identity of the node
 	Name string `hcl:"name,optional"`
 
-	// Whitelist is a list of required (block number, hash) pairs to accept
-	Whitelist map[string]string `hcl:"whitelist,optional"`
+	// RequiredBlocks is a list of required (block number, hash) pairs to accept
+	RequiredBlocks map[string]string `hcl:"requiredblocks,optional"`
 
 	// LogLevel is the level of the logs to put out
 	LogLevel string `hcl:"log-level,optional"`
@@ -380,11 +380,11 @@ type DeveloperConfig struct {
 
 func DefaultConfig() *Config {
 	return &Config{
-		Chain:     "mainnet",
-		Name:      Hostname(),
-		Whitelist: map[string]string{},
-		LogLevel:  "INFO",
-		DataDir:   defaultDataDir(),
+		Chain:          "mainnet",
+		Name:           Hostname(),
+		RequiredBlocks: map[string]string{},
+		LogLevel:       "INFO",
+		DataDir:        defaultDataDir(),
 		P2P: &P2PConfig{
 			MaxPeers:     30,
 			MaxPendPeers: 50,
@@ -718,17 +718,17 @@ func (c *Config) buildEth(stack *node.Node) (*ethconfig.Config, error) {
 		n.SnapDiscoveryURLs = c.P2P.Discovery.DNS
 	}
 
-	// whitelist
+	// RequiredBlocks
 	{
 		n.PeerRequiredBlocks = map[uint64]common.Hash{}
-		for k, v := range c.Whitelist {
+		for k, v := range c.RequiredBlocks {
 			number, err := strconv.ParseUint(k, 0, 64)
 			if err != nil {
-				return nil, fmt.Errorf("invalid whitelist block number %s: %v", k, err)
+				return nil, fmt.Errorf("invalid required block number %s: %v", k, err)
 			}
 			var hash common.Hash
 			if err = hash.UnmarshalText([]byte(v)); err != nil {
-				return nil, fmt.Errorf("invalid whitelist hash %s: %v", v, err)
+				return nil, fmt.Errorf("invalid required block hash %s: %v", v, err)
 			}
 			n.PeerRequiredBlocks[number] = hash
 		}

--- a/internal/cli/server/config_test.go
+++ b/internal/cli/server/config_test.go
@@ -24,7 +24,7 @@ func TestConfigMerge(t *testing.T) {
 	c0 := &Config{
 		Chain:      "0",
 		NoSnapshot: true,
-		Whitelist: map[string]string{
+		RequiredBlocks: map[string]string{
 			"a": "b",
 		},
 		TxPool: &TxPoolConfig{
@@ -40,7 +40,7 @@ func TestConfigMerge(t *testing.T) {
 	}
 	c1 := &Config{
 		Chain: "1",
-		Whitelist: map[string]string{
+		RequiredBlocks: map[string]string{
 			"b": "c",
 		},
 		P2P: &P2PConfig{
@@ -55,7 +55,7 @@ func TestConfigMerge(t *testing.T) {
 	expected := &Config{
 		Chain:      "1",
 		NoSnapshot: true,
-		Whitelist: map[string]string{
+		RequiredBlocks: map[string]string{
 			"a": "b",
 			"b": "c",
 		},
@@ -104,7 +104,7 @@ func TestConfigLoadFile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, config, &Config{
 			DataDir: "./data",
-			Whitelist: map[string]string{
+			RequiredBlocks: map[string]string{
 				"a": "b",
 			},
 			P2P: &P2PConfig{

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -45,9 +45,9 @@ func (c *Command) Flags() *flagset.Flagset {
 		Value: &c.cliConfig.GcMode,
 	})
 	f.MapStringFlag(&flagset.MapStringFlag{
-		Name:  "whitelist",
+		Name:  "requiredblocks",
 		Usage: "Comma separated block number-to-hash mappings to enforce (<number>=<hash>)",
-		Value: &c.cliConfig.Whitelist,
+		Value: &c.cliConfig.RequiredBlocks,
 	})
 	f.BoolFlag(&flagset.BoolFlag{
 		Name:  "no-snapshot",

--- a/internal/cli/server/testdata/simple.hcl
+++ b/internal/cli/server/testdata/simple.hcl
@@ -1,6 +1,6 @@
 data-dir = "./data"
 
-whitelist = {
+requiredblocks = {
 	a = "b"
 }
 

--- a/internal/cli/server/testdata/simple.json
+++ b/internal/cli/server/testdata/simple.json
@@ -1,6 +1,6 @@
 {
     "data-dir": "./data",
-    "whitelist": {
+    "requiredblocks": {
         "a": "b"
     },
     "p2p": {


### PR DESCRIPTION
Rename legacy flag "whitelist" to new flag "requiredblocks" introduced in new geth cli.