### PR TITLE
Remove orphaned containers when shutdown devnet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           if: always()
           run: |
             cd matic-cli/devnet
-            docker compose down
+            docker compose down --remove-orphans
             cd -
             mkdir -p ${{ github.run_id }}/matic-cli
             sudo mv bor ${{ github.run_id }}


### PR DESCRIPTION
This will potentially resolve "ERROR: network docker_default has active endpoints" problem.