### PR TITLE
github: add new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -14,9 +14,9 @@ NOTE: Please make sure to check of any addresses / private keys / rpc url's / IP
 
 #### **System information**
 
-Bor client version: [e.g. v0.2.16]
+Bor client version: [e.g. v0.2.16] <!--Can be found by running the command `bor version`-->
 
-Heimdall client version: [e.g. v0.2.10]
+Heimdall client version: [e.g. v0.2.10] <!--Can be found by running the command `heimdalld version`-->
 
 OS & Version: Windows / Linux / OSX
 
@@ -53,15 +53,16 @@ In order to debug the issue faster, we would stongly encourage if you can provid
 
 1. Your `start.sh` file or `bor.service`, if you're facing some peering issue or unable to use some service (like `http` endpoint) as expected. Moreover, if possible mention the chain configuration printed while starting the node which looks something like `Initialised chain configuration config="{ChainID: 137, ..., Engine: bor}"`
 <!--
-It should be start.sh if you're using bor v0.2.x and bor.service if it's bor v0.3.x. Mention this file if you're facing any issues like unable to use some flag/s according to their expected behaviour.
+It should be start.sh if you're using bor v0.2.x and bor.service (ideally located under `/lib/systemd/system/`) if it's bor v0.3.x. Mention this file if you're facing any issues like unable to use some flag/s according to their expected behaviour.
 -->
-2. The result of `eth.syncing`, `admin.peers.length`, value of the `maxpeers` flag in start.sh, and bootnodes/static nodes (if any) is you're facing some syncing issue. 
+2. The result of `eth.syncing`, `admin.peers.length`, `admin.nodeInfo`, value of the `maxpeers` flag in start.sh, and bootnodes/static nodes (if any) is you're facing some syncing issue.
 <!--
 You can get the above results by attaching to the IPC using the command `bor attach $BORDIR/bor.ipc` or `bor attach $DATADIR/bor.ipc` and running the mentioned commands. 
-Mention this if you're facing issues where bor keeps stalling and is not importing new blocks or making any progress. Adding chain configuration mentioned in the previous step would also be really helpful here.  
+Mention this if you're facing issues where bor keeps stalling and is not importing new blocks or making any progress. Adding chain configuration mentioned in the previous step would also be really helpful here as it might also be a genesis mismatch issue.
 -->
-3. Your `heimdall-config.toml` parameters (whose ideal location is `~/.heimdalld/config/`) for checking the ETH and BOR RPC url's, incase of issue with bor heimdall communication. 
+3. Your `heimdall-config.toml` parameters for checking the ETH and BOR RPC url's, incase of issue with bor heimdall communication. 
 <!--
+The location should be `~/.heimdalld/config/` if running heimdall v0.2.x and `/var/lib/heimdalld/config` if running heimdall v0.3.x. 
 As a sub-set of syncing issues, if your node keeps printing logs like `Retrying again in 5 seconds to fetch data from Heimdall`, it might be an issue with the communication between your bor node and heimdall node. In this case, also check if all the heimdall services (heimdalld, bridge, rest-server) are running correctly.
 -->
 4. The CURL request (for that specific error) if you're facing any issues or identify a bug while making RPC request.  

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,30 +1,70 @@
 ---
 name: Report a bug
-about: Something with go-ethereum is not working as expected
+about: Something with bor client is not working as expected
 title: ''
 labels: 'type:bug'
 assignees: ''
 ---
 
-#### System information
+Our support team has aggregated some common issues and their solutions from past which are faced while running or interacting with a bor client. In order to prevent redundant efforts, we would encourage you to have a look at the [FAQ's section](https://docs.polygon.technology/docs/faq/technical-faqs) of our documentation mentioning the same, before filing an issue here. In case of additional support, you can also join our [discord](https://discord.com/invite/zdwkdvMNY2) server
 
-Geth version: `geth version`
-OS & Version: Windows/Linux/OSX
-Commit hash : (if `develop`)
+<!--
+NOTE: Please make sure to check of any addresses / private keys / rpc url's / IP's before sharing the logs or anything from the additional information section (start.sh or heimdall config).
+-->
 
-#### Expected behaviour
+#### **System information**
 
+Bor client version: [e.g. v0.2.16]
 
-#### Actual behaviour
+Heimdall client version: [e.g. v0.2.10]
 
+OS & Version: Windows / Linux / OSX
 
-#### Steps to reproduce the behaviour
+Environment: Polygon Mainnet / Polygon Mumbai / Devnet
 
+Type of node: Validator / Sentry / Archive
 
-#### Backtrace
+Additional Information: <!--Modifications in the client (if any)-->
 
-````
-[backtrace]
-````
+#### **Overview of the problem**
 
-When submitting logs: please submit them as text and not screenshots.
+Please describe the issue you experiencing.
+<!--
+Mention in detail about the issue. Also mention the actual and expected behaviour.
+-->
+
+#### **Reproduction Steps**
+
+Please mention the steps required to reproduce this issue. 
+
+<!--
+E.g. 
+1. Start bor using these flags. 
+2. Node is unable to connect with other peers in the network and keeps disconnecting. 
+-->
+
+#### **Logs / Traces / Output / Error Messages**
+ 
+Please post any logs/traces/output/error messages (as text and not screenshots) which you believe may have caused the issue. If the log is longer than a few dozen lines, please include the URL to the [gist](https://gist.github.com/) of the log instead of posting it in the issue.
+
+**Additional Information**
+
+In order to debug the issue faster, we would stongly encourage if you can provide some of the details mentioned below (whichever seems relevant to your issue)
+
+1. Your `start.sh` file or `bor.service`, if you're facing some peering issue or unable to use some service (like `http` endpoint) as expected. Moreover, if possible mention the chain configuration printed while starting the node which looks something like `Initialised chain configuration config="{ChainID: 137, ..., Engine: bor}"`
+<!--
+It should be start.sh if you're using bor v0.2.x and bor.service if it's bor v0.3.x. Mention this file if you're facing any issues like unable to use some flag/s according to their expected behaviour.
+-->
+2. The result of `eth.syncing`, `admin.peers.length`, value of the `maxpeers` flag in start.sh, and bootnodes/static nodes (if any) is you're facing some syncing issue. 
+<!--
+You can get the above results by attaching to the IPC using the command `bor attach $BORDIR/bor.ipc` or `bor attach $DATADIR/bor.ipc` and running the mentioned commands. 
+Mention this if you're facing issues where bor keeps stalling and is not importing new blocks or making any progress. Adding chain configuration mentioned in the previous step would also be really helpful here.  
+-->
+3. Your `heimdall-config.toml` parameters (whose ideal location is `~/.heimdalld/config/`) for checking the ETH and BOR RPC url's, incase of issue with bor heimdall communication. 
+<!--
+As a sub-set of syncing issues, if your node keeps printing logs like `Retrying again in 5 seconds to fetch data from Heimdall`, it might be an issue with the communication between your bor node and heimdall node. In this case, also check if all the heimdall services (heimdalld, bridge, rest-server) are running correctly.
+-->
+4. The CURL request (for that specific error) if you're facing any issues or identify a bug while making RPC request.  
+<!--
+Make sure you hide the IP of your machine if you're doing the request externally.  
+-->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -8,10 +8,11 @@ assignees: ''
 
 # Rationale
 
-Why should this feature exist?
+The motivation behind the feature and why should this feature exist?
 What are the use-cases?
 
 # Implementation
 
-Do you have ideas regarding the implementation of this feature?
+Do you have ideas regarding the implementation of this feature? (Mention reference links if any)
+Any alternative solutions or features you've considered?
 Are you willing to implement this feature?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,9 +1,11 @@
 ---
-name: Ask a question
-about: Something is unclear
+name: Question/Support
+about: Ask a question or request support
 title: ''
 labels: 'type:docs'
 assignees: ''
 ---
 
-This should only be used in very rare cases e.g. if you are not 100% sure if something is a bug or asking a question that leads to improving the documentation. For general questions please use [discord](https://discord.gg/nthXNEv) or the Ethereum stack exchange at https://ethereum.stackexchange.com.
+This should only be used in very rare cases e.g. if you are not 100% sure if something is a bug or asking a question that leads to improving the documentation. 
+
+For general questions please join our [discord](https://discord.com/invite/zdwkdvMNY2) server.


### PR DESCRIPTION
This PR updates the github issue templates for bug, feature and question category. 

Checkout these files for preview: [Bug](https://github.com/maticnetwork/bor/blob/manav/POS-628-update-issue-template/.github/ISSUE_TEMPLATE/bug.md), [Feature](https://github.com/maticnetwork/bor/blob/manav/POS-628-update-issue-template/.github/ISSUE_TEMPLATE/feature.md) and [Question](https://github.com/maticnetwork/bor/blob/manav/POS-628-update-issue-template/.github/ISSUE_TEMPLATE/question.md). 

Jira: [POS 628 - Update github issue templates](https://polygon.atlassian.net/browse/POS-628)