### PR TITLE
tests: use better way to find available ports

### DIFF
--- a/internal/cli/server/helper.go
+++ b/internal/cli/server/helper.go
@@ -5,30 +5,18 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"sync/atomic"
 	"time"
 )
 
-var maxPortCheck int32 = 100
-
-// findAvailablePort returns the next available port starting from `from`
-func findAvailablePort(from int32, count int32) (int32, error) {
-	if count == maxPortCheck {
-		return 0, fmt.Errorf("no available port found")
+// findAvailablePort returns the next available port
+func findAvailablePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
 	}
+	defer l.Close()
 
-	port := atomic.AddInt32(&from, 1)
-	addr := fmt.Sprintf("localhost:%d", port)
-
-	count++
-
-	lis, err := net.Listen("tcp", addr)
-	if err == nil {
-		lis.Close()
-		return port, nil
-	} else {
-		return findAvailablePort(from, count)
-	}
+	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
 func CreateMockServer(config *Config) (*Server, error) {
@@ -39,13 +27,7 @@ func CreateMockServer(config *Config) (*Server, error) {
 	// find available port for grpc server
 	rand.Seed(time.Now().UnixNano())
 
-	var (
-		from int32 = 60000 // the min port to start checking from
-		to   int32 = 61000 // the max port to start checking from
-	)
-
-	//nolint: gosec
-	port, err := findAvailablePort(rand.Int31n(to-from+1)+from, 0)
+	port, err := findAvailablePort()
 	if err != nil {
 		return nil, err
 	}
@@ -57,12 +39,7 @@ func CreateMockServer(config *Config) (*Server, error) {
 	datadir, _ := os.MkdirTemp("/tmp", "bor-cli-test")
 	config.DataDir = datadir
 
-	// find available port for http server
-	from = 8545
-	to = 9545
-
-	//nolint: gosec
-	port, err = findAvailablePort(rand.Int31n(to-from+1)+from, 0)
+	port, err = findAvailablePort()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR implements a simple and better version of finding next available ports for testing (creating mock servers). 