### PR TITLE
 Failing geth integration tests

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -42,8 +42,10 @@ The state transitioning model does all the necessary work to work out a valid ne
 3) Create a new state object if the recipient is \0*32
 4) Value transfer
 == If contract creation ==
-  4a) Attempt to run transaction data
-  4b) If valid, use result as code for the new state object
+
+	4a) Attempt to run transaction data
+	4b) If valid, use result as code for the new state object
+
 == end ==
 5) Run Script section
 6) Derive new state root
@@ -262,13 +264,13 @@ func (st *StateTransition) preCheck() error {
 // TransitionDb will transition the state by applying the current message and
 // returning the evm execution result with following fields.
 //
-// - used gas:
-//      total gas used (including gas being refunded)
-// - returndata:
-//      the returned data from evm
-// - concrete execution error:
-//      various **EVM** error which aborts the execution,
-//      e.g. ErrOutOfGas, ErrExecutionReverted
+//   - used gas:
+//     total gas used (including gas being refunded)
+//   - returndata:
+//     the returned data from evm
+//   - concrete execution error:
+//     various **EVM** error which aborts the execution,
+//     e.g. ErrOutOfGas, ErrExecutionReverted
 //
 // However if any consensus issue encountered, return the error directly with
 // nil evm execution result.

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -50,7 +50,7 @@ func TestBlockchain(t *testing.T) {
 	// using 4.6 TGas
 	bt.skipLoad(`.*randomStatetest94.json.*`)
 
-	// FIXME POS-618
+	// See POS-618
 	bt.skipLoad(`.*ValidBlocks*`)
 	bt.skipLoad(`.*InvalidBlocks*`)
 	bt.skipLoad(`.*TransitionTests*`)

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -53,7 +53,7 @@ func TestBlockchain(t *testing.T) {
 	// FIXME POS-618
 	bt.skipLoad(`.*ValidBlocks*`)
 	bt.skipLoad(`.*InvalidBlocks*`)
-	//bt.skipLoad(`.*TransitionTests*`)
+	bt.skipLoad(`.*TransitionTests*`)
 
 	bt.walk(t, blockTestDir, func(t *testing.T, name string, test *BlockTest) {
 		if err := bt.checkFailure(t, test.Run(false)); err != nil {

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -51,9 +51,9 @@ func TestBlockchain(t *testing.T) {
 	bt.skipLoad(`.*randomStatetest94.json.*`)
 
 	// FIXME POS-618
-	bt.skipLoad(`.*ValidBlocks*`)
-	bt.skipLoad(`.*InvalidBlocks*`)
-	bt.skipLoad(`.*TransitionTests*`)
+	//bt.skipLoad(`.*ValidBlocks*`)
+	//bt.skipLoad(`.*InvalidBlocks*`)
+	//bt.skipLoad(`.*TransitionTests*`)
 
 	bt.walk(t, blockTestDir, func(t *testing.T, name string, test *BlockTest) {
 		if err := bt.checkFailure(t, test.Run(false)); err != nil {

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -51,8 +51,8 @@ func TestBlockchain(t *testing.T) {
 	bt.skipLoad(`.*randomStatetest94.json.*`)
 
 	// FIXME POS-618
-	//bt.skipLoad(`.*ValidBlocks*`)
-	//bt.skipLoad(`.*InvalidBlocks*`)
+	bt.skipLoad(`.*ValidBlocks*`)
+	bt.skipLoad(`.*InvalidBlocks*`)
 	//bt.skipLoad(`.*TransitionTests*`)
 
 	bt.walk(t, blockTestDir, func(t *testing.T, name string, test *BlockTest) {

--- a/tests/init.go
+++ b/tests/init.go
@@ -28,15 +28,18 @@ import (
 var Forks = map[string]*params.ChainConfig{
 	"Frontier": {
 		ChainID: big.NewInt(1),
+		Bor:     params.BorUnittestChainConfig.Bor,
 	},
 	"Homestead": {
 		ChainID:        big.NewInt(1),
 		HomesteadBlock: big.NewInt(0),
+		Bor:            params.BorUnittestChainConfig.Bor,
 	},
 	"EIP150": {
 		ChainID:        big.NewInt(1),
 		HomesteadBlock: big.NewInt(0),
 		EIP150Block:    big.NewInt(0),
+		Bor:            params.BorUnittestChainConfig.Bor,
 	},
 	"EIP158": {
 		ChainID:        big.NewInt(1),
@@ -44,6 +47,7 @@ var Forks = map[string]*params.ChainConfig{
 		EIP150Block:    big.NewInt(0),
 		EIP155Block:    big.NewInt(0),
 		EIP158Block:    big.NewInt(0),
+		Bor:            params.BorUnittestChainConfig.Bor,
 	},
 	"Byzantium": {
 		ChainID:        big.NewInt(1),
@@ -53,6 +57,7 @@ var Forks = map[string]*params.ChainConfig{
 		EIP158Block:    big.NewInt(0),
 		DAOForkBlock:   big.NewInt(0),
 		ByzantiumBlock: big.NewInt(0),
+		Bor:            params.BorUnittestChainConfig.Bor,
 	},
 	"Constantinople": {
 		ChainID:             big.NewInt(1),
@@ -64,6 +69,7 @@ var Forks = map[string]*params.ChainConfig{
 		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(10000000),
+		Bor:                 params.BorUnittestChainConfig.Bor,
 	},
 	"ConstantinopleFix": {
 		ChainID:             big.NewInt(1),
@@ -75,6 +81,7 @@ var Forks = map[string]*params.ChainConfig{
 		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
+		Bor:                 params.BorUnittestChainConfig.Bor,
 	},
 	"Istanbul": {
 		ChainID:             big.NewInt(1),
@@ -87,21 +94,25 @@ var Forks = map[string]*params.ChainConfig{
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
+		Bor:                 params.BorUnittestChainConfig.Bor,
 	},
 	"FrontierToHomesteadAt5": {
 		ChainID:        big.NewInt(1),
 		HomesteadBlock: big.NewInt(5),
+		Bor:            params.BorUnittestChainConfig.Bor,
 	},
 	"HomesteadToEIP150At5": {
 		ChainID:        big.NewInt(1),
 		HomesteadBlock: big.NewInt(0),
 		EIP150Block:    big.NewInt(5),
+		Bor:            params.BorUnittestChainConfig.Bor,
 	},
 	"HomesteadToDaoAt5": {
 		ChainID:        big.NewInt(1),
 		HomesteadBlock: big.NewInt(0),
 		DAOForkBlock:   big.NewInt(5),
 		DAOForkSupport: true,
+		Bor:            params.BorUnittestChainConfig.Bor,
 	},
 	"EIP158ToByzantiumAt5": {
 		ChainID:        big.NewInt(1),
@@ -110,6 +121,7 @@ var Forks = map[string]*params.ChainConfig{
 		EIP155Block:    big.NewInt(0),
 		EIP158Block:    big.NewInt(0),
 		ByzantiumBlock: big.NewInt(5),
+		Bor:            params.BorUnittestChainConfig.Bor,
 	},
 	"ByzantiumToConstantinopleAt5": {
 		ChainID:             big.NewInt(1),
@@ -119,6 +131,7 @@ var Forks = map[string]*params.ChainConfig{
 		EIP158Block:         big.NewInt(0),
 		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: big.NewInt(5),
+		Bor:                 params.BorUnittestChainConfig.Bor,
 	},
 	"ByzantiumToConstantinopleFixAt5": {
 		ChainID:             big.NewInt(1),
@@ -129,6 +142,7 @@ var Forks = map[string]*params.ChainConfig{
 		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: big.NewInt(5),
 		PetersburgBlock:     big.NewInt(5),
+		Bor:                 params.BorUnittestChainConfig.Bor,
 	},
 	"ConstantinopleFixToIstanbulAt5": {
 		ChainID:             big.NewInt(1),
@@ -140,6 +154,7 @@ var Forks = map[string]*params.ChainConfig{
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(5),
+		Bor:                 params.BorUnittestChainConfig.Bor,
 	},
 	"Berlin": {
 		ChainID:             big.NewInt(1),
@@ -153,6 +168,7 @@ var Forks = map[string]*params.ChainConfig{
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
+		Bor:                 params.BorUnittestChainConfig.Bor,
 	},
 	"BerlinToLondonAt5": {
 		ChainID:             big.NewInt(1),
@@ -167,6 +183,7 @@ var Forks = map[string]*params.ChainConfig{
 		MuirGlacierBlock:    big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(5),
+		Bor:                 params.BorUnittestChainConfig.Bor,
 	},
 	"London": {
 		ChainID:             big.NewInt(1),
@@ -181,6 +198,7 @@ var Forks = map[string]*params.ChainConfig{
 		MuirGlacierBlock:    big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
+		Bor:                 params.BorUnittestChainConfig.Bor,
 	},
 	"ArrowGlacier": {
 		ChainID:             big.NewInt(1),
@@ -196,6 +214,7 @@ var Forks = map[string]*params.ChainConfig{
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   big.NewInt(0),
+		Bor:                 params.BorUnittestChainConfig.Bor,
 	},
 }
 

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -59,7 +59,7 @@ func TestState(t *testing.T) {
 	st.skipLoad(`^stStaticCall/static_Call1MB`)
 
 	// FIXME POS-618
-	st.skipLoad(`.*micro/*`)
+	/*st.skipLoad(`.*micro/*`)
 	st.skipLoad(`.*main/*`)
 	st.skipLoad(`.*stSStoreTest*`)
 	st.skipLoad(`.*stReturnDataTest*`)
@@ -115,6 +115,7 @@ func TestState(t *testing.T) {
 	st.skipLoad(`.*stBadOpcode*`)
 	st.skipLoad(`.*stStackTests*`)
 	st.skipLoad(`.*stAttackTest*`)
+	*/
 
 	// Broken tests:
 	// Expected failures:

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -59,8 +59,8 @@ func TestState(t *testing.T) {
 	st.skipLoad(`^stStaticCall/static_Call1MB`)
 
 	// FIXME POS-618
-	/*st.skipLoad(`.*micro/*`)
-	st.skipLoad(`.*main/*`)
+	//st.skipLoad(`.*micro/*`)
+	//st.skipLoad(`.*main/*`)
 	st.skipLoad(`.*stSStoreTest*`)
 	st.skipLoad(`.*stReturnDataTest*`)
 	st.skipLoad(`.*stShift*`)
@@ -115,7 +115,6 @@ func TestState(t *testing.T) {
 	st.skipLoad(`.*stBadOpcode*`)
 	st.skipLoad(`.*stStackTests*`)
 	st.skipLoad(`.*stAttackTest*`)
-	*/
 
 	// Broken tests:
 	// Expected failures:

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -58,7 +58,7 @@ func TestState(t *testing.T) {
 	// Uses 1GB RAM per tested fork
 	st.skipLoad(`^stStaticCall/static_Call1MB`)
 
-	// FIXME POS-618
+	// See POS-618
 	st.skipLoad(`.*micro/*`)
 	st.skipLoad(`.*main/*`)
 	st.skipLoad(`.*stSStoreTest*`)
@@ -97,7 +97,6 @@ func TestState(t *testing.T) {
 	st.skipLoad(`.*stChangedEIP150*`)
 	st.skipLoad(`.*stLogTests*`)
 	st.skipLoad(`.*stSLoadTest*`)
-	//st.skipLoad(`.*stCreateTest*`)
 	st.skipLoad(`.*stDelegatecallTestHomestead*`)
 	st.skipLoad(`.*stCallDelegateCodesHomestead*`)
 	st.skipLoad(`.*VMTests*`)

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -59,8 +59,8 @@ func TestState(t *testing.T) {
 	st.skipLoad(`^stStaticCall/static_Call1MB`)
 
 	// FIXME POS-618
-	//st.skipLoad(`.*micro/*`)
-	//st.skipLoad(`.*main/*`)
+	st.skipLoad(`.*micro/*`)
+	st.skipLoad(`.*main/*`)
 	st.skipLoad(`.*stSStoreTest*`)
 	st.skipLoad(`.*stReturnDataTest*`)
 	st.skipLoad(`.*stShift*`)
@@ -97,7 +97,7 @@ func TestState(t *testing.T) {
 	st.skipLoad(`.*stChangedEIP150*`)
 	st.skipLoad(`.*stLogTests*`)
 	st.skipLoad(`.*stSLoadTest*`)
-	st.skipLoad(`.*stCreateTest*`)
+	//st.skipLoad(`.*stCreateTest*`)
 	st.skipLoad(`.*stDelegatecallTestHomestead*`)
 	st.skipLoad(`.*stCallDelegateCodesHomestead*`)
 	st.skipLoad(`.*VMTests*`)


### PR DESCRIPTION
This PR un-skips a geth integration test and also fixes a minor bug encountered while running the tests. Initially, this PR was meant to trigger CI by "un-skipping"  failing integration tests  and verify whether these are related to Bor's implementation. 

Ref: https://polygon.atlassian.net/browse/POS-618