### PR TITLE
consensus/bor: remove snapshot found log in bor consensus

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -552,8 +552,6 @@ func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash co
 		number, hash = number-1, header.ParentHash
 	}
 
-	log.Info("Snapshot has been found in", "headers depth", len(headers))
-
 	// check if snapshot is nil
 	if snap == nil {
 		return nil, fmt.Errorf("unknown error while retrieving snapshot at block number %v", number)


### PR DESCRIPTION
This PR removes the log which was added in the `snapshot()` function in bor consensus added to check the ideal capacity for the slice. 