### PR TITLE
Create MVHashMap and use it in StateDB

### DIFF
--- a/core/blockstm/executor.go
+++ b/core/blockstm/executor.go
@@ -1,0 +1,241 @@
+package blockstm
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type ExecResult struct {
+	err      error
+	ver      Version
+	txIn     TxnInput
+	txOut    TxnOutput
+	txAllOut TxnOutput
+}
+
+type ExecTask interface {
+	Execute(mvh *MVHashMap, incarnation int) error
+	MVReadList() []ReadDescriptor
+	MVWriteList() []WriteDescriptor
+	MVFullWriteList() []WriteDescriptor
+}
+
+type ExecVersionView struct {
+	ver Version
+	et  ExecTask
+	mvh *MVHashMap
+}
+
+func (ev *ExecVersionView) Execute() (er ExecResult) {
+	er.ver = ev.ver
+	if er.err = ev.et.Execute(ev.mvh, ev.ver.Incarnation); er.err != nil {
+		log.Debug("blockstm executed task failed", "Tx index", ev.ver.TxnIndex, "incarnation", ev.ver.Incarnation, "err", er.err)
+		return
+	}
+
+	er.txIn = ev.et.MVReadList()
+	er.txOut = ev.et.MVWriteList()
+	er.txAllOut = ev.et.MVFullWriteList()
+	log.Debug("blockstm executed task", "Tx index", ev.ver.TxnIndex, "incarnation", ev.ver.Incarnation, "err", er.err)
+
+	return
+}
+
+var ErrExecAbort = fmt.Errorf("execution aborted with dependency")
+
+const numGoProcs = 4
+
+// nolint: gocognit
+func ExecuteParallel(tasks []ExecTask) (lastTxIO *TxnInputOutput, err error) {
+	if len(tasks) == 0 {
+		return MakeTxnInputOutput(len(tasks)), nil
+	}
+
+	chTasks := make(chan ExecVersionView, len(tasks))
+	chResults := make(chan ExecResult, len(tasks))
+	chDone := make(chan bool)
+
+	var cntExec, cntSuccess, cntAbort, cntTotalValidations, cntValidationFail int
+
+	for i := 0; i < numGoProcs; i++ {
+		go func(procNum int, t chan ExecVersionView) {
+		Loop:
+			for {
+				select {
+				case task := <-t:
+					{
+						res := task.Execute()
+						chResults <- res
+					}
+				case <-chDone:
+					break Loop
+				}
+			}
+			log.Debug("blockstm", "proc done", procNum) // TODO: logging ...
+		}(i, chTasks)
+	}
+
+	mvh := MakeMVHashMap()
+
+	execTasks := makeStatusManager(len(tasks))
+	validateTasks := makeStatusManager(0)
+
+	// bootstrap execution
+	for x := 0; x < numGoProcs; x++ {
+		tx := execTasks.takeNextPending()
+		if tx != -1 {
+			cntExec++
+
+			log.Debug("blockstm", "bootstrap: proc", x, "executing task", tx)
+			chTasks <- ExecVersionView{ver: Version{tx, 0}, et: tasks[tx], mvh: mvh}
+		}
+	}
+
+	lastTxIO = MakeTxnInputOutput(len(tasks))
+	txIncarnations := make([]int, len(tasks))
+
+	diagExecSuccess := make([]int, len(tasks))
+	diagExecAbort := make([]int, len(tasks))
+
+	for {
+		res := <-chResults
+		switch res.err {
+		case nil:
+			{
+				mvh.FlushMVWriteSet(res.txAllOut)
+				lastTxIO.recordRead(res.ver.TxnIndex, res.txIn)
+				if res.ver.Incarnation == 0 {
+					lastTxIO.recordWrite(res.ver.TxnIndex, res.txOut)
+					lastTxIO.recordAllWrite(res.ver.TxnIndex, res.txAllOut)
+				} else {
+					if res.txAllOut.hasNewWrite(lastTxIO.AllWriteSet(res.ver.TxnIndex)) {
+						log.Debug("blockstm", "Revalidate completed txs greater than current tx: ", res.ver.TxnIndex)
+						validateTasks.pushPendingSet(execTasks.getRevalidationRange(res.ver.TxnIndex))
+					}
+
+					prevWrite := lastTxIO.AllWriteSet(res.ver.TxnIndex)
+
+					// Remove entries that were previously written but are no longer written
+
+					cmpMap := make(map[string]bool)
+
+					for _, w := range res.txAllOut {
+						cmpMap[string(w.Path)] = true
+					}
+
+					for _, v := range prevWrite {
+						if _, ok := cmpMap[string(v.Path)]; !ok {
+							mvh.Delete(v.Path, res.ver.TxnIndex)
+						}
+					}
+
+					lastTxIO.recordWrite(res.ver.TxnIndex, res.txOut)
+					lastTxIO.recordAllWrite(res.ver.TxnIndex, res.txAllOut)
+				}
+				validateTasks.pushPending(res.ver.TxnIndex)
+				execTasks.markComplete(res.ver.TxnIndex)
+				if diagExecSuccess[res.ver.TxnIndex] > 0 && diagExecAbort[res.ver.TxnIndex] == 0 {
+					log.Debug("blockstm", "got multiple successful execution w/o abort?", "Tx", res.ver.TxnIndex, "incarnation", res.ver.Incarnation)
+				}
+				diagExecSuccess[res.ver.TxnIndex]++
+				cntSuccess++
+			}
+		case ErrExecAbort:
+			{
+				// bit of a subtle / tricky bug here. this adds the tx back to pending ...
+				execTasks.revertInProgress(res.ver.TxnIndex)
+				// ... but the incarnation needs to be bumped
+				txIncarnations[res.ver.TxnIndex]++
+				diagExecAbort[res.ver.TxnIndex]++
+				cntAbort++
+			}
+		default:
+			{
+				err = res.err
+				break
+			}
+		}
+
+		// if we got more work, queue one up...
+		nextTx := execTasks.takeNextPending()
+		if nextTx != -1 {
+			cntExec++
+			chTasks <- ExecVersionView{ver: Version{nextTx, txIncarnations[nextTx]}, et: tasks[nextTx], mvh: mvh}
+		}
+
+		// do validations ...
+		maxComplete := execTasks.maxAllComplete()
+
+		const validationIncrement = 2
+
+		cntValidate := validateTasks.countPending()
+		// if we're currently done with all execution tasks then let's validate everything; otherwise do one increment ...
+		if execTasks.countComplete() != len(tasks) && cntValidate > validationIncrement {
+			cntValidate = validationIncrement
+		}
+
+		var toValidate []int
+
+		for i := 0; i < cntValidate; i++ {
+			if validateTasks.minPending() <= maxComplete {
+				toValidate = append(toValidate, validateTasks.takeNextPending())
+			} else {
+				break
+			}
+		}
+
+		for i := 0; i < len(toValidate); i++ {
+			cntTotalValidations++
+
+			tx := toValidate[i]
+			log.Debug("blockstm", "validating task", tx)
+
+			if ValidateVersion(tx, lastTxIO, mvh) {
+				log.Debug("blockstm", "* completed validation task", tx)
+				validateTasks.markComplete(tx)
+			} else {
+				log.Debug("blockstm", "* validation task FAILED", tx)
+				cntValidationFail++
+				diagExecAbort[tx]++
+				for _, v := range lastTxIO.AllWriteSet(tx) {
+					mvh.MarkEstimate(v.Path, tx)
+				}
+				// 'create validation tasks for all transactions > tx ...'
+				validateTasks.pushPendingSet(execTasks.getRevalidationRange(tx + 1))
+				validateTasks.clearInProgress(tx) // clear in progress - pending will be added again once new incarnation executes
+				if execTasks.checkPending(tx) {
+					// println() // have to think about this ...
+				} else {
+					execTasks.pushPending(tx)
+					execTasks.clearComplete(tx)
+					txIncarnations[tx]++
+				}
+			}
+		}
+
+		// if we didn't queue work previously, do check again so we keep making progress ...
+		if nextTx == -1 {
+			nextTx = execTasks.takeNextPending()
+			if nextTx != -1 {
+				cntExec++
+
+				log.Debug("blockstm", "# tx queued up", nextTx)
+				chTasks <- ExecVersionView{ver: Version{nextTx, txIncarnations[nextTx]}, et: tasks[nextTx], mvh: mvh}
+			}
+		}
+
+		if validateTasks.countComplete() == len(tasks) && execTasks.countComplete() == len(tasks) {
+			log.Debug("blockstm exec summary", "execs", cntExec, "success", cntSuccess, "aborts", cntAbort, "validations", cntTotalValidations, "failures", cntValidationFail)
+			break
+		}
+	}
+
+	for i := 0; i < numGoProcs; i++ {
+		chDone <- true
+	}
+	close(chTasks)
+	close(chResults)
+
+	return
+}

--- a/core/blockstm/mvhashmap.go
+++ b/core/blockstm/mvhashmap.go
@@ -1,0 +1,218 @@
+package blockstm
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/emirpasic/gods/maps/treemap"
+)
+
+const FlagDone = 0
+const FlagEstimate = 1
+
+type MVHashMap struct {
+	rw sync.RWMutex
+	m  map[string]*TxnIndexCells // TODO: might want a more efficient key representation
+}
+
+func MakeMVHashMap() *MVHashMap {
+	return &MVHashMap{
+		rw: sync.RWMutex{},
+		m:  make(map[string]*TxnIndexCells),
+	}
+}
+
+type WriteCell struct {
+	flag        uint
+	incarnation int
+	data        interface{}
+}
+
+type TxnIndexCells struct {
+	rw sync.RWMutex
+	tm *treemap.Map
+}
+
+type Version struct {
+	TxnIndex    int
+	Incarnation int
+}
+
+func (mv *MVHashMap) getKeyCells(k []byte, fNoKey func(kenc string) *TxnIndexCells) (cells *TxnIndexCells) {
+	kenc := string(k)
+
+	var ok bool
+
+	mv.rw.RLock()
+	cells, ok = mv.m[kenc]
+	mv.rw.RUnlock()
+
+	if !ok {
+		cells = fNoKey(kenc)
+	}
+
+	return
+}
+
+func (mv *MVHashMap) Write(k []byte, v Version, data interface{}) {
+	cells := mv.getKeyCells(k, func(kenc string) (cells *TxnIndexCells) {
+		n := &TxnIndexCells{
+			rw: sync.RWMutex{},
+			tm: treemap.NewWithIntComparator(),
+		}
+		var ok bool
+		mv.rw.Lock()
+		if cells, ok = mv.m[kenc]; !ok {
+			mv.m[kenc] = n
+			cells = n
+		}
+		mv.rw.Unlock()
+		return
+	})
+
+	// TODO: could probably have a scheme where this only generally requires a read lock since any given transaction transaction
+	//  should only have one incarnation executing at a time...
+	cells.rw.Lock()
+	defer cells.rw.Unlock()
+	ci, ok := cells.tm.Get(v.TxnIndex)
+
+	if ok {
+		if ci.(*WriteCell).incarnation > v.Incarnation {
+			panic(fmt.Errorf("existing transaction value does not have lower incarnation: %v, %v",
+				string(k), v.TxnIndex))
+		} else if ci.(*WriteCell).flag == FlagEstimate {
+			println("marking previous estimate as done tx", v.TxnIndex, v.Incarnation)
+		}
+
+		ci.(*WriteCell).flag = FlagDone
+		ci.(*WriteCell).incarnation = v.Incarnation
+		ci.(*WriteCell).data = data
+	} else {
+		cells.tm.Put(v.TxnIndex, &WriteCell{
+			flag:        FlagDone,
+			incarnation: v.Incarnation,
+			data:        data,
+		})
+	}
+}
+
+func (mv *MVHashMap) MarkEstimate(k []byte, txIdx int) {
+	cells := mv.getKeyCells(k, func(_ string) *TxnIndexCells {
+		panic(fmt.Errorf("path must already exist"))
+	})
+
+	cells.rw.RLock()
+	if ci, ok := cells.tm.Get(txIdx); !ok {
+		panic("should not happen - cell should be present for path")
+	} else {
+		ci.(*WriteCell).flag = FlagEstimate
+	}
+	cells.rw.RUnlock()
+}
+
+func (mv *MVHashMap) Delete(k []byte, txIdx int) {
+	cells := mv.getKeyCells(k, func(_ string) *TxnIndexCells {
+		panic(fmt.Errorf("path must already exist"))
+	})
+
+	cells.rw.Lock()
+	defer cells.rw.Unlock()
+	cells.tm.Remove(txIdx)
+}
+
+const (
+	MVReadResultDone       = 0
+	MVReadResultDependency = 1
+	MVReadResultNone       = 2
+)
+
+type MVReadResult struct {
+	depIdx      int
+	incarnation int
+	value       interface{}
+}
+
+func (res *MVReadResult) DepIdx() int {
+	return res.depIdx
+}
+
+func (res *MVReadResult) Incarnation() int {
+	return res.incarnation
+}
+
+func (res *MVReadResult) Value() interface{} {
+	return res.value
+}
+
+func (mvr MVReadResult) Status() int {
+	if mvr.depIdx != -1 {
+		if mvr.incarnation == -1 {
+			return MVReadResultDependency
+		} else {
+			return MVReadResultDone
+		}
+	}
+
+	return MVReadResultNone
+}
+
+func (mv *MVHashMap) Read(k []byte, txIdx int) (res MVReadResult) {
+	res.depIdx = -1
+	res.incarnation = -1
+
+	cells := mv.getKeyCells(k, func(_ string) *TxnIndexCells {
+		return nil
+	})
+	if cells == nil {
+		return
+	}
+
+	cells.rw.RLock()
+	defer cells.rw.RUnlock()
+
+	if fk, fv := cells.tm.Floor(txIdx - 1); fk != nil && fv != nil {
+		c := fv.(*WriteCell)
+		switch c.flag {
+		case FlagEstimate:
+			res.depIdx = fk.(int)
+			res.value = c.data
+		case FlagDone:
+			{
+				res.depIdx = fk.(int)
+				res.incarnation = c.incarnation
+				res.value = c.data
+			}
+		default:
+			panic(fmt.Errorf("should not happen - unknown flag value"))
+		}
+	}
+
+	return
+}
+
+func ValidateVersion(txIdx int, lastInputOutput *TxnInputOutput, versionedData *MVHashMap) (valid bool) {
+	valid = true
+
+	for _, rd := range lastInputOutput.readSet(txIdx) {
+		mvResult := versionedData.Read(rd.Path, txIdx)
+		switch mvResult.Status() {
+		case MVReadResultDone:
+			valid = rd.Kind == ReadKindMap && rd.V == Version{
+				TxnIndex:    mvResult.depIdx,
+				Incarnation: mvResult.incarnation,
+			}
+		case MVReadResultDependency:
+			valid = false
+		case MVReadResultNone:
+			valid = rd.Kind == ReadKindStorage // feels like an assertion?
+		default:
+			panic(fmt.Errorf("should not happen - undefined mv read status: %ver", mvResult.Status()))
+		}
+
+		if !valid {
+			break
+		}
+	}
+
+	return
+}

--- a/core/blockstm/status.go
+++ b/core/blockstm/status.go
@@ -1,0 +1,163 @@
+package blockstm
+
+import (
+	"fmt"
+	"sort"
+)
+
+func makeStatusManager(numTasks int) (t taskStatusManager) {
+	t.pending = make([]int, numTasks)
+	for i := 0; i < numTasks; i++ {
+		t.pending[i] = i
+	}
+
+	return
+}
+
+type taskStatusManager struct {
+	pending    []int
+	inProgress []int
+	complete   []int
+}
+
+func insertInList(l []int, v int) []int {
+	if len(l) == 0 || v > l[len(l)-1] {
+		return append(l, v)
+	} else {
+		x := sort.SearchInts(l, v)
+		if x < len(l) && l[x] == v {
+			// already in list
+			return l
+		}
+		a := append(l[:x+1], l[x:]...)
+		a[x] = v
+		return a
+	}
+}
+
+func (m *taskStatusManager) takeNextPending() int {
+	if len(m.pending) == 0 {
+		return -1
+	}
+
+	x := m.pending[0]
+	m.pending = m.pending[1:]
+	m.inProgress = insertInList(m.inProgress, x)
+
+	return x
+}
+
+func hasNoGap(l []int) bool {
+	return l[0]+len(l) == l[len(l)-1]+1
+}
+
+func (m taskStatusManager) maxAllComplete() int {
+	if len(m.complete) == 0 || m.complete[0] != 0 {
+		return -1
+	} else if m.complete[len(m.complete)-1] == len(m.complete)-1 {
+		return m.complete[len(m.complete)-1]
+	} else {
+		for i := len(m.complete) - 2; i >= 0; i-- {
+			if hasNoGap(m.complete[:i+1]) {
+				return m.complete[i]
+			}
+		}
+	}
+
+	return -1
+}
+
+func (m *taskStatusManager) pushPending(tx int) {
+	m.pending = insertInList(m.pending, tx)
+}
+
+func removeFromList(l []int, v int, expect bool) []int {
+	x := sort.SearchInts(l, v)
+	if x == -1 || l[x] != v {
+		if expect {
+			panic(fmt.Errorf("should not happen - element expected in list"))
+		}
+
+		return l
+	}
+
+	switch x {
+	case 0:
+		return l[1:]
+	case len(l) - 1:
+		return l[:len(l)-1]
+	default:
+		return append(l[:x], l[x+1:]...)
+	}
+}
+
+func (m *taskStatusManager) markComplete(tx int) {
+	m.inProgress = removeFromList(m.inProgress, tx, true)
+	m.complete = insertInList(m.complete, tx)
+}
+
+func (m *taskStatusManager) minPending() int {
+	if len(m.pending) == 0 {
+		return -1
+	} else {
+		return m.pending[0]
+	}
+}
+
+func (m *taskStatusManager) countComplete() int {
+	return len(m.complete)
+}
+
+func (m *taskStatusManager) revertInProgress(tx int) {
+	m.inProgress = removeFromList(m.inProgress, tx, true)
+	m.pending = insertInList(m.pending, tx)
+}
+
+func (m *taskStatusManager) clearInProgress(tx int) {
+	m.inProgress = removeFromList(m.inProgress, tx, true)
+}
+
+func (m *taskStatusManager) countPending() int {
+	return len(m.pending)
+}
+
+func (m *taskStatusManager) checkInProgress(tx int) bool {
+	x := sort.SearchInts(m.inProgress, tx)
+	if x < len(m.inProgress) && m.inProgress[x] == tx {
+		return true
+	}
+
+	return false
+}
+
+func (m *taskStatusManager) checkPending(tx int) bool {
+	x := sort.SearchInts(m.pending, tx)
+	if x < len(m.pending) && m.pending[x] == tx {
+		return true
+	}
+
+	return false
+}
+
+// getRevalidationRange: this range will be all tasks from tx (inclusive) that are not currently in progress up to the
+//  'all complete' limit
+func (m *taskStatusManager) getRevalidationRange(txFrom int) (ret []int) {
+	max := m.maxAllComplete() // haven't learned to trust compilers :)
+	for x := txFrom; x <= max; x++ {
+		if !m.checkInProgress(x) {
+			ret = append(ret, x)
+		}
+	}
+
+	return
+}
+
+func (m *taskStatusManager) pushPendingSet(set []int) {
+	for _, v := range set {
+		m.pushPending(v)
+	}
+}
+
+func (m *taskStatusManager) clearComplete(tx int) {
+	m.complete = removeFromList(m.complete, tx, false)
+}

--- a/core/blockstm/txio.go
+++ b/core/blockstm/txio.go
@@ -1,0 +1,75 @@
+//nolint: unused
+package blockstm
+
+import "encoding/base64"
+
+const (
+	ReadKindMap     = 0
+	ReadKindStorage = 1
+)
+
+type ReadDescriptor struct {
+	Path []byte
+	Kind int
+	V    Version
+}
+
+type WriteDescriptor struct {
+	Path []byte
+	V    Version
+	Val  interface{}
+}
+
+type TxnInput []ReadDescriptor
+type TxnOutput []WriteDescriptor
+
+// hasNewWrite: returns true if the current set has a new write compared to the input
+func (txo TxnOutput) hasNewWrite(cmpSet []WriteDescriptor) bool {
+	if len(txo) == 0 {
+		return false
+	} else if len(cmpSet) == 0 || len(txo) > len(cmpSet) {
+		return true
+	}
+
+	cmpMap := map[string]bool{base64.StdEncoding.EncodeToString(cmpSet[0].Path): true}
+
+	for i := 1; i < len(cmpSet); i++ {
+		cmpMap[base64.StdEncoding.EncodeToString(cmpSet[i].Path)] = true
+	}
+
+	for _, v := range txo {
+		if !cmpMap[base64.StdEncoding.EncodeToString(v.Path)] {
+			return true
+		}
+	}
+
+	return false
+}
+
+type TxnInputOutput struct {
+	inputs  []TxnInput
+	outputs []TxnOutput
+}
+
+func (io *TxnInputOutput) readSet(txnIdx int) []ReadDescriptor {
+	return io.inputs[txnIdx]
+}
+
+func (io *TxnInputOutput) writeSet(txnIdx int) []WriteDescriptor {
+	return io.outputs[txnIdx]
+}
+
+func MakeTxnInputOutput(numTx int) *TxnInputOutput {
+	return &TxnInputOutput{
+		inputs:  make([]TxnInput, numTx),
+		outputs: make([]TxnOutput, numTx),
+	}
+}
+
+func (io *TxnInputOutput) recordRead(txId int, input []ReadDescriptor) {
+	io.inputs[txId] = input
+}
+
+func (io *TxnInputOutput) recordWrite(txId int, output []WriteDescriptor) {
+	io.outputs[txId] = output
+}

--- a/core/blockstm/txio.go
+++ b/core/blockstm/txio.go
@@ -47,22 +47,28 @@ func (txo TxnOutput) hasNewWrite(cmpSet []WriteDescriptor) bool {
 }
 
 type TxnInputOutput struct {
-	inputs  []TxnInput
-	outputs []TxnOutput
+	inputs     []TxnInput
+	outputs    []TxnOutput // write sets that should be checked during validation
+	allOutputs []TxnOutput // entire write sets in MVHashMap. allOutputs should always be a parent set of outputs
 }
 
-func (io *TxnInputOutput) readSet(txnIdx int) []ReadDescriptor {
+func (io *TxnInputOutput) ReadSet(txnIdx int) []ReadDescriptor {
 	return io.inputs[txnIdx]
 }
 
-func (io *TxnInputOutput) writeSet(txnIdx int) []WriteDescriptor {
+func (io *TxnInputOutput) WriteSet(txnIdx int) []WriteDescriptor {
 	return io.outputs[txnIdx]
+}
+
+func (io *TxnInputOutput) AllWriteSet(txnIdx int) []WriteDescriptor {
+	return io.allOutputs[txnIdx]
 }
 
 func MakeTxnInputOutput(numTx int) *TxnInputOutput {
 	return &TxnInputOutput{
-		inputs:  make([]TxnInput, numTx),
-		outputs: make([]TxnOutput, numTx),
+		inputs:     make([]TxnInput, numTx),
+		outputs:    make([]TxnOutput, numTx),
+		allOutputs: make([]TxnOutput, numTx),
 	}
 }
 
@@ -72,4 +78,8 @@ func (io *TxnInputOutput) recordRead(txId int, input []ReadDescriptor) {
 
 func (io *TxnInputOutput) recordWrite(txId int, output []WriteDescriptor) {
 	io.outputs[txId] = output
+}
+
+func (io *TxnInputOutput) recordAllWrite(txId int, output []WriteDescriptor) {
+	io.allOutputs[txId] = output
 }

--- a/core/parallel_state_processor.go
+++ b/core/parallel_state_processor.go
@@ -1,0 +1,231 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/misc"
+	"github.com/ethereum/go-ethereum/core/blockstm"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// StateProcessor is a basic Processor, which takes care of transitioning
+// state from one point to another.
+//
+// StateProcessor implements Processor.
+type ParallelStateProcessor struct {
+	config *params.ChainConfig // Chain configuration options
+	bc     *BlockChain         // Canonical block chain
+	engine consensus.Engine    // Consensus engine used for block rewards
+}
+
+// NewStateProcessor initialises a new StateProcessor.
+func NewParallelStateProcessor(config *params.ChainConfig, bc *BlockChain, engine consensus.Engine) *ParallelStateProcessor {
+	return &ParallelStateProcessor{
+		config: config,
+		bc:     bc,
+		engine: engine,
+	}
+}
+
+type ExecutionTask struct {
+	msg    types.Message
+	config *params.ChainConfig
+
+	gasLimit     uint64
+	blockNumber  *big.Int
+	blockHash    common.Hash
+	blockContext vm.BlockContext
+	tx           *types.Transaction
+	index        int
+	statedb      *state.StateDB // State database that stores the modified values after tx execution.
+	cleanStateDB *state.StateDB // A clean copy of the initial statedb. It should not be modified.
+	evmConfig    vm.Config
+	result       *ExecutionResult
+}
+
+func (task *ExecutionTask) Execute(mvh *blockstm.MVHashMap, incarnation int) (err error) {
+	task.statedb = task.cleanStateDB.Copy()
+	task.statedb.Prepare(task.tx.Hash(), task.index)
+	task.statedb.SetMVHashmap(mvh)
+	task.statedb.SetIncarnation(incarnation)
+
+	evm := vm.NewEVM(task.blockContext, vm.TxContext{}, task.statedb, task.config, task.evmConfig)
+
+	// Create a new context to be used in the EVM environment.
+	txContext := NewEVMTxContext(task.msg)
+	evm.Reset(txContext, task.statedb)
+
+	defer func() {
+		if r := recover(); r != nil {
+			// In some pre-matured executions, EVM will panic. Recover from panic and retry the execution.
+			log.Debug("Recovered from EVM failure. Error:\n", r)
+
+			err = blockstm.ErrExecAbort
+
+			return
+		}
+	}()
+
+	// Apply the transaction to the current state (included in the env).
+	result, err := ApplyMessage(evm, task.msg, new(GasPool).AddGas(task.gasLimit))
+
+	if task.statedb.HadInvalidRead() || err != nil {
+		err = blockstm.ErrExecAbort
+		return
+	}
+
+	task.statedb.Finalise(false)
+
+	task.result = result
+
+	return
+}
+
+func (task *ExecutionTask) MVReadList() []blockstm.ReadDescriptor {
+	return task.statedb.MVReadList()
+}
+
+func (task *ExecutionTask) MVWriteList() []blockstm.WriteDescriptor {
+	return task.statedb.MVWriteList()
+}
+
+func (task *ExecutionTask) MVFullWriteList() []blockstm.WriteDescriptor {
+	return task.statedb.MVFullWriteList()
+}
+
+// Process processes the state changes according to the Ethereum rules by running
+// the transaction messages using the statedb and applying any rewards to both
+// the processor (coinbase) and any included uncles.
+//
+// Process returns the receipts and logs accumulated during the process and
+// returns the amount of gas that was used in the process. If any of the
+// transactions failed to execute due to insufficient gas it will return an error.
+func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error) {
+	var (
+		receipts    types.Receipts
+		header      = block.Header()
+		blockHash   = block.Hash()
+		blockNumber = block.Number()
+		allLogs     []*types.Log
+		usedGas     = new(uint64)
+	)
+	// Mutate the block and state according to any hard-fork specs
+	if p.config.DAOForkSupport && p.config.DAOForkBlock != nil && p.config.DAOForkBlock.Cmp(block.Number()) == 0 {
+		misc.ApplyDAOHardFork(statedb)
+	}
+
+	tasks := make([]blockstm.ExecTask, 0, len(block.Transactions()))
+
+	// Iterate over and process the individual transactions
+	for i, tx := range block.Transactions() {
+		msg, err := tx.AsMessage(types.MakeSigner(p.config, header.Number), header.BaseFee)
+		if err != nil {
+			log.Error("error creating message", "err", err)
+			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
+		}
+
+		cleansdb := statedb.Copy()
+
+		task := &ExecutionTask{
+			msg:          msg,
+			config:       p.config,
+			gasLimit:     block.GasLimit(),
+			blockNumber:  blockNumber,
+			blockHash:    blockHash,
+			tx:           tx,
+			index:        i,
+			cleanStateDB: cleansdb,
+			blockContext: NewEVMBlockContext(header, p.bc, nil),
+		}
+
+		tasks = append(tasks, task)
+	}
+
+	_, err := blockstm.ExecuteParallel(tasks)
+
+	if err != nil {
+		log.Error("blockstm error executing block", "err", err)
+		return nil, nil, 0, err
+	}
+
+	for _, task := range tasks {
+		task := task.(*ExecutionTask)
+		statedb.Prepare(task.tx.Hash(), task.index)
+		statedb.ApplyMVWriteSet(task.MVWriteList())
+
+		for _, l := range task.statedb.GetLogs(task.tx.Hash(), blockHash) {
+			statedb.AddLog(l)
+		}
+
+		for k, v := range task.statedb.Preimages() {
+			statedb.AddPreimage(k, v)
+		}
+
+		// Update the state with pending changes.
+		var root []byte
+
+		if p.config.IsByzantium(blockNumber) {
+			statedb.Finalise(true)
+		} else {
+			root = statedb.IntermediateRoot(p.config.IsEIP158(blockNumber)).Bytes()
+		}
+
+		*usedGas += task.result.UsedGas
+
+		// Create a new receipt for the transaction, storing the intermediate root and gas used
+		// by the tx.
+		receipt := &types.Receipt{Type: task.tx.Type(), PostState: root, CumulativeGasUsed: *usedGas}
+		if task.result.Failed() {
+			receipt.Status = types.ReceiptStatusFailed
+		} else {
+			receipt.Status = types.ReceiptStatusSuccessful
+		}
+
+		receipt.TxHash = task.tx.Hash()
+		receipt.GasUsed = task.result.UsedGas
+
+		// If the transaction created a contract, store the creation address in the receipt.
+		if task.msg.To() == nil {
+			receipt.ContractAddress = crypto.CreateAddress(task.msg.From(), task.tx.Nonce())
+		}
+
+		// Set the receipt logs and create the bloom filter.
+		receipt.Logs = statedb.GetLogs(task.tx.Hash(), blockHash)
+		receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+		receipt.BlockHash = blockHash
+		receipt.BlockNumber = blockNumber
+		receipt.TransactionIndex = uint(statedb.TxIndex())
+
+		receipts = append(receipts, receipt)
+		allLogs = append(allLogs, receipt.Logs...)
+	}
+
+	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
+	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles())
+
+	return receipts, allLogs, *usedGas, nil
+}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/blockstm"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -78,6 +79,12 @@ type StateDB struct {
 	stateObjects        map[common.Address]*stateObject
 	stateObjectsPending map[common.Address]struct{} // State objects finalized but not yet written to the trie
 	stateObjectsDirty   map[common.Address]struct{} // State objects modified in the current execution
+
+	// Block-stm related fields
+	mvHashmap   *blockstm.MVHashMap
+	incarnation int
+	readMap     map[string]blockstm.ReadDescriptor
+	writeMap    map[string]blockstm.WriteDescriptor
 
 	// DB error.
 	// State objects are used by the consensus core and VM which are
@@ -152,6 +159,159 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		}
 	}
 	return sdb, nil
+}
+
+func NewWithMVHashmap(root common.Hash, db Database, snaps *snapshot.Tree, mvhm *blockstm.MVHashMap) (*StateDB, error) {
+	if sdb, err := New(root, db, snaps); err != nil {
+		return nil, err
+	} else {
+		sdb.mvHashmap = mvhm
+		return sdb, nil
+	}
+}
+
+func (sdb *StateDB) SetMVHashmap(mvhm *blockstm.MVHashMap) {
+	sdb.mvHashmap = mvhm
+}
+
+func (s *StateDB) MVWriteList() []blockstm.WriteDescriptor {
+	writes := make([]blockstm.WriteDescriptor, 0, len(s.writeMap))
+
+	for _, v := range s.writeMap {
+		writes = append(writes, v)
+	}
+
+	return writes
+}
+
+func (s *StateDB) MVReadList() []blockstm.ReadDescriptor {
+	reads := make([]blockstm.ReadDescriptor, 0, len(s.readMap))
+
+	for _, v := range s.readMap {
+		reads = append(reads, v)
+	}
+
+	return reads
+}
+
+func (s *StateDB) ensureReadMap() {
+	if s.readMap == nil {
+		s.readMap = make(map[string]blockstm.ReadDescriptor)
+	}
+}
+
+func (s *StateDB) ensureWriteMap() {
+	if s.writeMap == nil {
+		s.writeMap = make(map[string]blockstm.WriteDescriptor)
+	}
+}
+
+func MVRead[T any](s *StateDB, k []byte, defaultV T, readStorage func(s *StateDB) T) (v T) {
+	if s.mvHashmap == nil {
+		return readStorage(s)
+	}
+
+	s.ensureReadMap()
+
+	if s.writeMap != nil {
+		if _, ok := s.writeMap[string(k)]; ok {
+			return readStorage(s)
+		}
+	}
+
+	res := s.mvHashmap.Read(k, s.txIndex)
+
+	var rd blockstm.ReadDescriptor
+
+	rd.V = blockstm.Version{
+		TxnIndex:    res.DepIdx(),
+		Incarnation: res.Incarnation(),
+	}
+
+	rd.Path = k
+
+	switch res.Status() {
+	case blockstm.MVReadResultDone:
+		{
+			v = readStorage(res.Value().(*StateDB))
+			rd.Kind = blockstm.ReadKindMap
+		}
+	case blockstm.MVReadResultDependency:
+		{
+			return defaultV
+		}
+	case blockstm.MVReadResultNone:
+		{
+			v = readStorage(s)
+			rd.Kind = blockstm.ReadKindStorage
+		}
+	default:
+		return defaultV
+	}
+
+	mk := string(k)
+	// TODO: I assume we don't want to overwrite an existing read because this could - for example - change a storage
+	//  read to map if the same value is read multiple times.
+	if _, ok := s.readMap[mk]; !ok {
+		s.readMap[mk] = rd
+	}
+
+	return
+}
+
+func MVWrite(s *StateDB, k []byte) {
+	if s.mvHashmap != nil {
+		s.ensureWriteMap()
+		s.mvHashmap.Write(k, s.Version(), s)
+		s.writeMap[string(k)] = blockstm.WriteDescriptor{
+			Path: k,
+			V:    s.Version(),
+			Val:  s,
+		}
+	}
+}
+
+func MVWritten(s *StateDB, k []byte) bool {
+	if s.mvHashmap == nil || s.writeMap == nil {
+		return false
+	}
+
+	_, ok := s.writeMap[string(k)]
+
+	return ok
+}
+
+func (sw *StateDB) ApplyMVWriteSet(writes []blockstm.WriteDescriptor) {
+	for i := range writes {
+		path := writes[i].Path
+		sr := writes[i].Val.(*StateDB)
+
+		keyLength := len(path)
+
+		if keyLength == common.AddressLength {
+			sw.GetOrNewStateObject(common.BytesToAddress(path))
+		} else if keyLength == (common.AddressLength + common.HashLength) {
+			addr := common.BytesToAddress(path[:common.AddressLength])
+			subPath := common.BytesToHash(path[common.AddressLength:])
+			sw.SetState(addr, subPath, sr.GetState(addr, subPath))
+		} else {
+			addr := common.BytesToAddress(path[:common.AddressLength])
+			switch path[keyLength-1] {
+			case balancePath:
+				sw.SetBalance(addr, sr.GetBalance(addr))
+			case noncePath:
+				sw.SetNonce(addr, sr.GetNonce(addr))
+			case codePath:
+				sw.SetCode(addr, sr.GetCode(addr))
+			case suicidePath:
+				if suicided := sr.HasSuicided(addr); suicided {
+					sw.Suicide(addr)
+				}
+			default:
+				panic(fmt.Errorf("unknown key type: %d", path[keyLength-1]))
+			}
+		}
+	}
 }
 
 // StartPrefetcher initializes a new trie prefetcher to pull in nodes from the
@@ -257,22 +417,48 @@ func (s *StateDB) Empty(addr common.Address) bool {
 	return so == nil || so.empty()
 }
 
+// Create a unique path for special fields (e.g. balance, code) in a state object.
+func subPath(prefix []byte, s uint8) []byte {
+	path := append(prefix, common.Hash{}.Bytes()...) // append a full empty hash to avoid collision with storage state
+	path = append(path, s)                           // append the special field identifier
+
+	return path
+}
+
+const balancePath = 1
+const noncePath = 2
+const codePath = 3
+const suicidePath = 4
+
 // GetBalance retrieves the balance from the given address or 0 if object not found
 func (s *StateDB) GetBalance(addr common.Address) *big.Int {
-	stateObject := s.getStateObject(addr)
-	if stateObject != nil {
-		return stateObject.Balance()
+	if s.getStateObject(addr) == nil {
+		return common.Big0
 	}
-	return common.Big0
+
+	return MVRead(s, subPath(addr.Bytes(), balancePath), common.Big0, func(s *StateDB) *big.Int {
+		stateObject := s.getStateObject(addr)
+		if stateObject != nil {
+			return stateObject.Balance()
+		}
+
+		return common.Big0
+	})
 }
 
 func (s *StateDB) GetNonce(addr common.Address) uint64 {
-	stateObject := s.getStateObject(addr)
-	if stateObject != nil {
-		return stateObject.Nonce()
+	if s.getStateObject(addr) == nil {
+		return 0
 	}
 
-	return 0
+	return MVRead(s, subPath(addr.Bytes(), noncePath), 0, func(s *StateDB) uint64 {
+		stateObject := s.getStateObject(addr)
+		if stateObject != nil {
+			return stateObject.Nonce()
+		}
+
+		return 0
+	})
 }
 
 // TxIndex returns the current transaction index set by Prepare.
@@ -280,37 +466,68 @@ func (s *StateDB) TxIndex() int {
 	return s.txIndex
 }
 
-func (s *StateDB) GetCode(addr common.Address) []byte {
-	stateObject := s.getStateObject(addr)
-	if stateObject != nil {
-		return stateObject.Code(s.db)
+func (s *StateDB) Version() blockstm.Version {
+	return blockstm.Version{
+		TxnIndex:    s.txIndex,
+		Incarnation: s.incarnation,
 	}
-	return nil
+}
+
+func (s *StateDB) GetCode(addr common.Address) []byte {
+	if s.getStateObject(addr) == nil {
+		return nil
+	}
+
+	return MVRead(s, subPath(addr.Bytes(), codePath), nil, func(s *StateDB) []byte {
+		stateObject := s.getStateObject(addr)
+		if stateObject != nil {
+			return stateObject.Code(s.db)
+		}
+		return nil
+	})
 }
 
 func (s *StateDB) GetCodeSize(addr common.Address) int {
-	stateObject := s.getStateObject(addr)
-	if stateObject != nil {
-		return stateObject.CodeSize(s.db)
+	if s.getStateObject(addr) == nil {
+		return 0
 	}
-	return 0
+
+	return MVRead(s, subPath(addr.Bytes(), codePath), 0, func(s *StateDB) int {
+		stateObject := s.getStateObject(addr)
+		if stateObject != nil {
+			return stateObject.CodeSize(s.db)
+		}
+		return 0
+	})
 }
 
 func (s *StateDB) GetCodeHash(addr common.Address) common.Hash {
-	stateObject := s.getStateObject(addr)
-	if stateObject == nil {
+	if s.getStateObject(addr) == nil {
 		return common.Hash{}
 	}
-	return common.BytesToHash(stateObject.CodeHash())
+
+	return MVRead(s, subPath(addr.Bytes(), codePath), common.Hash{}, func(s *StateDB) common.Hash {
+		stateObject := s.getStateObject(addr)
+		if stateObject == nil {
+			return common.Hash{}
+		}
+		return common.BytesToHash(stateObject.CodeHash())
+	})
 }
 
 // GetState retrieves a value from the given account's storage trie.
 func (s *StateDB) GetState(addr common.Address, hash common.Hash) common.Hash {
-	stateObject := s.getStateObject(addr)
-	if stateObject != nil {
-		return stateObject.GetState(s.db, hash)
+	if s.getStateObject(addr) == nil {
+		return common.Hash{}
 	}
-	return common.Hash{}
+
+	return MVRead(s, append(addr.Bytes(), hash.Bytes()...), common.Hash{}, func(s *StateDB) common.Hash {
+		stateObject := s.getStateObject(addr)
+		if stateObject != nil {
+			return stateObject.GetState(s.db, hash)
+		}
+		return common.Hash{}
+	})
 }
 
 // GetProof returns the Merkle proof for a given account.
@@ -338,11 +555,17 @@ func (s *StateDB) GetStorageProof(a common.Address, key common.Hash) ([][]byte, 
 
 // GetCommittedState retrieves a value from the given account's committed storage trie.
 func (s *StateDB) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
-	stateObject := s.getStateObject(addr)
-	if stateObject != nil {
-		return stateObject.GetCommittedState(s.db, hash)
+	if s.getStateObject(addr) == nil {
+		return common.Hash{}
 	}
-	return common.Hash{}
+
+	return MVRead(s, append(addr.Bytes(), hash.Bytes()...), common.Hash{}, func(s *StateDB) common.Hash {
+		stateObject := s.getStateObject(addr)
+		if stateObject != nil {
+			return stateObject.GetCommittedState(s.db, hash)
+		}
+		return common.Hash{}
+	})
 }
 
 // Database retrieves the low level database supporting the lower level trie ops.
@@ -363,11 +586,17 @@ func (s *StateDB) StorageTrie(addr common.Address) Trie {
 }
 
 func (s *StateDB) HasSuicided(addr common.Address) bool {
-	stateObject := s.getStateObject(addr)
-	if stateObject != nil {
-		return stateObject.suicided
+	if s.getStateObject(addr) == nil {
+		return false
 	}
-	return false
+
+	return MVRead(s, subPath(addr.Bytes(), suicidePath), false, func(s *StateDB) bool {
+		stateObject := s.getStateObject(addr)
+		if stateObject != nil {
+			return stateObject.suicided
+		}
+		return false
+	})
 }
 
 /*
@@ -378,7 +607,9 @@ func (s *StateDB) HasSuicided(addr common.Address) bool {
 func (s *StateDB) AddBalance(addr common.Address, amount *big.Int) {
 	stateObject := s.GetOrNewStateObject(addr)
 	if stateObject != nil {
+		stateObject = s.mvRecordWritten(stateObject)
 		stateObject.AddBalance(amount)
+		MVWrite(s, subPath(addr.Bytes(), balancePath))
 	}
 }
 
@@ -386,35 +617,45 @@ func (s *StateDB) AddBalance(addr common.Address, amount *big.Int) {
 func (s *StateDB) SubBalance(addr common.Address, amount *big.Int) {
 	stateObject := s.GetOrNewStateObject(addr)
 	if stateObject != nil {
+		stateObject = s.mvRecordWritten(stateObject)
 		stateObject.SubBalance(amount)
+		MVWrite(s, subPath(addr.Bytes(), balancePath))
 	}
 }
 
 func (s *StateDB) SetBalance(addr common.Address, amount *big.Int) {
 	stateObject := s.GetOrNewStateObject(addr)
 	if stateObject != nil {
+		stateObject = s.mvRecordWritten(stateObject)
 		stateObject.SetBalance(amount)
+		MVWrite(s, subPath(addr.Bytes(), balancePath))
 	}
 }
 
 func (s *StateDB) SetNonce(addr common.Address, nonce uint64) {
 	stateObject := s.GetOrNewStateObject(addr)
 	if stateObject != nil {
+		stateObject = s.mvRecordWritten(stateObject)
 		stateObject.SetNonce(nonce)
+		MVWrite(s, subPath(addr.Bytes(), noncePath))
 	}
 }
 
 func (s *StateDB) SetCode(addr common.Address, code []byte) {
 	stateObject := s.GetOrNewStateObject(addr)
 	if stateObject != nil {
+		stateObject = s.mvRecordWritten(stateObject)
 		stateObject.SetCode(crypto.Keccak256Hash(code), code)
+		MVWrite(s, subPath(addr.Bytes(), codePath))
 	}
 }
 
 func (s *StateDB) SetState(addr common.Address, key, value common.Hash) {
 	stateObject := s.GetOrNewStateObject(addr)
 	if stateObject != nil {
+		stateObject = s.mvRecordWritten(stateObject)
 		stateObject.SetState(s.db, key, value)
+		MVWrite(s, append(addr.Bytes(), key.Bytes()...))
 	}
 }
 
@@ -437,6 +678,8 @@ func (s *StateDB) Suicide(addr common.Address) bool {
 	if stateObject == nil {
 		return false
 	}
+
+	stateObject = s.mvRecordWritten(stateObject)
 	s.journal.append(suicideChange{
 		account:     &addr,
 		prev:        stateObject.suicided,
@@ -444,6 +687,9 @@ func (s *StateDB) Suicide(addr common.Address) bool {
 	})
 	stateObject.markSuicided()
 	stateObject.data.Balance = new(big.Int)
+
+	MVWrite(s, subPath(addr.Bytes(), suicidePath))
+	MVWrite(s, subPath(addr.Bytes(), balancePath))
 
 	return true
 }
@@ -501,60 +747,62 @@ func (s *StateDB) getStateObject(addr common.Address) *stateObject {
 // flag set. This is needed by the state journal to revert to the correct s-
 // destructed object instead of wiping all knowledge about the state object.
 func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
-	// Prefer live objects if any is available
-	if obj := s.stateObjects[addr]; obj != nil {
-		return obj
-	}
-	// If no live objects are available, attempt to use snapshots
-	var data *types.StateAccount
-	if s.snap != nil {
-		start := time.Now()
-		acc, err := s.snap.Account(crypto.HashData(s.hasher, addr.Bytes()))
-		if metrics.EnabledExpensive {
-			s.SnapshotAccountReads += time.Since(start)
+	return MVRead(s, addr.Bytes(), nil, func(s *StateDB) *stateObject {
+		// Prefer live objects if any is available
+		if obj := s.stateObjects[addr]; obj != nil {
+			return obj
 		}
-		if err == nil {
-			if acc == nil {
+		// If no live objects are available, attempt to use snapshots
+		var data *types.StateAccount
+		if s.snap != nil { // nolint
+			start := time.Now()
+			acc, err := s.snap.Account(crypto.HashData(s.hasher, addr.Bytes()))
+			if metrics.EnabledExpensive {
+				s.SnapshotAccountReads += time.Since(start)
+			}
+			if err == nil {
+				if acc == nil {
+					return nil
+				}
+				data = &types.StateAccount{
+					Nonce:    acc.Nonce,
+					Balance:  acc.Balance,
+					CodeHash: acc.CodeHash,
+					Root:     common.BytesToHash(acc.Root),
+				}
+				if len(data.CodeHash) == 0 {
+					data.CodeHash = emptyCodeHash
+				}
+				if data.Root == (common.Hash{}) {
+					data.Root = emptyRoot
+				}
+			}
+		}
+		// If snapshot unavailable or reading from it failed, load from the database
+		if data == nil {
+			start := time.Now()
+			enc, err := s.trie.TryGet(addr.Bytes())
+			if metrics.EnabledExpensive {
+				s.AccountReads += time.Since(start)
+			}
+			if err != nil {
+				s.setError(fmt.Errorf("getDeleteStateObject (%x) error: %v", addr.Bytes(), err))
 				return nil
 			}
-			data = &types.StateAccount{
-				Nonce:    acc.Nonce,
-				Balance:  acc.Balance,
-				CodeHash: acc.CodeHash,
-				Root:     common.BytesToHash(acc.Root),
+			if len(enc) == 0 {
+				return nil
 			}
-			if len(data.CodeHash) == 0 {
-				data.CodeHash = emptyCodeHash
-			}
-			if data.Root == (common.Hash{}) {
-				data.Root = emptyRoot
+			data = new(types.StateAccount)
+			if err := rlp.DecodeBytes(enc, data); err != nil {
+				log.Error("Failed to decode state object", "addr", addr, "err", err)
+				return nil
 			}
 		}
-	}
-	// If snapshot unavailable or reading from it failed, load from the database
-	if data == nil {
-		start := time.Now()
-		enc, err := s.trie.TryGet(addr.Bytes())
-		if metrics.EnabledExpensive {
-			s.AccountReads += time.Since(start)
-		}
-		if err != nil {
-			s.setError(fmt.Errorf("getDeleteStateObject (%x) error: %v", addr.Bytes(), err))
-			return nil
-		}
-		if len(enc) == 0 {
-			return nil
-		}
-		data = new(types.StateAccount)
-		if err := rlp.DecodeBytes(enc, data); err != nil {
-			log.Error("Failed to decode state object", "addr", addr, "err", err)
-			return nil
-		}
-	}
-	// Insert into the live set
-	obj := newObject(s, addr, *data)
-	s.setStateObject(obj)
-	return obj
+		// Insert into the live set
+		obj := newObject(s, addr, *data)
+		s.setStateObject(obj)
+		return obj
+	})
 }
 
 func (s *StateDB) setStateObject(object *stateObject) {
@@ -568,6 +816,28 @@ func (s *StateDB) GetOrNewStateObject(addr common.Address) *stateObject {
 		stateObject, _ = s.createObject(addr)
 	}
 	return stateObject
+}
+
+// mvRecordWritten checks whether a state object is already present in the current MV writeMap.
+// If yes, it returns the object directly.
+// If not, it clones the object and inserts it into the writeMap before returning it.
+func (s *StateDB) mvRecordWritten(object *stateObject) *stateObject {
+	if s.mvHashmap == nil {
+		return object
+	}
+
+	addrPath := object.Address().Bytes()
+
+	if MVWritten(s, addrPath) {
+		return object
+	}
+
+	// Deepcopy is needed to ensure that objects are not written by multiple transactions at the same time, because
+	// the input state object can come from a different transaction.
+	s.setStateObject(object.deepCopy(s))
+	MVWrite(s, addrPath)
+
+	return s.stateObjects[object.Address()]
 }
 
 // createObject creates a new state object. If there is an existing account with
@@ -589,6 +859,7 @@ func (s *StateDB) createObject(addr common.Address) (newobj, prev *stateObject) 
 		s.journal.append(resetObjectChange{prev: prev, prevdestruct: prevdestruct})
 	}
 	s.setStateObject(newobj)
+	MVWrite(s, addr.Bytes())
 	if prev != nil && !prev.deleted {
 		return newobj, prev
 	}
@@ -609,6 +880,7 @@ func (s *StateDB) CreateAccount(addr common.Address) {
 	newObj, prev := s.createObject(addr)
 	if prev != nil {
 		newObj.setBalance(prev.data.Balance)
+		MVWrite(s, subPath(addr.Bytes(), balancePath))
 	}
 }
 
@@ -737,6 +1009,10 @@ func (s *StateDB) Copy() *StateDB {
 			}
 			state.snapStorage[k] = temp
 		}
+	}
+
+	if s.mvHashmap != nil {
+		state.mvHashmap = s.mvHashmap
 	}
 	return state
 }

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -29,7 +29,10 @@ import (
 	"testing"
 	"testing/quick"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/blockstm"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -486,6 +489,427 @@ func TestTouchDelete(t *testing.T) {
 	if len(s.state.journal.dirties) != 0 {
 		t.Fatal("expected no dirty state object")
 	}
+}
+
+func TestMVHashMapReadWriteDelete(t *testing.T) {
+	t.Parallel()
+
+	db := NewDatabase(rawdb.NewMemoryDatabase())
+	mvhm := blockstm.MakeMVHashMap()
+	s, _ := NewWithMVHashmap(common.Hash{}, db, nil, mvhm)
+
+	states := []*StateDB{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	key := common.HexToHash("0x01")
+	val := common.HexToHash("0x01")
+	balance := new(big.Int).SetUint64(uint64(100))
+
+	// Tx0 read
+	v := states[0].GetState(addr, key)
+
+	assert.Equal(t, common.Hash{}, v)
+
+	// Tx1 write
+	states[1].GetOrNewStateObject(addr)
+	states[1].SetState(addr, key, val)
+	states[1].SetBalance(addr, balance)
+
+	// Tx1 read
+	v = states[2].GetState(addr, key)
+	b := states[2].GetBalance(addr)
+
+	assert.Equal(t, val, v)
+	assert.Equal(t, balance, b)
+
+	// Tx2 read
+	v = states[2].GetState(addr, key)
+	b = states[2].GetBalance(addr)
+
+	assert.Equal(t, val, v)
+	assert.Equal(t, balance, b)
+
+	// Tx3 delete
+	states[3].Suicide(addr)
+
+	// Within Tx 3, the state should not change before finalize
+	v = states[3].GetState(addr, key)
+	assert.Equal(t, val, v)
+
+	// After finalizing Tx 3, the state will change
+	states[3].Finalise(false)
+	v = states[3].GetState(addr, key)
+	assert.Equal(t, common.Hash{}, v)
+
+	// Tx4 read
+	v = states[4].GetState(addr, key)
+	b = states[4].GetBalance(addr)
+
+	assert.Equal(t, common.Hash{}, v)
+	assert.Equal(t, common.Big0, b)
+}
+
+func TestMVHashMapRevert(t *testing.T) {
+	t.Parallel()
+
+	db := NewDatabase(rawdb.NewMemoryDatabase())
+	mvhm := blockstm.MakeMVHashMap()
+	s, _ := NewWithMVHashmap(common.Hash{}, db, nil, mvhm)
+
+	states := []*StateDB{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	key := common.HexToHash("0x01")
+	val := common.HexToHash("0x01")
+	balance := new(big.Int).SetUint64(uint64(100))
+
+	// Tx0 write
+	states[0].GetOrNewStateObject(addr)
+	states[0].SetState(addr, key, val)
+	states[0].SetBalance(addr, balance)
+
+	// Tx1 perform some ops and then revert
+	snapshot := states[1].Snapshot()
+	states[1].AddBalance(addr, new(big.Int).SetUint64(uint64(100)))
+	states[1].SetState(addr, key, common.HexToHash("0x02"))
+	v := states[1].GetState(addr, key)
+	b := states[1].GetBalance(addr)
+	assert.Equal(t, new(big.Int).SetUint64(uint64(200)), b)
+	assert.Equal(t, common.HexToHash("0x02"), v)
+
+	states[1].Suicide(addr)
+
+	states[1].RevertToSnapshot(snapshot)
+
+	v = states[1].GetState(addr, key)
+	b = states[1].GetBalance(addr)
+
+	assert.Equal(t, val, v)
+	assert.Equal(t, balance, b)
+	states[1].Finalise(false)
+
+	// Tx2 check the state and balance
+	v = states[2].GetState(addr, key)
+	b = states[2].GetBalance(addr)
+
+	assert.Equal(t, val, v)
+	assert.Equal(t, balance, b)
+}
+
+func TestMVHashMapMarkEstimate(t *testing.T) {
+	t.Parallel()
+
+	db := NewDatabase(rawdb.NewMemoryDatabase())
+	mvhm := blockstm.MakeMVHashMap()
+	s, _ := NewWithMVHashmap(common.Hash{}, db, nil, mvhm)
+
+	states := []*StateDB{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	key := common.HexToHash("0x01")
+	val := common.HexToHash("0x01")
+	balance := new(big.Int).SetUint64(uint64(100))
+
+	// Tx0 read
+	v := states[0].GetState(addr, key)
+	assert.Equal(t, common.Hash{}, v)
+
+	// Tx0 write
+	states[0].SetState(addr, key, val)
+	v = states[0].GetState(addr, key)
+	assert.Equal(t, val, v)
+
+	// Tx1 write
+	states[1].GetOrNewStateObject(addr)
+	states[1].SetState(addr, key, val)
+	states[1].SetBalance(addr, balance)
+
+	// Tx2 read
+	v = states[2].GetState(addr, key)
+	b := states[2].GetBalance(addr)
+
+	assert.Equal(t, val, v)
+	assert.Equal(t, balance, b)
+
+	// Tx1 mark estimate
+	for _, v := range states[1].writeMap {
+		mvhm.MarkEstimate(v.Path, 1)
+	}
+
+	// Tx2 read again should get default (empty) vals because its dependency Tx1 is marked as estimate
+	v = states[2].GetState(addr, key)
+	b = states[2].GetBalance(addr)
+
+	assert.Equal(t, common.Hash{}, v)
+	assert.Equal(t, common.Big0, b)
+
+	// Tx1 read again should get Tx0 vals
+	v = states[1].GetState(addr, key)
+	assert.Equal(t, val, v)
+}
+
+func TestMVHashMapOverwrite(t *testing.T) {
+	t.Parallel()
+
+	db := NewDatabase(rawdb.NewMemoryDatabase())
+	mvhm := blockstm.MakeMVHashMap()
+	s, _ := NewWithMVHashmap(common.Hash{}, db, nil, mvhm)
+
+	states := []*StateDB{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	key := common.HexToHash("0x01")
+	val1 := common.HexToHash("0x01")
+	balance1 := new(big.Int).SetUint64(uint64(100))
+	val2 := common.HexToHash("0x02")
+	balance2 := new(big.Int).SetUint64(uint64(200))
+
+	// Tx0 write
+	states[0].GetOrNewStateObject(addr)
+	states[0].SetState(addr, key, val1)
+	states[0].SetBalance(addr, balance1)
+
+	// Tx1 write
+	states[1].SetState(addr, key, val2)
+	states[1].SetBalance(addr, balance2)
+	v := states[1].GetState(addr, key)
+	b := states[1].GetBalance(addr)
+
+	assert.Equal(t, val2, v)
+	assert.Equal(t, balance2, b)
+
+	// Tx2 read should get Tx1's value
+	v = states[2].GetState(addr, key)
+	b = states[2].GetBalance(addr)
+
+	assert.Equal(t, val2, v)
+	assert.Equal(t, balance2, b)
+
+	// Tx1 delete
+	for _, v := range states[1].writeMap {
+		mvhm.Delete(v.Path, 1)
+
+		states[1].writeMap = nil
+	}
+
+	// Tx2 read should get Tx0's value
+	v = states[2].GetState(addr, key)
+	b = states[2].GetBalance(addr)
+
+	assert.Equal(t, val1, v)
+	assert.Equal(t, balance1, b)
+
+	// Tx1 read should get Tx0's value
+	v = states[1].GetState(addr, key)
+	b = states[1].GetBalance(addr)
+
+	assert.Equal(t, val1, v)
+	assert.Equal(t, balance1, b)
+
+	// Tx0 delete
+	for _, v := range states[0].writeMap {
+		mvhm.Delete(v.Path, 0)
+
+		states[0].writeMap = nil
+	}
+
+	// Tx2 read again should get default vals
+	v = states[2].GetState(addr, key)
+	b = states[2].GetBalance(addr)
+
+	assert.Equal(t, common.Hash{}, v)
+	assert.Equal(t, common.Big0, b)
+}
+
+func TestMVHashMapWriteNoConflict(t *testing.T) {
+	t.Parallel()
+
+	db := NewDatabase(rawdb.NewMemoryDatabase())
+	mvhm := blockstm.MakeMVHashMap()
+	s, _ := NewWithMVHashmap(common.Hash{}, db, nil, mvhm)
+
+	states := []*StateDB{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	key1 := common.HexToHash("0x01")
+	key2 := common.HexToHash("0x02")
+	val1 := common.HexToHash("0x01")
+	balance1 := new(big.Int).SetUint64(uint64(100))
+	val2 := common.HexToHash("0x02")
+
+	// Tx0 write
+	states[0].GetOrNewStateObject(addr)
+
+	// Tx2 write
+	states[2].SetState(addr, key2, val2)
+
+	// Tx1 write
+	tx1Snapshot := states[1].Snapshot()
+	states[1].SetState(addr, key1, val1)
+	states[1].SetBalance(addr, balance1)
+
+	// Tx1 read
+	assert.Equal(t, val1, states[1].GetState(addr, key1))
+	assert.Equal(t, balance1, states[1].GetBalance(addr))
+	// Tx1 should see empty value in key2
+	assert.Equal(t, common.Hash{}, states[1].GetState(addr, key2))
+
+	// Tx2 read
+	assert.Equal(t, val2, states[2].GetState(addr, key2))
+	// Tx2 should see values written by Tx1
+	assert.Equal(t, val1, states[2].GetState(addr, key1))
+	assert.Equal(t, balance1, states[2].GetBalance(addr))
+
+	// Tx3 read
+	assert.Equal(t, val1, states[3].GetState(addr, key1))
+	assert.Equal(t, val2, states[3].GetState(addr, key2))
+	assert.Equal(t, balance1, states[3].GetBalance(addr))
+
+	// Tx2 delete
+	for _, v := range states[2].writeMap {
+		mvhm.Delete(v.Path, 2)
+
+		states[2].writeMap = nil
+	}
+
+	assert.Equal(t, val1, states[3].GetState(addr, key1))
+	assert.Equal(t, balance1, states[3].GetBalance(addr))
+	assert.Equal(t, common.Hash{}, states[3].GetState(addr, key2))
+
+	// Tx1 revert
+	states[1].RevertToSnapshot(tx1Snapshot)
+
+	assert.Equal(t, common.Hash{}, states[3].GetState(addr, key1))
+	assert.Equal(t, common.Hash{}, states[3].GetState(addr, key2))
+	assert.Equal(t, common.Big0, states[3].GetBalance(addr))
+
+	// Tx1 delete
+	for _, v := range states[1].writeMap {
+		mvhm.Delete(v.Path, 1)
+
+		states[1].writeMap = nil
+	}
+
+	assert.Equal(t, common.Hash{}, states[3].GetState(addr, key1))
+	assert.Equal(t, common.Hash{}, states[3].GetState(addr, key2))
+	assert.Equal(t, common.Big0, states[3].GetBalance(addr))
+}
+
+func TestApplyMVWriteSet(t *testing.T) {
+	t.Parallel()
+
+	db := NewDatabase(rawdb.NewMemoryDatabase())
+	mvhm := blockstm.MakeMVHashMap()
+	s, _ := NewWithMVHashmap(common.Hash{}, db, nil, mvhm)
+
+	sClean := s.Copy()
+	sClean.mvHashmap = nil
+
+	sSingleProcess := sClean.Copy()
+
+	states := []*StateDB{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr1 := common.HexToAddress("0x01")
+	addr2 := common.HexToAddress("0x02")
+	key1 := common.HexToHash("0x01")
+	key2 := common.HexToHash("0x02")
+	val1 := common.HexToHash("0x01")
+	balance1 := new(big.Int).SetUint64(uint64(100))
+	val2 := common.HexToHash("0x02")
+	balance2 := new(big.Int).SetUint64(uint64(200))
+	code := []byte{1, 2, 3}
+
+	// Tx0 write
+	states[0].SetState(addr1, key1, val1)
+	states[0].SetBalance(addr1, balance1)
+	states[0].SetState(addr2, key2, val2)
+
+	sSingleProcess.SetState(addr1, key1, val1)
+	sSingleProcess.SetBalance(addr1, balance1)
+	sSingleProcess.SetState(addr2, key2, val2)
+
+	sClean.ApplyMVWriteSet(states[0].MVWriteList())
+
+	assert.Equal(t, sSingleProcess.IntermediateRoot(false), sClean.IntermediateRoot(false))
+
+	// Tx1 write
+	states[1].SetState(addr1, key2, val2)
+	states[1].SetBalance(addr1, balance2)
+	states[1].SetNonce(addr1, 1)
+
+	sSingleProcess.SetState(addr1, key2, val2)
+	sSingleProcess.SetBalance(addr1, balance2)
+	sSingleProcess.SetNonce(addr1, 1)
+
+	sClean.ApplyMVWriteSet(states[1].MVWriteList())
+
+	assert.Equal(t, sSingleProcess.IntermediateRoot(false), sClean.IntermediateRoot(false))
+
+	// Tx2 write
+	states[2].SetState(addr1, key1, val2)
+	states[2].SetBalance(addr1, balance2)
+	states[2].SetNonce(addr1, 2)
+
+	sSingleProcess.SetState(addr1, key1, val2)
+	sSingleProcess.SetBalance(addr1, balance2)
+	sSingleProcess.SetNonce(addr1, 2)
+
+	sClean.ApplyMVWriteSet(states[2].MVWriteList())
+
+	assert.Equal(t, sSingleProcess.IntermediateRoot(false), sClean.IntermediateRoot(false))
+
+	// Tx3 write
+	states[3].Suicide(addr2)
+	states[3].SetCode(addr1, code)
+
+	sSingleProcess.Suicide(addr2)
+	sSingleProcess.SetCode(addr1, code)
+
+	sClean.ApplyMVWriteSet(states[3].MVWriteList())
+
+	assert.Equal(t, sSingleProcess.IntermediateRoot(false), sClean.IntermediateRoot(false))
 }
 
 // TestCopyOfCopy tests that modified objects are carried over to the copy, and the copy of the copy.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -60,6 +60,11 @@ type StateTransition struct {
 	data       []byte
 	state      vm.StateDB
 	evm        *vm.EVM
+
+	// If true, fee burning and tipping won't happen during transition. Instead, their values will be included in the
+	// ExecutionResult, which caller can use the values to update the balance of burner and coinbase account.
+	// This is useful during parallel state transition, where the common account read/write should be minimized.
+	noFeeBurnAndTip bool
 }
 
 // Message represents a message sent to a contract.
@@ -82,9 +87,13 @@ type Message interface {
 // ExecutionResult includes all output after executing given evm
 // message no matter the execution itself is successful or not.
 type ExecutionResult struct {
-	UsedGas    uint64 // Total used gas but include the refunded gas
-	Err        error  // Any error encountered during the execution(listed in core/vm/errors.go)
-	ReturnData []byte // Returned data from evm(function result or data supplied with revert opcode)
+	UsedGas              uint64 // Total used gas but include the refunded gas
+	Err                  error  // Any error encountered during the execution(listed in core/vm/errors.go)
+	ReturnData           []byte // Returned data from evm(function result or data supplied with revert opcode)
+	senderInitBalance    *big.Int
+	FeeBurnt             *big.Int
+	BurntContractAddress common.Address
+	FeeTipped            *big.Int
 }
 
 // Unwrap returns the internal evm error which allows us for further
@@ -181,6 +190,13 @@ func ApplyMessage(evm *vm.EVM, msg Message, gp *GasPool) (*ExecutionResult, erro
 	return NewStateTransition(evm, msg, gp).TransitionDb()
 }
 
+func ApplyMessageNoFeeBurnOrTip(evm *vm.EVM, msg Message, gp *GasPool) (*ExecutionResult, error) {
+	st := NewStateTransition(evm, msg, gp)
+	st.noFeeBurnAndTip = true
+
+	return st.TransitionDb()
+}
+
 // to returns the recipient of the message.
 func (st *StateTransition) to() common.Address {
 	if st.msg == nil || st.msg.To() == nil /* contract creation */ {
@@ -274,7 +290,12 @@ func (st *StateTransition) preCheck() error {
 // nil evm execution result.
 func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	input1 := st.state.GetBalance(st.msg.From())
-	input2 := st.state.GetBalance(st.evm.Context.Coinbase)
+
+	var input2 *big.Int
+
+	if !st.noFeeBurnAndTip {
+		input2 = st.state.GetBalance(st.evm.Context.Coinbase)
+	}
 
 	// First check this message satisfies all consensus rules before
 	// applying the message. The rules include these clauses
@@ -340,34 +361,50 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		effectiveTip = cmath.BigMin(st.gasTipCap, new(big.Int).Sub(st.gasFeeCap, st.evm.Context.BaseFee))
 	}
 	amount := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), effectiveTip)
+
+	var burnAmount *big.Int
+
+	var burntContractAddress common.Address
+
 	if london {
-		burntContractAddress := common.HexToAddress(st.evm.ChainConfig().Bor.CalculateBurntContract(st.evm.Context.BlockNumber.Uint64()))
-		burnAmount := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee)
-		st.state.AddBalance(burntContractAddress, burnAmount)
+		burntContractAddress = common.HexToAddress(st.evm.ChainConfig().Bor.CalculateBurntContract(st.evm.Context.BlockNumber.Uint64()))
+		burnAmount = new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee)
+
+		if !st.noFeeBurnAndTip {
+			st.state.AddBalance(burntContractAddress, burnAmount)
+		}
 	}
-	st.state.AddBalance(st.evm.Context.Coinbase, amount)
-	output1 := new(big.Int).SetBytes(input1.Bytes())
-	output2 := new(big.Int).SetBytes(input2.Bytes())
 
-	// Deprecating transfer log and will be removed in future fork. PLEASE DO NOT USE this transfer log going forward. Parameters won't get updated as expected going forward with EIP1559
-	// add transfer log
-	AddFeeTransferLog(
-		st.state,
+	if !st.noFeeBurnAndTip {
+		st.state.AddBalance(st.evm.Context.Coinbase, amount)
 
-		msg.From(),
-		st.evm.Context.Coinbase,
+		output1 := new(big.Int).SetBytes(input1.Bytes())
+		output2 := new(big.Int).SetBytes(input2.Bytes())
 
-		amount,
-		input1,
-		input2,
-		output1.Sub(output1, amount),
-		output2.Add(output2, amount),
-	)
+		// Deprecating transfer log and will be removed in future fork. PLEASE DO NOT USE this transfer log going forward. Parameters won't get updated as expected going forward with EIP1559
+		// add transfer log
+		AddFeeTransferLog(
+			st.state,
+
+			msg.From(),
+			st.evm.Context.Coinbase,
+
+			amount,
+			input1,
+			input2,
+			output1.Sub(output1, amount),
+			output2.Add(output2, amount),
+		)
+	}
 
 	return &ExecutionResult{
-		UsedGas:    st.gasUsed(),
-		Err:        vmerr,
-		ReturnData: ret,
+		UsedGas:              st.gasUsed(),
+		Err:                  vmerr,
+		ReturnData:           ret,
+		senderInitBalance:    input1,
+		FeeBurnt:             burnAmount,
+		BurntContractAddress: burntContractAddress,
+		FeeTipped:            amount,
 	}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/deepmap/oapi-codegen v1.8.2 // indirect
 	github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 // indirect
+	github.com/emirpasic/gods v1.18.1
 	github.com/go-kit/kit v0.9.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
+github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
The implementation of MVHashMap slightly differs from the original implementation by storing an instance of statedb, instead of the actual data bytes, as the value of a key in the map.