### PR TITLE
Fix transaction hash assignment in getTransactionReceiptsByBlock

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -680,7 +680,7 @@ func (s *PublicBlockChainAPI) GetTransactionReceiptsByBlock(ctx context.Context,
 		if receipt.Logs == nil {
 			fields["logs"] = [][]*types.Log{}
 		}
-		if borReceipt != nil && idx == len(receipts) - 1 {
+		if borReceipt != nil && idx == len(receipts)-1 {
 			fields["transactionHash"] = txHash
 		}
 		// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -680,7 +680,7 @@ func (s *PublicBlockChainAPI) GetTransactionReceiptsByBlock(ctx context.Context,
 		if receipt.Logs == nil {
 			fields["logs"] = [][]*types.Log{}
 		}
-		if borReceipt != nil {
+		if borReceipt != nil && idx == len(receipts) - 1 {
 			fields["transactionHash"] = txHash
 		}
 		// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation


### PR DESCRIPTION
There is a bug in getTransactionReceiptsByBlock which causes every transaction in a block take the same transaction hash if that block contains a bor transaction because of a loose condition in `if` expression. I've added an additional check to fix that. Since the bor transaction is always the last in a block, we can check if it's the bor transaction by comparing its index with length of the receipts array minus one.
The related issue is #447
