### PR TITLE
internal/cli, cmd/geth: replaced package naoina/toml with BurntSushi/toml and updated config name-tags

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -17,16 +17,15 @@
 package main
 
 import (
-	"bufio"
-	"errors"
 	"fmt"
+	"io/ioutil"
 	"math/big"
 	"os"
-	"reflect"
 	"time"
-	"unicode"
 
 	"gopkg.in/urfave/cli.v1"
+
+	"github.com/BurntSushi/toml"
 
 	"github.com/ethereum/go-ethereum/accounts/external"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -41,7 +40,6 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/naoina/toml"
 )
 
 var (
@@ -61,28 +59,6 @@ var (
 	}
 )
 
-// These settings ensure that TOML keys use the same names as Go struct fields.
-var tomlSettings = toml.Config{
-	NormFieldName: func(rt reflect.Type, key string) string {
-		return key
-	},
-	FieldToKey: func(rt reflect.Type, field string) string {
-		return field
-	},
-	MissingField: func(rt reflect.Type, field string) error {
-		id := fmt.Sprintf("%s.%s", rt.String(), field)
-		if deprecated(id) {
-			log.Warn("Config field is deprecated and won't have an effect", "name", id)
-			return nil
-		}
-		var link string
-		if unicode.IsUpper(rune(rt.Name()[0])) && rt.PkgPath() != "main" {
-			link = fmt.Sprintf(", see https://godoc.org/%s#%s for available fields", rt.PkgPath(), rt.Name())
-		}
-		return fmt.Errorf("field '%s' is not defined in %s%s", field, rt.String(), link)
-	},
-}
-
 type ethstatsConfig struct {
 	URL string `toml:",omitempty"`
 }
@@ -95,18 +71,17 @@ type gethConfig struct {
 }
 
 func loadConfig(file string, cfg *gethConfig) error {
-	f, err := os.Open(file)
+	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
-	err = tomlSettings.NewDecoder(bufio.NewReader(f)).Decode(cfg)
-	// Add file name to errors that have a line number.
-	if _, ok := err.(*toml.LineError); ok {
-		err = errors.New(file + ", " + err.Error())
+	tomlData := string(data)
+	if _, err = toml.Decode(tomlData, &cfg); err != nil {
+		return err
 	}
-	return err
+
+	return nil
 }
 
 func defaultNodeConfig() node.Config {
@@ -214,21 +189,9 @@ func dumpConfig(ctx *cli.Context) error {
 		comment += "# Note: this config doesn't contain the genesis block.\n\n"
 	}
 
-	out, err := tomlSettings.Marshal(&cfg)
-	if err != nil {
+	if err := toml.NewEncoder(os.Stdout).Encode(&cfg); err != nil {
 		return err
 	}
-
-	dump := os.Stdout
-	if ctx.NArg() > 0 {
-		dump, err = os.OpenFile(ctx.Args().Get(0), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
-		if err != nil {
-			return err
-		}
-		defer dump.Close()
-	}
-	dump.WriteString(comment)
-	dump.Write(out)
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.3.0
+	github.com/BurntSushi/toml v1.1.0
 	github.com/VictoriaMetrics/fastcache v1.6.0
 	github.com/aws/aws-sdk-go-v2 v1.2.0
 	github.com/aws/aws-sdk-go-v2/config v1.1.1
@@ -48,7 +49,6 @@ require (
 	github.com/mitchellh/cli v1.1.2
 	github.com/mitchellh/go-grpc-net-conn v0.0.0-20200427190222-eb030e4876f0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7
 	github.com/prometheus/tsdb v0.7.1
@@ -83,7 +83,6 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 // indirect
-	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
@@ -119,7 +118,6 @@ require (
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/mitchellh/pointerstructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
-	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -374,10 +374,6 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/naoina/go-stringutil v0.1.0 h1:rCUeRUHjBjGTSHl0VC00jUPLz8/F9dDzYI70Hzifhks=
-github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
-github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416 h1:shk/vn9oCoOTmwcouEdwIeOtOGA/ELRUw/GwvxwfT+0=
-github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -459,7 +455,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=

--- a/internal/cli/dumpconfig.go
+++ b/internal/cli/dumpconfig.go
@@ -1,23 +1,23 @@
 package cli
 
 import (
-	"reflect"
+	"os"
 	"strings"
 
-	"github.com/naoina/toml"
+	"github.com/BurntSushi/toml"
 
 	"github.com/ethereum/go-ethereum/internal/cli/server"
 )
 
-// These settings ensure that TOML keys use the same names as Go struct fields.
-var tomlSettings = toml.Config{
-	NormFieldName: func(rt reflect.Type, key string) string {
-		return key
-	},
-	FieldToKey: func(rt reflect.Type, field string) string {
-		return field
-	},
-}
+// // These settings ensure that TOML keys use the same names as Go struct fields.
+// var tomlSettings = toml.Config{
+// 	NormFieldName: func(rt reflect.Type, key string) string {
+// 		return key
+// 	},
+// 	FieldToKey: func(rt reflect.Type, field string) string {
+// 		return field
+// 	},
+// }
 
 // DumpconfigCommand is for exporting user provided flags into a config file
 type DumpconfigCommand struct {
@@ -69,14 +69,12 @@ func (c *DumpconfigCommand) Run(args []string) int {
 	userConfig.Gpo.IgnorePriceRaw = userConfig.Gpo.IgnorePrice.String()
 	userConfig.Cache.RejournalRaw = userConfig.Cache.Rejournal.String()
 
-	// Currently, the configurations (userConfig) is exported into `toml` file format.
-	out, err := tomlSettings.Marshal(&userConfig)
-	if err != nil {
+	// // Currently, the configurations (userConfig) is exported into `toml` file format.
+	// out, err := tomlSettings.Marshal(&userConfig)
+	if err := toml.NewEncoder(os.Stdout).Encode(userConfig); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}
-
-	c.UI.Output(string(out))
 
 	return 0
 }

--- a/internal/cli/dumpconfig.go
+++ b/internal/cli/dumpconfig.go
@@ -9,16 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/internal/cli/server"
 )
 
-// // These settings ensure that TOML keys use the same names as Go struct fields.
-// var tomlSettings = toml.Config{
-// 	NormFieldName: func(rt reflect.Type, key string) string {
-// 		return key
-// 	},
-// 	FieldToKey: func(rt reflect.Type, field string) string {
-// 		return field
-// 	},
-// }
-
 // DumpconfigCommand is for exporting user provided flags into a config file
 type DumpconfigCommand struct {
 	*Meta2
@@ -69,8 +59,6 @@ func (c *DumpconfigCommand) Run(args []string) int {
 	userConfig.Gpo.IgnorePriceRaw = userConfig.Gpo.IgnorePrice.String()
 	userConfig.Cache.RejournalRaw = userConfig.Cache.Rejournal.String()
 
-	// // Currently, the configurations (userConfig) is exported into `toml` file format.
-	// out, err := tomlSettings.Marshal(&userConfig)
 	if err := toml.NewEncoder(os.Stdout).Encode(userConfig); err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -167,7 +167,7 @@ type TxPoolConfig struct {
 	Journal string `hcl:"journal,optional" toml:"journal,optional"`
 
 	// Rejournal is the time interval to regenerate the local transaction journal
-	Rejournal    time.Duration `hcl:"-,optional" toml:"-,optional"`
+	Rejournal    time.Duration `hcl:"-,optional" toml:"-"`
 	RejournalRaw string        `hcl:"rejournal,optional" toml:"rejournal,optional"`
 
 	// PriceLimit is the minimum gas price to enforce for acceptance into the pool
@@ -189,7 +189,7 @@ type TxPoolConfig struct {
 	GlobalQueue uint64 `hcl:"globalqueue,optional" toml:"globalqueue,optional"`
 
 	// lifetime is the maximum amount of time non-executable transaction are queued
-	LifeTime    time.Duration `hcl:"-,optional" toml:"-,optional"`
+	LifeTime    time.Duration `hcl:"-,optional" toml:"-"`
 	LifeTimeRaw string        `hcl:"lifetime,optional" toml:"lifetime,optional"`
 }
 
@@ -207,7 +207,7 @@ type SealerConfig struct {
 	GasCeil uint64 `hcl:"gaslimit,optional" toml:"gaslimit,optional"`
 
 	// GasPrice is the minimum gas price for mining a transaction
-	GasPrice    *big.Int `hcl:"-,optional" toml:"-,optional"`
+	GasPrice    *big.Int `hcl:"-,optional" toml:"-"`
 	GasPriceRaw string   `hcl:"gasprice,optional" toml:"gasprice,optional"`
 }
 
@@ -270,11 +270,11 @@ type GpoConfig struct {
 	Percentile uint64 `hcl:"percentile,optional" toml:"percentile,optional"`
 
 	// MaxPrice is an upper bound gas price
-	MaxPrice    *big.Int `hcl:"-,optional" toml:"-,optional"`
+	MaxPrice    *big.Int `hcl:"-,optional" toml:"-"`
 	MaxPriceRaw string   `hcl:"maxprice,optional" toml:"maxprice,optional"`
 
 	// IgnorePrice is a lower bound gas price
-	IgnorePrice    *big.Int `hcl:"-,optional" toml:"-,optional"`
+	IgnorePrice    *big.Int `hcl:"-,optional" toml:"-"`
 	IgnorePriceRaw string   `hcl:"ignoreprice,optional" toml:"ignoreprice,optional"`
 }
 
@@ -347,7 +347,7 @@ type CacheConfig struct {
 	Journal string `hcl:"journal,optional" toml:"journal,optional"`
 
 	// Rejournal is the time interval to regenerate the journal for clean cache
-	Rejournal    time.Duration `hcl:"-,optional" toml:"-,optional"`
+	Rejournal    time.Duration `hcl:"-,optional" toml:"-"`
 	RejournalRaw string        `hcl:"rejournal,optional" toml:"rejournal,optional"`
 
 	// NoPrefetch is used to disable prefetch of tries

--- a/internal/cli/server/config_legacy_test.go
+++ b/internal/cli/server/config_legacy_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestConfigLegacy(t *testing.T) {
@@ -71,8 +72,8 @@ func TestConfigLegacy(t *testing.T) {
 			Gpo: &GpoConfig{
 				Blocks:      20,
 				Percentile:  60,
-				MaxPrice:    big.NewInt(100),
-				IgnorePrice: big.NewInt(2),
+				MaxPrice:    big.NewInt(5000 * params.GWei),
+				IgnorePrice: big.NewInt(4),
 			},
 			JsonRPC: &JsonRPCConfig{
 				IPCDisable: false,
@@ -129,7 +130,7 @@ func TestConfigLegacy(t *testing.T) {
 				PercGc:        25,
 				PercSnapshot:  10,
 				Journal:       "triecache",
-				Rejournal:     1 * time.Hour,
+				Rejournal:     1 * time.Second,
 				NoPrefetch:    false,
 				Preimages:     false,
 				TxLookupLimit: 2350000,

--- a/internal/cli/server/testdata/test.toml
+++ b/internal/cli/server/testdata/test.toml
@@ -8,7 +8,6 @@ maxpeers = 30
 
 [txpool]
 locals = []
-rejournal = "1h0m0s"
 lifetime = "1s"
 
 [miner]
@@ -17,9 +16,8 @@ gaslimit = 20000000
 gasprice = "30000000000"
 
 [gpo]
-maxprice = "100"
-ignoreprice = "2"
+ignoreprice = "4"
 
 [cache]
 cache = 1024
-rejournal = "1h0m0s"
+rejournal = "1s"


### PR DESCRIPTION
This PR,

- Replaced the `naoina/toml` package in `dumpconfig` with `BurntSushi/toml` package.
- Updated the toml name tags for the raw field types in the config structure.
- Updated/modified tests accordingly.
- Replaced the `naoina/toml` package in `cmd/geth/config.go` with `BurntSushi/toml` package.

[Jira Task Link](https://polygon.atlassian.net/browse/POS-687)