### PR TITLE
Add ability to calculate the longest execution path in a block

### DIFF
--- a/core/blockstm/dag.go
+++ b/core/blockstm/dag.go
@@ -2,8 +2,8 @@ package blockstm
 
 import (
 	"fmt"
-	"sort"
 	"strings"
+	"time"
 
 	"github.com/heimdalr/dag"
 
@@ -62,8 +62,6 @@ func BuildDAG(deps TxnInputOutput) (d DAG) {
 				if err != nil {
 					log.Warn("Failed to add edge", "from", txFromId, "to", txToId, "err", err)
 				}
-
-				break // once we add a 'backward' dep we can't execute before that transaction so no need to proceed
 			}
 		}
 	}
@@ -71,23 +69,67 @@ func BuildDAG(deps TxnInputOutput) (d DAG) {
 	return
 }
 
-func (d DAG) Report(out func(string)) {
-	roots := make([]int, 0)
-	rootIds := make([]string, 0)
-	rootIdMap := make(map[int]string, len(d.GetRoots()))
+// Find the longest execution path in the DAG
+func (d DAG) LongestPath(stats map[int]ExecutionStat) ([]int, uint64) {
+	prev := make(map[int]int, len(d.GetVertices()))
 
-	for k, i := range d.GetRoots() {
-		roots = append(roots, i.(int))
-		rootIdMap[i.(int)] = k
+	for i := 0; i < len(d.GetVertices()); i++ {
+		prev[i] = -1
 	}
 
-	sort.Ints(roots)
+	pathWeights := make(map[int]uint64, len(d.GetVertices()))
 
-	for _, i := range roots {
-		rootIds = append(rootIds, rootIdMap[i])
+	maxPath := 0
+	maxPathWeight := uint64(0)
+
+	idxToId := make(map[int]string, len(d.GetVertices()))
+
+	for k, i := range d.GetVertices() {
+		idxToId[i.(int)] = k
 	}
 
-	fmt.Println(roots)
+	for i := 0; i < len(idxToId); i++ {
+		parents, _ := d.GetParents(idxToId[i])
+
+		if len(parents) > 0 {
+			for _, p := range parents {
+				weight := pathWeights[p.(int)] + stats[i].End - stats[i].Start
+				if weight > pathWeights[i] {
+					pathWeights[i] = weight
+					prev[i] = p.(int)
+				}
+			}
+		} else {
+			pathWeights[i] = stats[i].End - stats[i].Start
+		}
+
+		if pathWeights[i] > maxPathWeight {
+			maxPath = i
+			maxPathWeight = pathWeights[i]
+		}
+	}
+
+	path := make([]int, 0)
+	for i := maxPath; i != -1; i = prev[i] {
+		path = append(path, i)
+	}
+
+	// Reverse the path so the transactions are in the ascending order
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+
+	return path, maxPathWeight
+}
+
+func (d DAG) Report(stats map[int]ExecutionStat, out func(string)) {
+	longestPath, weight := d.LongestPath(stats)
+
+	serialWeight := uint64(0)
+
+	for i := 0; i < len(d.GetVertices()); i++ {
+		serialWeight += stats[i].End - stats[i].Start
+	}
 
 	makeStrs := func(ints []int) (ret []string) {
 		for _, v := range ints {
@@ -97,29 +139,9 @@ func (d DAG) Report(out func(string)) {
 		return
 	}
 
-	maxDesc := 0
-	maxDeps := 0
-	totalDeps := 0
+	out("Longest execution path:")
+	out(fmt.Sprintf("(%v) %v", len(longestPath), strings.Join(makeStrs(longestPath), "->")))
 
-	for k, v := range roots {
-		ids := []int{v}
-		desc, _ := d.GetDescendants(rootIds[k])
-
-		for _, i := range desc {
-			ids = append(ids, i.(int))
-		}
-
-		sort.Ints(ids)
-		out(fmt.Sprintf("(%v) %v", len(ids), strings.Join(makeStrs(ids), "->")))
-
-		if len(desc) > maxDesc {
-			maxDesc = len(desc)
-		}
-	}
-
-	numTx := len(d.DAG.GetVertices())
-	out(fmt.Sprintf("max chain length: %v of %v (%v%%)", maxDesc+1, numTx,
-		fmt.Sprintf("%.1f", float64(maxDesc+1)*100.0/float64(numTx))))
-	out(fmt.Sprintf("max dep count: %v of %v (%v%%)", maxDeps, totalDeps,
-		fmt.Sprintf("%.1f", float64(maxDeps)*100.0/float64(totalDeps))))
+	out(fmt.Sprintf("Longest path ideal execution time: %v of %v (serial total), %v%%", time.Duration(weight),
+		time.Duration(serialWeight), fmt.Sprintf("%.1f", float64(weight)*100.0/float64(serialWeight))))
 }

--- a/core/blockstm/executor_test.go
+++ b/core/blockstm/executor_test.go
@@ -348,8 +348,14 @@ func checkNoDroppedTx(pe *ParallelExecutor) error {
 func runParallel(t *testing.T, tasks []ExecTask, validation PropertyCheck) time.Duration {
 	t.Helper()
 
+	profile := false
+
 	start := time.Now()
-	_, err := executeParallelWithCheck(tasks, false, validation)
+	result, err := executeParallelWithCheck(tasks, profile, validation)
+
+	if result.Deps != nil && profile {
+		result.Deps.Report(*result.Stats, func(str string) { fmt.Println(str) })
+	}
 
 	assert.NoError(t, err, "error occur during parallel execution")
 


### PR DESCRIPTION
Calculate longest execution path based on the time each transaction spent .

Sample report output of alternating tx test:

```
INFO [10-04|17:03:21.538] Executing block                          numTx=200 numRead=20 numWrite=20 numNonIO=100
DEBUG[10-04|17:03:21.581] blockstm exec summary                    execs=200 success=200 aborts=0 validations=200 failures=0 #tasks/#execs=100.00%
Longest execution path:
(100) 0->2->4->6->8->10->12->14->16->18->20->22->24->26->28->30->32->34->36->38->40->42->44->46->48->50->52->54->56->58->60->62->64->66->68->70->72->74->76->78->80->82->84->86->88->90->92->94->96->98->100->102->104->106->108->110->112->114->116->118->120->122->124->126->128->130->132->134->136->138->140->142->144->146->148->150->152->154->156->158->160->162->164->166->168->170->172->174->176->178->180->182->184->186->188->190->192->194->196->198
Longest path ideal execution time: 38.048159ms of 76.020204ms (serial total), 50.1%
exec duration 112.965855ms, serial duration 75.65929ms, time reduced -37.306565ms -49.31%, ❌
Improved:  0 Total:  1 success rate:  0
Total exec duration: 112.965855ms, total serial duration: 75.65929ms, time reduced: -37.306565ms, time reduced percent: -49.31%
```