### PR TITLE
Changing default txpool pricelimit to 1

### DIFF
--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -425,7 +425,7 @@ func DefaultConfig() *Config {
 			NoLocals:     false,
 			Journal:      "",
 			Rejournal:    1 * time.Hour,
-			PriceLimit:   30000000000,
+			PriceLimit:   1,
 			PriceBump:    10,
 			AccountSlots: 16,
 			GlobalSlots:  32768,

--- a/internal/cli/server/config_legacy_test.go
+++ b/internal/cli/server/config_legacy_test.go
@@ -54,7 +54,7 @@ func TestConfigLegacy(t *testing.T) {
 				NoLocals:     false,
 				Journal:      "",
 				Rejournal:    1 * time.Hour,
-				PriceLimit:   30000000000,
+				PriceLimit:   1,
 				PriceBump:    10,
 				AccountSlots: 16,
 				GlobalSlots:  32768,


### PR DESCRIPTION
Prior to this PR, 
Bor client running on ^v0.3.0 were setting 30Gwei  as default txpool.pricelimit which was not suitable for mumbai testnet. 

In this PR, the bor client will set 1 wei as default txpool.pricelimit. 