### PR TITLE
eth, cli: prevent snap sync mode migration - v0.3.x

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1621,6 +1621,13 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 
 	if ctx.GlobalIsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)
+
+		// To be extra preventive, we won't allow the node to start
+		// in snap sync mode until we have it working
+		// TODO(snap): Comment when we have snap sync working
+		if cfg.SyncMode == downloader.SnapSync {
+			cfg.SyncMode = downloader.FullSync
+		}
 	}
 	if ctx.GlobalIsSet(NetworkIdFlag.Name) {
 		cfg.NetworkId = ctx.GlobalUint64(NetworkIdFlag.Name)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -162,8 +162,15 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		// In these cases however it's safe to reenable snap sync.
 		fullBlock, fastBlock := h.chain.CurrentBlock(), h.chain.CurrentFastBlock()
 		if fullBlock.NumberU64() == 0 && fastBlock.NumberU64() > 0 {
-			h.snapSync = uint32(1)
-			log.Warn("Switch sync mode from full sync to snap sync")
+			// Note: Ideally this should never happen with bor, but to be extra
+			// preventive we won't allow it to roll over to snap sync until
+			// we have it working
+
+			// TODO(snap): Uncomment when we have snap sync working
+			// h.snapSync = uint32(1)
+			// log.Warn("Switch sync mode from full sync to snap sync")
+
+			log.Warn("Preventing switching sync mode from full sync to snap sync")
 		}
 	} else {
 		if h.chain.CurrentBlock().NumberU64() > 0 {

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -850,6 +850,7 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 	case "snap":
 		// n.SyncMode = downloader.SnapSync // TODO(snap): Uncomment when we have snap sync working
 		n.SyncMode = downloader.FullSync
+
 		log.Warn("Bor doesn't support Snap Sync yet, switching to Full Sync mode")
 	default:
 		return nil, fmt.Errorf("sync mode '%s' not found", c.SyncMode)

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -848,7 +848,9 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 	case "full":
 		n.SyncMode = downloader.FullSync
 	case "snap":
-		n.SyncMode = downloader.SnapSync
+		// n.SyncMode = downloader.SnapSync // TODO(snap): Uncomment when we have snap sync working
+		n.SyncMode = downloader.FullSync
+		log.Warn("Bor doesn't support Snap Sync yet, switching to Full Sync mode")
 	default:
 		return nil, fmt.Errorf("sync mode '%s' not found", c.SyncMode)
 	}


### PR DESCRIPTION
We've seen a couple of scenarios where some of our internal nodes have migrated to snap sync mode. Until we make it working fully, this PR will prevent that from happening. 

It adds a preventive layer in the cli (old and new both) so that it's not enabled through flag and also handles cases where is migrates to snap sync. 