### PR TITLE
internal/cli: add support for bor.logs flag in new-cli

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -10,6 +10,7 @@ datadir = "/var/lib/bor/data"
 syncmode = "full"
 # gcmode = "full"
 # snapshot = true
+# "bor.logs" = false
 # ethstats = ""
 
 # ["eth.requiredblocks"]

--- a/docs/cli/removedb.md
+++ b/docs/cli/removedb.md
@@ -4,4 +4,6 @@ The ```bor removedb``` command will remove the blockchain and state databases at
 
 ## Options
 
+- ```address```: Address of the grpc endpoint
+
 - ```datadir```: Path of the data directory to store information

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -16,17 +16,21 @@ The ```bor server``` command runs the Bor client.
 
 - ```config```: File for the config file
 
-- ```syncmode```: Blockchain sync mode ("fast", "full", or "snap")
+- ```syncmode```: Blockchain sync mode (only "full" sync supported)
 
 - ```gcmode```: Blockchain garbage collection mode ("full", "archive")
 
-- ```requiredblocks```: Comma separated block number-to-hash mappings to enforce (<number>=<hash>)
+- ```eth.requiredblocks```: Comma separated block number-to-hash mappings to require for peering (<number>=<hash>)
 
-- ```snapshot```: Disables/Enables the snapshot-database mode (default = true)
+- ```snapshot```: Enables the snapshot-database mode (default = true)
+
+- ```bor.logs```: Enables bor log retrieval (default = false)
 
 - ```bor.heimdall```: URL of Heimdall service
 
 - ```bor.withoutheimdall```: Run without Heimdall service (for testing purpose)
+
+- ```bor.heimdallgRPC```: Address of Heimdall gRPC service
 
 - ```ethstats```: Reporting URL of a ethstats service (nodename:secret@host:port)
 

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -62,8 +62,11 @@ type Config struct {
 	// GcMode selects the garbage collection mode for the trie
 	GcMode string `hcl:"gcmode,optional" toml:"gcmode,optional"`
 
-	// Snapshot disables/enables the snapshot database mode
+	// Snapshot enables the snapshot database mode
 	Snapshot bool `hcl:"snapshot,optional" toml:"snapshot,optional"`
+
+	// BorLogs enables bor log retrieval
+	BorLogs bool `hcl:"bor.logs,optional" toml:"bor.logs,optional"`
 
 	// Ethstats is the address of the ethstats server to send telemetry
 	Ethstats string `hcl:"ethstats,optional" toml:"ethstats,optional"`
@@ -420,6 +423,7 @@ func DefaultConfig() *Config {
 		SyncMode: "full",
 		GcMode:   "full",
 		Snapshot: true,
+		BorLogs:  false,
 		TxPool: &TxPoolConfig{
 			Locals:       []string{},
 			NoLocals:     false,
@@ -649,6 +653,7 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 		n.NetworkId = c.chain.NetworkId
 		n.Genesis = c.chain.Genesis
 	}
+
 	n.HeimdallURL = c.Heimdall.URL
 	n.WithoutHeimdall = c.Heimdall.Without
 	n.HeimdallgRPCAddress = c.Heimdall.GRPCAddress
@@ -881,6 +886,7 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 		}
 	}
 
+	n.BorLogs = c.BorLogs
 	n.DatabaseHandles = dbHandles
 
 	return &n, nil

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -45,7 +45,7 @@ func (c *Command) Flags() *flagset.Flagset {
 	})
 	f.StringFlag(&flagset.StringFlag{
 		Name:    "syncmode",
-		Usage:   `Blockchain sync mode ("fast", "full", or "snap")`,
+		Usage:   `Blockchain sync mode (only "full" sync supported)`,
 		Value:   &c.cliConfig.SyncMode,
 		Default: c.cliConfig.SyncMode,
 	})
@@ -62,9 +62,15 @@ func (c *Command) Flags() *flagset.Flagset {
 	})
 	f.BoolFlag(&flagset.BoolFlag{
 		Name:    "snapshot",
-		Usage:   `Disables/Enables the snapshot-database mode (default = true)`,
+		Usage:   `Enables the snapshot-database mode (default = true)`,
 		Value:   &c.cliConfig.Snapshot,
 		Default: c.cliConfig.Snapshot,
+	})
+	f.BoolFlag(&flagset.BoolFlag{
+		Name:    "bor.logs",
+		Usage:   `Enables bor log retrieval (default = false)`,
+		Value:   &c.cliConfig.BorLogs,
+		Default: c.cliConfig.BorLogs,
 	})
 
 	// heimdall

--- a/scripts/getconfig.go
+++ b/scripts/getconfig.go
@@ -109,6 +109,7 @@ var nameTagMap = map[string]string{
 	"gcmode":                 "gcmode",
 	"eth.requiredblocks":     "eth.requiredblocks",
 	"0-snapshot":             "snapshot",
+	"\"bor.logs\"":           "bor.logs",
 	"url":                    "bor.heimdall",
 	"bor.without":            "bor.withoutheimdall",
 	"grpc-address":           "bor.heimdallgRPC",
@@ -231,6 +232,7 @@ var replacedFlagsMapFlag = map[string]string{
 
 var currentBoolFlags = []string{
 	"snapshot",
+	"bor.logs",
 	"bor.withoutheimdall",
 	"txpool.nolocals",
 	"mine",

--- a/scripts/getconfig.go
+++ b/scripts/getconfig.go
@@ -111,7 +111,7 @@ var nameTagMap = map[string]string{
 	"0-snapshot":             "snapshot",
 	"\"bor.logs\"":           "bor.logs",
 	"url":                    "bor.heimdall",
-	"bor.without":            "bor.withoutheimdall",
+	"\"bor.without\"":        "bor.withoutheimdall",
 	"grpc-address":           "bor.heimdallgRPC",
 	"locals":                 "txpool.locals",
 	"nolocals":               "txpool.nolocals",


### PR DESCRIPTION
This PR adds support for `bor.logs` boolean flag in the new-cli. It also updates relevant places where it needs to be used. 

All the changes have been tested on a devnet. 