### PR TITLE
Remove 'edit' from github CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - "**"
-    types: [opened, synchronize, edited]
+    types: [opened, synchronize]
 
 concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
This change will prevent github workflow from re-running when the description of the PR is editted.