### PR TITLE
Fix default Dockerfile for new CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN apt-get update -y && apt-get upgrade -y \
 
 WORKDIR ${BOR_DIR}
 COPY . .
-RUN make bor-all
+RUN make bor
+
+RUN cp build/bin/bor /usr/local/bin/
 
 ENV SHELL /bin/bash
 EXPOSE 8545 8546 8547 30303 30303/udp

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -548,7 +548,7 @@ func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash co
 		number, hash = number-1, header.ParentHash
 	}
 
-	log.Info("Snapshot has been found in %d headers depth.", len(headers))
+	log.Info("Snapshot has been found in", "headers depth", len(headers))
 
 	// check if snapshot is nil
 	if snap == nil {


### PR DESCRIPTION
* `make bor-all` will stop working in v0.3.0, changing the target to `bor` instead.
* Also fix a minor bug in logger.