### PR TITLE
internal/cli/server: fix flag behaviour

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -96,8 +96,8 @@ syncmode = "full"
 [telemetry]
   metrics = true
   # expensive = false
-  prometheus-addr = "127.0.0.1:7071"
-  # opencollector-endpoint = ""
+  # prometheus-addr = "127.0.0.1:7071"
+  # opencollector-endpoint = "127.0.0.1:4317"
   # [telemetry.influx]
     # influxdb = false
     # endpoint = ""

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -996,8 +996,7 @@ func (c *Config) buildNode() (*node.Config, error) {
 	}
 
 	if c.P2P.NoDiscover {
-		// Disable networking, for now, we will not even allow incomming connections
-		cfg.P2P.MaxPeers = 0
+		// Disable peer discovery
 		cfg.P2P.NoDiscovery = true
 	}
 

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -479,8 +479,8 @@ func DefaultConfig() *Config {
 		Telemetry: &TelemetryConfig{
 			Enabled:               false,
 			Expensive:             false,
-			PrometheusAddr:        "",
-			OpenCollectorEndpoint: "",
+			PrometheusAddr:        "0.0.0.0:7071",
+			OpenCollectorEndpoint: "0.0.0.0:4317",
 			InfluxDB: &InfluxDBConfig{
 				V1Enabled:    false,
 				Endpoint:     "",

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -479,8 +479,8 @@ func DefaultConfig() *Config {
 		Telemetry: &TelemetryConfig{
 			Enabled:               false,
 			Expensive:             false,
-			PrometheusAddr:        "0.0.0.0:7071",
-			OpenCollectorEndpoint: "0.0.0.0:4317",
+			PrometheusAddr:        "127.0.0.1:7071",
+			OpenCollectorEndpoint: "127.0.0.1:4317",
 			InfluxDB: &InfluxDBConfig{
 				V1Enabled:    false,
 				Endpoint:     "",

--- a/internal/cli/server/config_legacy_test.go
+++ b/internal/cli/server/config_legacy_test.go
@@ -6,9 +6,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/ethereum/go-ethereum/eth/ethconfig"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestConfigLegacy(t *testing.T) {
@@ -17,139 +14,23 @@ func TestConfigLegacy(t *testing.T) {
 		expectedConfig, err := readLegacyConfig(path)
 		assert.NoError(t, err)
 
-		testConfig := &Config{
-			Chain:    "mainnet",
-			Identity: Hostname(),
-			RequiredBlocks: map[string]string{
-				"a": "b",
-			},
-			LogLevel: "INFO",
-			DataDir:  "./data",
-			P2P: &P2PConfig{
-				MaxPeers:     30,
-				MaxPendPeers: 50,
-				Bind:         "0.0.0.0",
-				Port:         30303,
-				NoDiscover:   false,
-				NAT:          "any",
-				Discovery: &P2PDiscovery{
-					V5Enabled:    false,
-					Bootnodes:    []string{},
-					BootnodesV4:  []string{},
-					BootnodesV5:  []string{},
-					StaticNodes:  []string{},
-					TrustedNodes: []string{},
-					DNS:          []string{},
-				},
-			},
-			Heimdall: &HeimdallConfig{
-				URL:     "http://localhost:1317",
-				Without: false,
-			},
-			SyncMode: "full",
-			GcMode:   "full",
-			Snapshot: true,
-			TxPool: &TxPoolConfig{
-				Locals:       []string{},
-				NoLocals:     false,
-				Journal:      "transactions.rlp",
-				Rejournal:    1 * time.Hour,
-				PriceLimit:   1,
-				PriceBump:    10,
-				AccountSlots: 16,
-				GlobalSlots:  32768,
-				AccountQueue: 16,
-				GlobalQueue:  32768,
-				LifeTime:     1 * time.Second,
-			},
-			Sealer: &SealerConfig{
-				Enabled:   false,
-				Etherbase: "",
-				GasCeil:   30000000,
-				GasPrice:  big.NewInt(1 * params.GWei),
-				ExtraData: "",
-			},
-			Gpo: &GpoConfig{
-				Blocks:      20,
-				Percentile:  60,
-				MaxPrice:    big.NewInt(5000 * params.GWei),
-				IgnorePrice: big.NewInt(4),
-			},
-			JsonRPC: &JsonRPCConfig{
-				IPCDisable: false,
-				IPCPath:    "",
-				GasCap:     ethconfig.Defaults.RPCGasCap,
-				TxFeeCap:   ethconfig.Defaults.RPCTxFeeCap,
-				Http: &APIConfig{
-					Enabled: false,
-					Port:    8545,
-					Prefix:  "",
-					Host:    "localhost",
-					API:     []string{"eth", "net", "web3", "txpool", "bor"},
-					Cors:    []string{"localhost"},
-					VHost:   []string{"localhost"},
-				},
-				Ws: &APIConfig{
-					Enabled: false,
-					Port:    8546,
-					Prefix:  "",
-					Host:    "localhost",
-					API:     []string{"net", "web3"},
-					Cors:    []string{"localhost"},
-					VHost:   []string{"localhost"},
-				},
-				Graphql: &APIConfig{
-					Enabled: false,
-					Cors:    []string{"localhost"},
-					VHost:   []string{"localhost"},
-				},
-			},
-			Ethstats: "",
-			Telemetry: &TelemetryConfig{
-				Enabled:               false,
-				Expensive:             false,
-				PrometheusAddr:        "",
-				OpenCollectorEndpoint: "",
-				InfluxDB: &InfluxDBConfig{
-					V1Enabled:    false,
-					Endpoint:     "",
-					Database:     "",
-					Username:     "",
-					Password:     "",
-					Tags:         map[string]string{},
-					V2Enabled:    false,
-					Token:        "",
-					Bucket:       "",
-					Organization: "",
-				},
-			},
-			Cache: &CacheConfig{
-				Cache:         1024,
-				PercDatabase:  50,
-				PercTrie:      15,
-				PercGc:        25,
-				PercSnapshot:  10,
-				Journal:       "triecache",
-				Rejournal:     1 * time.Second,
-				NoPrefetch:    false,
-				Preimages:     false,
-				TxLookupLimit: 2350000,
-			},
-			Accounts: &AccountsConfig{
-				Unlock:              []string{},
-				PasswordFile:        "",
-				AllowInsecureUnlock: false,
-				UseLightweightKDF:   false,
-				DisableBorWallet:    true,
-			},
-			GRPC: &GRPCConfig{
-				Addr: ":3131",
-			},
-			Developer: &DeveloperConfig{
-				Enabled: false,
-				Period:  0,
-			},
+		testConfig := DefaultConfig()
+
+		testConfig.DataDir = "./data"
+		testConfig.Snapshot = false
+		testConfig.RequiredBlocks = map[string]string{
+			"31000000": "0x2087b9e2b353209c2c21e370c82daa12278efd0fe5f0febe6c29035352cf050e",
+			"32000000": "0x875500011e5eecc0c554f95d07b31cf59df4ca2505f4dbbfffa7d4e4da917c68",
 		}
+		testConfig.P2P.MaxPeers = 30
+		testConfig.TxPool.Locals = []string{}
+		testConfig.TxPool.LifeTime = time.Second
+		testConfig.Sealer.Enabled = true
+		testConfig.Sealer.GasCeil = 30000000
+		testConfig.Sealer.GasPrice = big.NewInt(1000000000)
+		testConfig.Gpo.IgnorePrice = big.NewInt(4)
+		testConfig.Cache.Cache = 1024
+		testConfig.Cache.Rejournal = time.Second
 
 		assert.Equal(t, expectedConfig, testConfig)
 	}

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -305,6 +305,8 @@ func (s *Server) setupMetrics(config *TelemetryConfig, serviceName string) error
 			}
 		}()
 
+		log.Info("Enabling metrics export to prometheus", "path", fmt.Sprintf("http://%s/debug/metrics/prometheus", config.PrometheusAddr))
+
 	}
 
 	if config.OpenCollectorEndpoint != "" {
@@ -346,6 +348,8 @@ func (s *Server) setupMetrics(config *TelemetryConfig, serviceName string) error
 
 		// set the tracer
 		s.tracer = tracerProvider
+
+		log.Info("Open collector tracing started", "address", config.OpenCollectorEndpoint)
 	}
 
 	return nil

--- a/internal/cli/server/testdata/test.toml
+++ b/internal/cli/server/testdata/test.toml
@@ -1,7 +1,9 @@
 datadir = "./data"
+snapshot = false
 
 ["eth.requiredblocks"]
-a = "b"
+"31000000" = "0x2087b9e2b353209c2c21e370c82daa12278efd0fe5f0febe6c29035352cf050e"
+"32000000" = "0x875500011e5eecc0c554f95d07b31cf59df4ca2505f4dbbfffa7d4e4da917c68"
 
 [p2p]
 maxpeers = 30
@@ -11,7 +13,7 @@ locals = []
 lifetime = "1s"
 
 [miner]
-mine = false
+mine = true
 gaslimit = 30000000
 gasprice = "1000000000"
 

--- a/scripts/getconfig.go
+++ b/scripts/getconfig.go
@@ -445,28 +445,42 @@ func updateArgsAdd(args []string) []string {
 	return args
 }
 
-//nolint:deadcode, unused
-func handleGRPC(args []string, updatedArgs []string) []string {
+func handlePrometheus(args []string, updatedArgs []string) []string {
 	var newUpdatedArgs []string
 
-	var addr string
+	mAddr := ""
+	mPort := ""
 
-	var port string
+	pAddr := ""
+	pPort := ""
 
 	newUpdatedArgs = append(newUpdatedArgs, updatedArgs...)
 
 	for i, val := range args {
-		if strings.Contains(val, "pprof.addr") && strings.Contains(val, "-") {
-			addr = args[i+1]
+		if strings.Contains(val, "metrics.addr") && strings.HasPrefix(val, "-") {
+			mAddr = args[i+1]
 		}
 
-		if strings.Contains(val, "pprof.port") && strings.Contains(val, "-") {
-			port = args[i+1]
+		if strings.Contains(val, "metrics.port") && strings.HasPrefix(val, "-") {
+			mPort = args[i+1]
+		}
+
+		if strings.Contains(val, "pprof.addr") && strings.HasPrefix(val, "-") {
+			pAddr = args[i+1]
+		}
+
+		if strings.Contains(val, "pprof.port") && strings.HasPrefix(val, "-") {
+			pPort = args[i+1]
 		}
 	}
 
-	newUpdatedArgs = append(newUpdatedArgs, "--grpc.addr")
-	newUpdatedArgs = append(newUpdatedArgs, addr+":"+port)
+	if mAddr != "" && mPort != "" {
+		newUpdatedArgs = append(newUpdatedArgs, "--metrics.prometheus-addr")
+		newUpdatedArgs = append(newUpdatedArgs, mAddr+":"+mPort)
+	} else if pAddr != "" && pPort != "" {
+		newUpdatedArgs = append(newUpdatedArgs, "--metrics.prometheus-addr")
+		newUpdatedArgs = append(newUpdatedArgs, pAddr+":"+pPort)
+	}
 
 	return newUpdatedArgs
 }
@@ -659,7 +673,7 @@ func main() {
 	outOfDateFlags := checkFlag(allFlags, flagsToCheck)
 	updatedArgs := updateArgsClean(args, outOfDateFlags)
 	updatedArgs = updateArgsAdd(updatedArgs)
-	// updatedArgs = handleGRPC(args, updatedArgs)
+	updatedArgs = handlePrometheus(args, updatedArgs)
 
 	if temp == notYet {
 		updatedArgs = append(updatedArgs, ignoreForNow...)

--- a/scripts/getconfig.go
+++ b/scripts/getconfig.go
@@ -445,6 +445,7 @@ func updateArgsAdd(args []string) []string {
 	return args
 }
 
+// Unused for now, can be removed later
 func handleGRPC(args []string, updatedArgs []string) []string {
 	var newUpdatedArgs []string
 
@@ -658,7 +659,7 @@ func main() {
 	outOfDateFlags := checkFlag(allFlags, flagsToCheck)
 	updatedArgs := updateArgsClean(args, outOfDateFlags)
 	updatedArgs = updateArgsAdd(updatedArgs)
-	updatedArgs = handleGRPC(args, updatedArgs)
+	// updatedArgs = handleGRPC(args, updatedArgs)
 
 	if temp == notYet {
 		updatedArgs = append(updatedArgs, ignoreForNow...)

--- a/scripts/getconfig.go
+++ b/scripts/getconfig.go
@@ -445,7 +445,7 @@ func updateArgsAdd(args []string) []string {
 	return args
 }
 
-// Unused for now, can be removed later
+//nolint:deadcode, unused
 func handleGRPC(args []string, updatedArgs []string) []string {
 	var newUpdatedArgs []string
 


### PR DESCRIPTION
This PR achieves the following things

1. When the flag `nodiscover` was enabled in the old-cli, the node would not discover other peers but still connected to static and trusted peers if required, which was much convenient for our validator and sentry architecture. But, in the new-cli, when we set this flag, we also used to set `maxpeers` to 0. This would not allow the node to connect to any static peers. Ideally, we've suggested people to use [this](https://github.com/maticnetwork/launch/blob/master/mainnet-v1/sentry/validator/bor/start.sh#L39) setting of flags (`nodiscover` along with `maxpeers=0`). Now, we can either get rid of this flag and keep the same behaviour in client as it is now by not translating it the new toml file using @pratikpatil024's migration script or we can keep the same behaviour of `nodiscover` in the client (as geth does). I prefer the latter one. 

2. We were unable to send metrics to datadog from some of our internal validator nodes running the new-cli. On investigating further, we found out that in the old-cli, prometheus address was set on based on `metrics.addr` and `metrics.port` flags (or `pprof.addr` and `pprof.port` flag if the earlier ones are not available). The defaults address in any case is `127.0.0.1:7071`. So, ideally even if the users have not provided these flags, the prometheus metrics are exported on the default address. In case of the new-cli, currently we need to explicitly set the address for prometheus. Instead we can set them as default so that the changes on our end (w.r.t to metrics collector) are minimized. Also, if these flags are available, use them to derive prometheus address in the migration script. 

3. As finalized in (2), the default port for prometheus is 7071 and with the migration script, we're translating the pprof address + port combination to grpc address. Most of the nodes have pprof port set to 7071 and hence it would not allow prometheus to work. My suggestion is to ignore all pprof flags and just rely on default grpc port which is 3131. 