### PR TITLE
eth, cli: prevent snap sync mode migration - v0.2.x

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1620,6 +1620,13 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 
 	if ctx.GlobalIsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)
+
+		// To be extra preventive, we won't allow the node to start
+		// in snap sync mode until we have it working
+		// TODO(snap): Comment when we have snap sync working
+		if cfg.SyncMode == downloader.SnapSync {
+			cfg.SyncMode = downloader.FullSync
+		}
 	}
 	if ctx.GlobalIsSet(NetworkIdFlag.Name) {
 		cfg.NetworkId = ctx.GlobalUint64(NetworkIdFlag.Name)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -155,8 +155,15 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		// In these cases however it's safe to reenable snap sync.
 		fullBlock, fastBlock := h.chain.CurrentBlock(), h.chain.CurrentFastBlock()
 		if fullBlock.NumberU64() == 0 && fastBlock.NumberU64() > 0 {
-			h.snapSync = uint32(1)
-			log.Warn("Switch sync mode from full sync to snap sync")
+			// Note: Ideally this should never happen with bor, but to be extra
+			// preventive we won't allow it to roll over to snap sync until
+			// we have it working
+
+			// TODO(snap): Uncomment when we have snap sync working
+			// h.snapSync = uint32(1)
+			// log.Warn("Switch sync mode from full sync to snap sync")
+
+			log.Warn("Preventing switching sync mode from full sync to snap sync")
 		}
 	} else {
 		if h.chain.CurrentBlock().NumberU64() > 0 {

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -204,25 +204,36 @@ func peerToSyncOp(mode downloader.SyncMode, p *eth.Peer) *chainSyncOp {
 }
 
 func (cs *chainSyncer) modeAndLocalHead() (downloader.SyncMode, *big.Int) {
-	// If we're in snap sync mode, return that directly
-	if atomic.LoadUint32(&cs.handler.snapSync) == 1 {
-		block := cs.handler.chain.CurrentFastBlock()
-		td := cs.handler.chain.GetTd(block.Hash(), block.NumberU64())
-		return downloader.SnapSync, td
-	}
-	// We are probably in full sync, but we might have rewound to before the
-	// snap sync pivot, check if we should reenable
-	if pivot := rawdb.ReadLastPivotNumber(cs.handler.database); pivot != nil {
-		if head := cs.handler.chain.CurrentBlock(); head.NumberU64() < *pivot {
-			block := cs.handler.chain.CurrentFastBlock()
-			td := cs.handler.chain.GetTd(block.Hash(), block.NumberU64())
-			return downloader.SnapSync, td
-		}
-	}
-	// Nope, we're really full syncing
+	// Note: Ideally this should never happen with bor, but to be extra
+	// preventive we won't allow it to roll over to snap sync until
+	// we have it working
+
+	// Handle full sync mode only
 	head := cs.handler.chain.CurrentBlock()
 	td := cs.handler.chain.GetTd(head.Hash(), head.NumberU64())
 	return downloader.FullSync, td
+
+	// TODO(snap): Uncomment when we have snap sync working
+
+	// If we're in snap sync mode, return that directly
+	// if atomic.LoadUint32(&cs.handler.snapSync) == 1 {
+	// 	block := cs.handler.chain.CurrentFastBlock()
+	// 	td := cs.handler.chain.GetTd(block.Hash(), block.NumberU64())
+	// 	return downloader.SnapSync, td
+	// }
+	// // We are probably in full sync, but we might have rewound to before the
+	// // snap sync pivot, check if we should reenable
+	// if pivot := rawdb.ReadLastPivotNumber(cs.handler.database); pivot != nil {
+	// 	if head := cs.handler.chain.CurrentBlock(); head.NumberU64() < *pivot {
+	// 		block := cs.handler.chain.CurrentFastBlock()
+	// 		td := cs.handler.chain.GetTd(block.Hash(), block.NumberU64())
+	// 		return downloader.SnapSync, td
+	// 	}
+	// }
+	// // Nope, we're really full syncing
+	// head := cs.handler.chain.CurrentBlock()
+	// td := cs.handler.chain.GetTd(head.Hash(), head.NumberU64())
+	// return downloader.FullSync, td
 }
 
 // startSync launches doSync in a new goroutine.


### PR DESCRIPTION
We've seen a couple of scenarios where some of our internal nodes have migrated to snap sync mode. Until we make it working fully, this PR will prevent that from happening.

It adds a preventive layer in the cli (old one) so that it's not enabled through flag and also handles cases where is migrates to snap sync.