### PR TITLE
rpc, ethclient: cater 'finalized' and 'safe' blocks in ethclient (v0.3.x)

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -537,6 +537,14 @@ func toBlockNumArg(number *big.Int) string {
 	if number.Cmp(pending) == 0 {
 		return "pending"
 	}
+	finalized := big.NewInt(int64(rpc.FinalizedBlockNumber))
+	if number.Cmp(finalized) == 0 {
+		return "finalized"
+	}
+	safe := big.NewInt(int64(rpc.SafeBlockNumber))
+	if number.Cmp(safe) == 0 {
+		return "safe"
+	}
 	return hexutil.EncodeBig(number)
 }
 

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -187,6 +187,14 @@ func toBlockNumArg(number *big.Int) string {
 	if number.Cmp(pending) == 0 {
 		return "pending"
 	}
+	finalized := big.NewInt(int64(rpc.FinalizedBlockNumber))
+	if number.Cmp(finalized) == 0 {
+		return "finalized"
+	}
+	safe := big.NewInt(int64(rpc.SafeBlockNumber))
+	if number.Cmp(safe) == 0 {
+		return "safe"
+	}
 	return hexutil.EncodeBig(number)
 }
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -61,9 +61,11 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
-	PendingBlockNumber  = BlockNumber(-2)
-	LatestBlockNumber   = BlockNumber(-1)
-	EarliestBlockNumber = BlockNumber(0)
+	SafeBlockNumber      = BlockNumber(-4)
+	FinalizedBlockNumber = BlockNumber(-3)
+	PendingBlockNumber   = BlockNumber(-2)
+	LatestBlockNumber    = BlockNumber(-1)
+	EarliestBlockNumber  = BlockNumber(0)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:


### PR DESCRIPTION
This PR cherry picks commits from https://github.com/maticnetwork/bor/pull/517 PR which was done for v0.2.18-candidate. 

-----

This PR adds new block type for "finalized and "safe" blocks to honour the post-merge API modifications.

The purpose behind this change is to consume this client in heimdall for L1 communication i.e. ethereum mainnet and goerli test network which are already following these notions.

Reference implementation from geth: https://github.com/ethereum/go-ethereum/pull/24282, https://github.com/ethereum/go-ethereum/pull/25165, https://github.com/ethereum/go-ethereum/pull/25580.

NOTE: This by no means adds/serves "finalized" or "safe" blocks from bor.