### PR TITLE
internal/cli/server: fixes in function definition

### DIFF
--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -615,7 +615,7 @@ func (c *Config) loadChain() error {
 	return nil
 }
 
-func (c *Config) buildEth(accountManager *accounts.Manager) (*ethconfig.Config, error) {
+func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*ethconfig.Config, error) {
 	dbHandles, err := makeDatabaseHandles()
 	if err != nil {
 		return nil, err
@@ -670,15 +670,15 @@ func (c *Config) buildEth(accountManager *accounts.Manager) (*ethconfig.Config, 
 	// unlock accounts
 	if len(c.Accounts.Unlock) > 0 {
 		if !stack.Config().InsecureUnlockAllowed && stack.Config().ExtRPCEnabled() {
-			return nil, fmt.Errorf("Account unlock with HTTP access is forbidden!")
+			return nil, fmt.Errorf("account unlock with HTTP access is forbidden")
 		}
-		ks := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
+		ks := accountManager.Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
 		passwords, err := MakePasswordListFromFile(c.Accounts.PasswordFile)
 		if err != nil {
 			return nil, err
 		}
 		if len(passwords) < len(c.Accounts.Unlock) {
-			return nil, fmt.Errorf("Number of passwords provided (%v) is less than number of accounts (%v) to unlock",
+			return nil, fmt.Errorf("number of passwords provided (%v) is less than number of accounts (%v) to unlock",
 				len(passwords), len(c.Accounts.Unlock))
 		}
 		for i, account := range c.Accounts.Unlock {

--- a/internal/cli/server/config_test.go
+++ b/internal/cli/server/config_test.go
@@ -16,7 +16,7 @@ func TestConfigDefault(t *testing.T) {
 	_, err := config.buildNode()
 	assert.NoError(t, err)
 
-	_, err = config.buildEth(nil)
+	_, err = config.buildEth(nil, nil)
 	assert.NoError(t, err)
 }
 

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -95,7 +95,7 @@ func NewServer(config *Config) (*Server, error) {
 		stack.AccountManager().AddBackend(keystore.NewKeyStore(keydir, n, p))
 
 		// register the ethereum backend
-		ethCfg, err := config.buildEth(stack.AccountManager())
+		ethCfg, err := config.buildEth(stack, stack.AccountManager())
 		if err != nil {
 			return nil, err
 		}
@@ -106,7 +106,7 @@ func NewServer(config *Config) (*Server, error) {
 		srv.backend = backend
 	} else {
 		// register the ethereum backend (with temporary created account manager)
-		ethCfg, err := config.buildEth(accountManager)
+		ethCfg, err := config.buildEth(stack, accountManager)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR fixes error in the function definition of buildEth function in the new-cli server, introduced due to modifications in https://github.com/maticnetwork/bor/pull/394.  