### PR TITLE
rpc, ethclient: cater 'finalized' and 'safe' blocks in ethclient

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -96,15 +96,6 @@ func (ec *Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.Bl
 	return ec.getBlock(ctx, "eth_getBlockByNumber", toBlockNumArg(number), true)
 }
 
-// BlockByNumber returns a block from the current canonical chain without transactions.
-// If number is nil, the latest known block is returned.
-//
-// Note that loading full blocks requires two requests. Use HeaderByNumber
-// if you don't need all transactions or uncle headers.
-func (ec *Client) BlockByNumberWithoutTx(ctx context.Context, number *big.Int) (*types.Block, error) {
-	return ec.getBlock(ctx, "eth_getBlockByNumber", toBlockNumArg(number), false)
-}
-
 // BlockNumber returns the most recent block number
 func (ec *Client) BlockNumber(ctx context.Context) (uint64, error) {
 	var result hexutil.Uint64

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -96,6 +96,15 @@ func (ec *Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.Bl
 	return ec.getBlock(ctx, "eth_getBlockByNumber", toBlockNumArg(number), true)
 }
 
+// BlockByNumber returns a block from the current canonical chain without transactions.
+// If number is nil, the latest known block is returned.
+//
+// Note that loading full blocks requires two requests. Use HeaderByNumber
+// if you don't need all transactions or uncle headers.
+func (ec *Client) BlockByNumberWithoutTx(ctx context.Context, number *big.Int) (*types.Block, error) {
+	return ec.getBlock(ctx, "eth_getBlockByNumber", toBlockNumArg(number), false)
+}
+
 // BlockNumber returns the most recent block number
 func (ec *Client) BlockNumber(ctx context.Context) (uint64, error) {
 	var result hexutil.Uint64
@@ -536,6 +545,14 @@ func toBlockNumArg(number *big.Int) string {
 	pending := big.NewInt(-1)
 	if number.Cmp(pending) == 0 {
 		return "pending"
+	}
+	finalized := big.NewInt(int64(rpc.FinalizedBlockNumber))
+	if number.Cmp(finalized) == 0 {
+		return "finalized"
+	}
+	safe := big.NewInt(int64(rpc.SafeBlockNumber))
+	if number.Cmp(safe) == 0 {
+		return "safe"
 	}
 	return hexutil.EncodeBig(number)
 }

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -187,6 +187,14 @@ func toBlockNumArg(number *big.Int) string {
 	if number.Cmp(pending) == 0 {
 		return "pending"
 	}
+	finalized := big.NewInt(int64(rpc.FinalizedBlockNumber))
+	if number.Cmp(finalized) == 0 {
+		return "finalized"
+	}
+	safe := big.NewInt(int64(rpc.SafeBlockNumber))
+	if number.Cmp(safe) == 0 {
+		return "safe"
+	}
 	return hexutil.EncodeBig(number)
 }
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -61,9 +61,11 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
-	PendingBlockNumber  = BlockNumber(-2)
-	LatestBlockNumber   = BlockNumber(-1)
-	EarliestBlockNumber = BlockNumber(0)
+	SafeBlockNumber      = BlockNumber(-4)
+	FinalizedBlockNumber = BlockNumber(-3)
+	PendingBlockNumber   = BlockNumber(-2)
+	LatestBlockNumber    = BlockNumber(-1)
+	EarliestBlockNumber  = BlockNumber(0)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:


### PR DESCRIPTION
This PR adds new block type for "finalized and "safe" blocks to honour the post-merge API modifications. 

The purpose behind this change is to consume this client in heimdall for L1 communication i.e. ethereum mainnet and goerli test network which are already following these notions. 

Reference implementation from geth: https://github.com/ethereum/go-ethereum/pull/24282, https://github.com/ethereum/go-ethereum/pull/25165, https://github.com/ethereum/go-ethereum/pull/25580. 

NOTE: This by no means adds/serves "finalized" or "safe" blocks from bor. 