### PR TITLE
Fix "Signer 0x... is not a part of the producer set at block xxxx"

### DIFF
--- a/consensus/bor/snapshot.go
+++ b/consensus/bor/snapshot.go
@@ -59,6 +59,8 @@ func loadSnapshot(config *params.BorConfig, sigcache *lru.ARCCache, db ethdb.Dat
 		return nil, err
 	}
 
+	snap.ValidatorSet.UpdateValidatorMap()
+
 	snap.config = config
 	snap.sigcache = sigcache
 

--- a/consensus/bor/valset/validator_set.go
+++ b/consensus/bor/valset/validator_set.go
@@ -628,6 +628,10 @@ func (vals *ValidatorSet) updateValidators(updates []*Validator, deletes []*Vali
 	vals.applyUpdates(updates)
 	vals.applyRemovals(deletes)
 
+	vals.UpdateValidatorMap()
+}
+
+func (vals *ValidatorSet) UpdateValidatorMap() {
 	vals.validatorsMap = make(map[common.Address]int, len(vals.Validators))
 
 	for i, val := range vals.Validators {


### PR DESCRIPTION
The validator set json loaded from database will have an empty map. This change will recompute the validator map based on validator set.