### PR TITLE
Change diverged flags back to Geth's convention (POS-602)

### DIFF
--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -6,7 +6,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```chain```: Name of the chain to sync
 
-- ```name```: Name/Identity of the node
+- ```identity```: Identity of the node
 
 - ```log-level```: Set log level for the server
 
@@ -22,7 +22,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```requiredblocks```: Comma separated block number-to-hash mappings to enforce (<number>=<hash>)
 
-- ```no-snapshot```: Disables the snapshot-database mode (default = false)
+- ```snapshot```: Disables the snapshot-database mode (default = true)
 
 - ```bor.heimdall```: URL of Heimdall service
 
@@ -88,9 +88,9 @@ The ```bor server``` command runs the Bor client.
 
 - ```ipcpath```: Filename for IPC socket/pipe within the datadir (explicit paths escape it)
 
-- ```jsonrpc.corsdomain```: Comma separated list of domains from which to accept cross origin requests (browser enforced)
+- ```http.corsdomain```: Comma separated list of domains from which to accept cross origin requests (browser enforced)
 
-- ```jsonrpc.vhosts```: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.
+- ```http.vhosts```: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.
 
 - ```http```: Enable the HTTP-RPC server
 
@@ -100,7 +100,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```http.rpcprefix```: HTTP path path prefix on which JSON-RPC is served. Use '/' to serve on all paths.
 
-- ```http.modules```: API's offered over the HTTP-RPC interface
+- ```http.api```: API's offered over the HTTP-RPC interface
 
 - ```ws```: Enable the WS-RPC server
 
@@ -110,7 +110,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```ws.rpcprefix```: HTTP path prefix on which JSON-RPC is served. Use '/' to serve on all paths.
 
-- ```ws.modules```: API's offered over the WS-RPC interface
+- ```ws.api```: API's offered over the WS-RPC interface
 
 - ```graphql```: Enable GraphQL on the HTTP-RPC server. Note that GraphQL can only be started if an HTTP server is started as well.
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -92,6 +92,14 @@ The ```bor server``` command runs the Bor client.
 
 - ```http.vhosts```: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.
 
+- ```ws.corsdomain```: Comma separated list of domains from which to accept cross origin requests (browser enforced)
+
+- ```ws.vhosts```: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.
+
+- ```graphql.corsdomain```: Comma separated list of domains from which to accept cross origin requests (browser enforced)
+
+- ```graphql.vhosts```: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.
+
 - ```http```: Enable the HTTP-RPC server
 
 - ```http.addr```: HTTP-RPC server listening interface

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -6,7 +6,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```chain```: Name of the chain to sync
 
-- ```identity```: Identity of the node
+- ```identity```: Name/Identity of the node
 
 - ```log-level```: Set log level for the server
 
@@ -22,7 +22,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```requiredblocks```: Comma separated block number-to-hash mappings to enforce (<number>=<hash>)
 
-- ```snapshot```: Disables the snapshot-database mode (default = true)
+- ```snapshot```: Disables/Enables the snapshot-database mode (default = true)
 
 - ```bor.heimdall```: URL of Heimdall service
 

--- a/internal/cli/flagset/flagset.go
+++ b/internal/cli/flagset/flagset.go
@@ -217,8 +217,8 @@ func (i *SliceStringFlag) String() string {
 }
 
 func (i *SliceStringFlag) Set(value string) error {
-	*i.Value = append(*i.Value, strings.Split(value, ",")...)
-
+	// overwritting insted of appending
+	*i.Value = strings.Split(value, ",")
 	return nil
 }
 

--- a/internal/cli/flagset/flagset.go
+++ b/internal/cli/flagset/flagset.go
@@ -202,10 +202,11 @@ func (f *Flagset) BigIntFlag(b *BigIntFlag) {
 }
 
 type SliceStringFlag struct {
-	Name  string
-	Usage string
-	Value *[]string
-	Group string
+	Name    string
+	Usage   string
+	Value   *[]string
+	Default []string
+	Group   string
 }
 
 func (i *SliceStringFlag) String() string {

--- a/internal/cli/flagset/flagset_test.go
+++ b/internal/cli/flagset/flagset_test.go
@@ -23,14 +23,17 @@ func TestFlagsetBool(t *testing.T) {
 func TestFlagsetSliceString(t *testing.T) {
 	f := NewFlagSet("")
 
-	value := []string{}
+	value := []string{"a", "b", "c"}
 	f.SliceStringFlag(&SliceStringFlag{
-		Name:  "flag",
-		Value: &value,
+		Name:    "flag",
+		Value:   &value,
+		Default: value,
 	})
 
-	assert.NoError(t, f.Parse([]string{"--flag", "a,b", "--flag", "c"}))
+	assert.NoError(t, f.Parse([]string{}))
 	assert.Equal(t, value, []string{"a", "b", "c"})
+	assert.NoError(t, f.Parse([]string{"--flag", "a,b"}))
+	assert.Equal(t, value, []string{"a", "b"})
 }
 
 func TestFlagsetDuration(t *testing.T) {

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -61,8 +61,8 @@ type Config struct {
 	// GcMode selects the garbage collection mode for the trie
 	GcMode string `hcl:"gc-mode,optional"`
 
-	// NoSnapshot disables the snapshot database mode
-	NoSnapshot bool `hcl:"no-snapshot,optional"`
+	// Snapshot disables/enables the snapshot database mode
+	Snapshot bool `hcl:"snapshot,optional"`
 
 	// Ethstats is the address of the ethstats server to send telemetry
 	Ethstats string `hcl:"ethstats,optional"`
@@ -412,9 +412,9 @@ func DefaultConfig() *Config {
 			URL:     "http://localhost:1317",
 			Without: false,
 		},
-		SyncMode:   "full",
-		GcMode:     "full",
-		NoSnapshot: false,
+		SyncMode: "full",
+		GcMode:   "full",
+		Snapshot: true,
 		TxPool: &TxPoolConfig{
 			Locals:       []string{},
 			NoLocals:     false,
@@ -864,7 +864,7 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 	}
 
 	// snapshot disable check
-	if c.NoSnapshot {
+	if !c.Snapshot {
 		if n.SyncMode == downloader.SnapSync {
 			log.Info("Snap sync requested, enabling --snapshot")
 		} else {

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -217,12 +217,6 @@ type JsonRPCConfig struct {
 	// IPCPath is the path of the ipc endpoint
 	IPCPath string `hcl:"ipc-path,optional"`
 
-	// VHost is the list of valid virtual hosts
-	VHost []string `hcl:"vhost,optional"`
-
-	// Cors is the list of Cors endpoints
-	Cors []string `hcl:"cors,optional"`
-
 	// GasCap is the global gas cap for eth-call variants.
 	GasCap uint64 `hcl:"gas-cap,optional"`
 
@@ -259,6 +253,12 @@ type APIConfig struct {
 
 	// Modules is the list of enabled api modules
 	API []string `hcl:"modules,optional"`
+
+	// VHost is the list of valid virtual hosts
+	VHost []string `hcl:"vhost,optional"`
+
+	// Cors is the list of Cors endpoints
+	Cors []string `hcl:"cors,optional"`
 }
 
 type GpoConfig struct {
@@ -444,8 +444,6 @@ func DefaultConfig() *Config {
 		JsonRPC: &JsonRPCConfig{
 			IPCDisable: false,
 			IPCPath:    "",
-			Cors:       []string{"*"},
-			VHost:      []string{"*"},
 			GasCap:     ethconfig.Defaults.RPCGasCap,
 			TxFeeCap:   ethconfig.Defaults.RPCTxFeeCap,
 			Http: &APIConfig{
@@ -454,6 +452,8 @@ func DefaultConfig() *Config {
 				Prefix:  "",
 				Host:    "localhost",
 				API:     []string{"eth", "net", "web3", "txpool", "bor"},
+				Cors:    []string{"*"},
+				VHost:   []string{"*"},
 			},
 			Ws: &APIConfig{
 				Enabled: false,
@@ -461,9 +461,13 @@ func DefaultConfig() *Config {
 				Prefix:  "",
 				Host:    "localhost",
 				API:     []string{"web3", "net"},
+				Cors:    []string{"*"},
+				VHost:   []string{"*"},
 			},
 			Graphql: &APIConfig{
 				Enabled: false,
+				Cors:    []string{"*"},
+				VHost:   []string{"*"},
 			},
 		},
 		Ethstats: "",
@@ -909,14 +913,14 @@ func (c *Config) buildNode() (*node.Config, error) {
 			DiscoveryV5:     c.P2P.Discovery.V5Enabled,
 		},
 		HTTPModules:         c.JsonRPC.Http.API,
-		HTTPCors:            c.JsonRPC.Cors,
-		HTTPVirtualHosts:    c.JsonRPC.VHost,
+		HTTPCors:            c.JsonRPC.Http.Cors,
+		HTTPVirtualHosts:    c.JsonRPC.Http.VHost,
 		HTTPPathPrefix:      c.JsonRPC.Http.Prefix,
 		WSModules:           c.JsonRPC.Ws.API,
-		WSOrigins:           c.JsonRPC.Cors,
+		WSOrigins:           c.JsonRPC.Ws.Cors,
 		WSPathPrefix:        c.JsonRPC.Ws.Prefix,
-		GraphQLCors:         c.JsonRPC.Cors,
-		GraphQLVirtualHosts: c.JsonRPC.VHost,
+		GraphQLCors:         c.JsonRPC.Graphql.Cors,
+		GraphQLVirtualHosts: c.JsonRPC.Graphql.VHost,
 	}
 
 	// dev mode

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -40,8 +40,8 @@ type Config struct {
 	// Chain is the chain to sync with
 	Chain string `hcl:"chain,optional"`
 
-	// Name, or identity of the node
-	Name string `hcl:"name,optional"`
+	// Identity of the node
+	Identity string `hcl:"identity,optional"`
 
 	// RequiredBlocks is a list of required (block number, hash) pairs to accept
 	RequiredBlocks map[string]string `hcl:"requiredblocks,optional"`
@@ -387,7 +387,7 @@ type DeveloperConfig struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Chain:          "mainnet",
-		Name:           Hostname(),
+		Identity:       Hostname(),
 		RequiredBlocks: map[string]string{},
 		LogLevel:       "INFO",
 		DataDir:        defaultDataDir(),

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -232,10 +232,10 @@ type JsonRPCConfig struct {
 	// Http has the json-rpc http related settings
 	Http *APIConfig `hcl:"http,block"`
 
-	// Http has the json-rpc websocket related settings
+	// Ws has the json-rpc websocket related settings
 	Ws *APIConfig `hcl:"ws,block"`
 
-	// Http has the json-rpc graphql related settings
+	// Graphql has the json-rpc graphql related settings
 	Graphql *APIConfig `hcl:"graphql,block"`
 }
 
@@ -999,7 +999,7 @@ func (c *Config) buildNode() (*node.Config, error) {
 
 func (c *Config) Merge(cc ...*Config) error {
 	for _, elem := range cc {
-		if err := mergo.Merge(c, elem, mergo.WithOverwriteWithEmptyValue, mergo.WithAppendSlice); err != nil {
+		if err := mergo.Merge(c, elem, mergo.WithOverwriteWithEmptyValue); err != nil {
 			return fmt.Errorf("failed to merge configurations: %v", err)
 		}
 	}

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -258,7 +258,7 @@ type APIConfig struct {
 	Host string `hcl:"host,optional"`
 
 	// Modules is the list of enabled api modules
-	Modules []string `hcl:"modules,optional"`
+	API []string `hcl:"modules,optional"`
 }
 
 type GpoConfig struct {
@@ -453,14 +453,14 @@ func DefaultConfig() *Config {
 				Port:    8545,
 				Prefix:  "",
 				Host:    "localhost",
-				Modules: []string{"eth", "net", "web3", "txpool", "bor"},
+				API:     []string{"eth", "net", "web3", "txpool", "bor"},
 			},
 			Ws: &APIConfig{
 				Enabled: false,
 				Port:    8546,
 				Prefix:  "",
 				Host:    "localhost",
-				Modules: []string{"web3", "net"},
+				API:     []string{"web3", "net"},
 			},
 			Graphql: &APIConfig{
 				Enabled: false,
@@ -908,11 +908,11 @@ func (c *Config) buildNode() (*node.Config, error) {
 			ListenAddr:      c.P2P.Bind + ":" + strconv.Itoa(int(c.P2P.Port)),
 			DiscoveryV5:     c.P2P.Discovery.V5Enabled,
 		},
-		HTTPModules:         c.JsonRPC.Http.Modules,
+		HTTPModules:         c.JsonRPC.Http.API,
 		HTTPCors:            c.JsonRPC.Cors,
 		HTTPVirtualHosts:    c.JsonRPC.VHost,
 		HTTPPathPrefix:      c.JsonRPC.Http.Prefix,
-		WSModules:           c.JsonRPC.Ws.Modules,
+		WSModules:           c.JsonRPC.Ws.API,
 		WSOrigins:           c.JsonRPC.Cors,
 		WSPathPrefix:        c.JsonRPC.Ws.Prefix,
 		GraphQLCors:         c.JsonRPC.Cors,

--- a/internal/cli/server/config_test.go
+++ b/internal/cli/server/config_test.go
@@ -22,8 +22,8 @@ func TestConfigDefault(t *testing.T) {
 
 func TestConfigMerge(t *testing.T) {
 	c0 := &Config{
-		Chain:      "0",
-		NoSnapshot: true,
+		Chain:    "0",
+		Snapshot: true,
 		RequiredBlocks: map[string]string{
 			"a": "b",
 		},
@@ -54,8 +54,8 @@ func TestConfigMerge(t *testing.T) {
 	}
 
 	expected := &Config{
-		Chain:      "1",
-		NoSnapshot: false,
+		Chain:    "1",
+		Snapshot: false,
 		RequiredBlocks: map[string]string{
 			"a": "b",
 			"b": "c",

--- a/internal/cli/server/config_test.go
+++ b/internal/cli/server/config_test.go
@@ -64,7 +64,6 @@ func TestConfigMerge(t *testing.T) {
 			MaxPeers: 10,
 			Discovery: &P2PDiscovery{
 				StaticNodes: []string{
-					"a",
 					"b",
 				},
 			},

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -329,7 +329,7 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "JsonRPC",
 	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "jsonrpc.corsdomain",
+		Name:  "http.corsdomain",
 		Usage: "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
 		Value: &c.cliConfig.JsonRPC.Cors,
 		Group: "JsonRPC",

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -61,10 +61,10 @@ func (c *Command) Flags() *flagset.Flagset {
 		Value: &c.cliConfig.RequiredBlocks,
 	})
 	f.BoolFlag(&flagset.BoolFlag{
-		Name:    "no-snapshot",
-		Usage:   `Disables the snapshot-database mode (default = false)`,
-		Value:   &c.cliConfig.NoSnapshot,
-		Default: c.cliConfig.NoSnapshot,
+		Name:    "snapshot",
+		Usage:   `Disables/Enables the snapshot-database mode (default = true)`,
+		Value:   &c.cliConfig.Snapshot,
+		Default: c.cliConfig.Snapshot,
 	})
 
 	// heimdall

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -83,10 +83,11 @@ func (c *Command) Flags() *flagset.Flagset {
 
 	// txpool options
 	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "txpool.locals",
-		Usage: "Comma separated accounts to treat as locals (no flush, priority inclusion)",
-		Value: &c.cliConfig.TxPool.Locals,
-		Group: "Transaction Pool",
+		Name:    "txpool.locals",
+		Usage:   "Comma separated accounts to treat as locals (no flush, priority inclusion)",
+		Value:   &c.cliConfig.TxPool.Locals,
+		Default: c.cliConfig.TxPool.Locals,
+		Group:   "Transaction Pool",
 	})
 	f.BoolFlag(&flagset.BoolFlag{
 		Name:    "txpool.nolocals",
@@ -329,16 +330,18 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "JsonRPC",
 	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "http.corsdomain",
-		Usage: "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
-		Value: &c.cliConfig.JsonRPC.Cors,
-		Group: "JsonRPC",
+		Name:    "http.corsdomain",
+		Usage:   "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
+		Value:   &c.cliConfig.JsonRPC.Cors,
+		Default: c.cliConfig.JsonRPC.Cors,
+		Group:   "JsonRPC",
 	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "http.vhosts",
-		Usage: "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
-		Value: &c.cliConfig.JsonRPC.VHost,
-		Group: "JsonRPC",
+		Name:    "http.vhosts",
+		Usage:   "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
+		Value:   &c.cliConfig.JsonRPC.VHost,
+		Default: c.cliConfig.JsonRPC.VHost,
+		Group:   "JsonRPC",
 	})
 
 	// http options
@@ -371,10 +374,11 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "JsonRPC",
 	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "http.api",
-		Usage: "API's offered over the HTTP-RPC interface",
-		Value: &c.cliConfig.JsonRPC.Http.API,
-		Group: "JsonRPC",
+		Name:    "http.api",
+		Usage:   "API's offered over the HTTP-RPC interface",
+		Value:   &c.cliConfig.JsonRPC.Http.API,
+		Default: c.cliConfig.JsonRPC.Http.API,
+		Group:   "JsonRPC",
 	})
 
 	// ws options
@@ -407,10 +411,11 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "JsonRPC",
 	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "ws.api",
-		Usage: "API's offered over the WS-RPC interface",
-		Value: &c.cliConfig.JsonRPC.Ws.API,
-		Group: "JsonRPC",
+		Name:    "ws.api",
+		Usage:   "API's offered over the WS-RPC interface",
+		Value:   &c.cliConfig.JsonRPC.Ws.API,
+		Default: c.cliConfig.JsonRPC.Ws.API,
+		Group:   "JsonRPC",
 	})
 
 	// graphql options
@@ -438,10 +443,11 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "P2P",
 	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "bootnodes",
-		Usage: "Comma separated enode URLs for P2P discovery bootstrap",
-		Value: &c.cliConfig.P2P.Discovery.Bootnodes,
-		Group: "P2P",
+		Name:    "bootnodes",
+		Usage:   "Comma separated enode URLs for P2P discovery bootstrap",
+		Value:   &c.cliConfig.P2P.Discovery.Bootnodes,
+		Default: c.cliConfig.P2P.Discovery.Bootnodes,
+		Group:   "P2P",
 	})
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "maxpeers",
@@ -581,10 +587,11 @@ func (c *Command) Flags() *flagset.Flagset {
 
 	// account
 	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "unlock",
-		Usage: "Comma separated list of accounts to unlock",
-		Value: &c.cliConfig.Accounts.Unlock,
-		Group: "Account Management",
+		Name:    "unlock",
+		Usage:   "Comma separated list of accounts to unlock",
+		Value:   &c.cliConfig.Accounts.Unlock,
+		Default: c.cliConfig.Accounts.Unlock,
+		Group:   "Account Management",
 	})
 	f.StringFlag(&flagset.StringFlag{
 		Name:    "password",

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -16,10 +16,10 @@ func (c *Command) Flags() *flagset.Flagset {
 		Default: c.cliConfig.Chain,
 	})
 	f.StringFlag(&flagset.StringFlag{
-		Name:    "name",
+		Name:    "identity",
 		Usage:   "Name/Identity of the node",
-		Value:   &c.cliConfig.Name,
-		Default: c.cliConfig.Name,
+		Value:   &c.cliConfig.Identity,
+		Default: c.cliConfig.Identity,
 	})
 	f.StringFlag(&flagset.StringFlag{
 		Name:    "log-level",

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -332,15 +332,43 @@ func (c *Command) Flags() *flagset.Flagset {
 	f.SliceStringFlag(&flagset.SliceStringFlag{
 		Name:    "http.corsdomain",
 		Usage:   "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
-		Value:   &c.cliConfig.JsonRPC.Cors,
-		Default: c.cliConfig.JsonRPC.Cors,
+		Value:   &c.cliConfig.JsonRPC.Http.Cors,
+		Default: c.cliConfig.JsonRPC.Http.Cors,
 		Group:   "JsonRPC",
 	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
 		Name:    "http.vhosts",
 		Usage:   "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
-		Value:   &c.cliConfig.JsonRPC.VHost,
-		Default: c.cliConfig.JsonRPC.VHost,
+		Value:   &c.cliConfig.JsonRPC.Http.VHost,
+		Default: c.cliConfig.JsonRPC.Http.VHost,
+		Group:   "JsonRPC",
+	})
+	f.SliceStringFlag(&flagset.SliceStringFlag{
+		Name:    "ws.corsdomain",
+		Usage:   "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
+		Value:   &c.cliConfig.JsonRPC.Ws.Cors,
+		Default: c.cliConfig.JsonRPC.Ws.Cors,
+		Group:   "JsonRPC",
+	})
+	f.SliceStringFlag(&flagset.SliceStringFlag{
+		Name:    "ws.vhosts",
+		Usage:   "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
+		Value:   &c.cliConfig.JsonRPC.Ws.VHost,
+		Default: c.cliConfig.JsonRPC.Ws.VHost,
+		Group:   "JsonRPC",
+	})
+	f.SliceStringFlag(&flagset.SliceStringFlag{
+		Name:    "graphql.corsdomain",
+		Usage:   "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
+		Value:   &c.cliConfig.JsonRPC.Graphql.Cors,
+		Default: c.cliConfig.JsonRPC.Graphql.Cors,
+		Group:   "JsonRPC",
+	})
+	f.SliceStringFlag(&flagset.SliceStringFlag{
+		Name:    "graphql.vhosts",
+		Usage:   "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
+		Value:   &c.cliConfig.JsonRPC.Graphql.VHost,
+		Default: c.cliConfig.JsonRPC.Graphql.VHost,
 		Group:   "JsonRPC",
 	})
 

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -371,9 +371,9 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "JsonRPC",
 	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "http.modules",
+		Name:  "http.api",
 		Usage: "API's offered over the HTTP-RPC interface",
-		Value: &c.cliConfig.JsonRPC.Http.Modules,
+		Value: &c.cliConfig.JsonRPC.Http.API,
 		Group: "JsonRPC",
 	})
 
@@ -407,9 +407,9 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "JsonRPC",
 	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "ws.modules",
+		Name:  "ws.api",
 		Usage: "API's offered over the WS-RPC interface",
-		Value: &c.cliConfig.JsonRPC.Ws.Modules,
+		Value: &c.cliConfig.JsonRPC.Ws.API,
 		Group: "JsonRPC",
 	})
 

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -335,7 +335,7 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group: "JsonRPC",
 	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
-		Name:  "jsonrpc.vhosts",
+		Name:  "http.vhosts",
 		Usage: "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.",
 		Value: &c.cliConfig.JsonRPC.VHost,
 		Group: "JsonRPC",

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -182,7 +182,7 @@ func NewServer(config *Config) (*Server, error) {
 
 	// graphql is started from another place
 	if config.JsonRPC.Graphql.Enabled {
-		if err := graphql.New(stack, srv.backend.APIBackend, config.JsonRPC.Cors, config.JsonRPC.VHost); err != nil {
+		if err := graphql.New(stack, srv.backend.APIBackend, config.JsonRPC.Graphql.Cors, config.JsonRPC.Graphql.VHost); err != nil {
 			return nil, fmt.Errorf("failed to register the GraphQL service: %v", err)
 		}
 	}

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -201,7 +201,7 @@ func NewServer(config *Config) (*Server, error) {
 		}
 	}
 
-	if err := srv.setupMetrics(config.Telemetry, config.Name); err != nil {
+	if err := srv.setupMetrics(config.Telemetry, config.Identity); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR does the following things:

1. Changes the following flags:
```
name -> identity
no-snapshot -> snapshot=False / snapshot=True
http.modules -> http.api
ws.modules -> ws.api
```
2. Fixes the bug where items are appended to the SliceString instead of overwriting it.
3. Adds a `Default` field to the `SliceStringFlag`.
4. Adds separate flags for `corsdomain` and `vhosts` for `http, ws, and graphql`.
```
http.corsdomain
http.vhosts
ws.corsdomain
ws.vhosts
graphql.corsdomain
graphql.vhosts
```


[POS-602](https://polygon.atlassian.net/browse/POS-602?atlOrigin=eyJpIjoiMzJjZDE1MjgwY2ViNDUyMGFjZGY5ZWUwMjQyZTk3N2IiLCJwIjoiaiJ9)