### PR TITLE
internal/cli/server: disable bor wallet flag by default

### DIFF
--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -507,7 +507,7 @@ func DefaultConfig() *Config {
 			PasswordFile:        "",
 			AllowInsecureUnlock: false,
 			UseLightweightKDF:   false,
-			DisableBorWallet:    false,
+			DisableBorWallet:    true,
 		},
 		GRPC: &GRPCConfig{
 			Addr: ":3131",


### PR DESCRIPTION
This PR disables personal endpoints by default in the new-cli. 