### PR TITLE
Fix EOF error in gRPC state-sync

### DIFF
--- a/consensus/bor/heimdallgrpc/state_sync.go
+++ b/consensus/bor/heimdallgrpc/state_sync.go
@@ -2,6 +2,7 @@ package heimdallgrpc
 
 import (
 	"context"
+	"io"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/bor/clerk"
@@ -25,8 +26,12 @@ func (h *HeimdallGRPCClient) StateSyncEvents(ctx context.Context, fromID uint64,
 
 	for {
 		events, err := res.Recv()
+		if err == io.EOF {
+			return eventRecords, nil
+		}
+
 		if err != nil {
-			break
+			return nil, err
 		}
 
 		for _, event := range events.Result {
@@ -44,6 +49,4 @@ func (h *HeimdallGRPCClient) StateSyncEvents(ctx context.Context, fromID uint64,
 			eventRecords = append(eventRecords, eventRecord)
 		}
 	}
-
-	return eventRecords, nil
 }

--- a/consensus/bor/heimdallgrpc/state_sync.go
+++ b/consensus/bor/heimdallgrpc/state_sync.go
@@ -56,6 +56,4 @@ func (h *HeimdallGRPCClient) StateSyncEvents(ctx context.Context, fromID uint64,
 			eventRecords = append(eventRecords, eventRecord)
 		}
 	}
-
-	return eventRecords, nil
 }


### PR DESCRIPTION
This change should fix the issue where we might end up processing partial number of event records in case of an error in gRPC client - server streaming.

It will only return records when there is an EOF from server side, Which means all the records are processed, If there is any other error than EOF, It should return the error and no records (nil).

Reference : https://grpc.io/docs/languages/go/basics/#client-side-streaming-rpc

https://polygon.atlassian.net/browse/POS-718