### PR TITLE
eth: fix whitelist/requiredblocks regression - v0.2.x

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -425,7 +425,7 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 		}()
 	}
 	// If we have any explicit peer required block hashes, request them
-	for number := range h.peerRequiredBlocks {
+	for number, hash := range h.peerRequiredBlocks {
 		resCh := make(chan *eth.Response)
 		if _, err := peer.RequestHeadersByNumber(number, 1, 0, false, resCh); err != nil {
 			return err


### PR DESCRIPTION
This PR fixes a bug in checking blocks (and hash) set using the `--requiredblocks` flag in the old cli. 

Reference: https://github.com/ethereum/go-ethereum/pull/24817

Jira - [[v0.2.16 and v0.3.0] Required block mismatch when whitelist blocks are provided](https://polygon.atlassian.net/browse/POS-726)