### PR TITLE
scripts: make config creation script independent of OS

### DIFF
--- a/scripts/getconfig.sh
+++ b/scripts/getconfig.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env sh
+set -e
 
 # Instructions:
 # Execute `./getconfig.sh`, and follow the instructions displayed on the terminal
 # The `*-config.toml` file will be created in the same directory as start.sh
 # It is recommended to check the flags generated in config.toml
 
+# Some checks to make commands OS independent
+OS="$(uname -s)"
+MKTEMPOPTION=
+SEDOPTION= ## Not used as of now (TODO)
+shopt -s nocasematch; if [[ "$OS" == "darwin"* ]]; then
+  SEDOPTION="''"
+  MKTEMPOPTION="-t"
+fi
 
 read -p "* Path to start.sh: " startPath
 # check if start.sh is present
@@ -15,7 +24,7 @@ then
 fi
 read -p "* Your validator address (e.g. 0xca67a8D767e45056DC92384b488E9Af654d78DE2), or press Enter to skip if running a sentry node: " ADD
 
-echo "\nThank you, your inputs are:"
+printf "\nThank you, your inputs are:\n"
 echo "Path to start.sh: "$startPath
 echo "Address: "$ADD
 
@@ -26,8 +35,9 @@ if [[ -f $confPath ]]
 then
     echo "WARN: config.toml exists, data will be overwritten."
 fi
+printf "\n"
 
-tmpDir="$(mktemp -d -t ./temp-dir-XXXXXXXXXXX || oops "Can't create temporary directory")"
+tmpDir="$(mktemp -d $MKTEMPOPTION ./temp-dir-XXXXXXXXXXX || oops "Can't create temporary directory")"
 cleanup() {
     rm -rf "$tmpDir"
 }
@@ -39,8 +49,11 @@ chmod +x $tmpDir/3305fe263dd4a999d58f96deb064e21bb70123d9.sh
 $tmpDir/3305fe263dd4a999d58f96deb064e21bb70123d9.sh $ADD
 rm $tmpDir/3305fe263dd4a999d58f96deb064e21bb70123d9.sh
 
-
-sed -i '' "s%*%'*'%g" ./temp
+shopt -s nocasematch; if [[ "$OS" == "darwin"* ]]; then
+    sed -i '' "s%*%'*'%g" ./temp
+else
+    sed -i "s%*%'*'%g" ./temp
+fi
 
 # read the flags from `./temp`
 dumpconfigflags=$(head -1 ./temp)
@@ -51,17 +64,27 @@ bash -c "$command"
 
 rm ./temp
 
+printf "\n"
+
 if [[ -f ./tempStaticNodes.json ]]
 then
     echo "JSON StaticNodes found"
     staticnodesjson=$(head -1 ./tempStaticNodes.json)
-    sed -i '' "s%static-nodes = \[\]%static-nodes = \[\"${staticnodesjson}\"\]%" $confPath
+    shopt -s nocasematch; if [[ "$OS" == "darwin"* ]]; then
+        sed -i '' "s%static-nodes = \[\]%static-nodes = \[\"${staticnodesjson}\"\]%" $confPath
+    else
+        sed -i "s%static-nodes = \[\]%static-nodes = \[\"${staticnodesjson}\"\]%" $confPath
+    fi
     rm ./tempStaticNodes.json
 elif [[ -f ./tempStaticNodes.toml ]]
 then
     echo "TOML StaticNodes found"
     staticnodestoml=$(head -1 ./tempStaticNodes.toml)
-    sed -i '' "s%static-nodes = \[\]%static-nodes = \[\"${staticnodestoml}\"\]%" $confPath
+    shopt -s nocasematch; if [[ "$OS" == "darwin"* ]]; then
+        sed -i '' "s%static-nodes = \[\]%static-nodes = \[\"${staticnodestoml}\"\]%" $confPath
+    else
+        sed -i "s%static-nodes = \[\]%static-nodes = \[\"${staticnodestoml}\"\]%" $confPath
+    fi
     rm ./tempStaticNodes.toml
 else
     echo "neither JSON nor TOML StaticNodes found"
@@ -71,11 +94,17 @@ if [[ -f ./tempTrustedNodes.toml ]]
 then
     echo "TOML TrustedNodes found"
     trustednodestoml=$(head -1 ./tempTrustedNodes.toml)
-    sed -i '' "s%trusted-nodes = \[\]%trusted-nodes = \[\"${trustednodestoml}\"\]%" $confPath
+    shopt -s nocasematch; if [[ "$OS" == "darwin"* ]]; then
+        sed -i '' "s%trusted-nodes = \[\]%trusted-nodes = \[\"${trustednodestoml}\"\]%" $confPath
+    else
+        sed -i "s%trusted-nodes = \[\]%trusted-nodes = \[\"${trustednodestoml}\"\]%" $confPath
+    fi
     rm ./tempTrustedNodes.toml
 else
     echo "neither JSON nor TOML TrustedNodes found"
 fi
+
+printf "\n"
 
 # comment flags in $configPath that were not passed through $startPath
 # SHA1 hash of `tempStart` -> `3305fe263dd4a999d58f96deb064e21bb70123d9`


### PR DESCRIPTION
This PR makes some modifications in the getconfig script which is used to generate the toml config file according to the new-cli from an old (v0.2.x) start.sh to make it executable on Mac and Linux machines. 

We've tried to make the solution simpler using some methods but that didn't work out. So, as of now, the current solution just includes if else statements at places to run commands depending on the current OS. 

[Reference Issue](https://stackoverflow.com/questions/43171648/sed-gives-sed-cant-read-no-such-file-or-directory)