### PR TITLE
Add state sync transaction to debug_trace functions.

### DIFF
--- a/consensus/bor/statefull/processor.go
+++ b/consensus/bor/statefull/processor.go
@@ -92,11 +92,9 @@ func ApplyMessage(
 	gasUsed := initialGas - gasLeft
 
 	return gasUsed, nil
-
 }
 
 func ApplyBorMessage(vmenv vm.EVM, msg Callmsg) (*core.ExecutionResult, error) {
-
 	initialGas := msg.Gas()
 
 	// Apply the transaction to the current state (included in the env)
@@ -119,5 +117,4 @@ func ApplyBorMessage(vmenv vm.EVM, msg Callmsg) (*core.ExecutionResult, error) {
 		Err:        err,
 		ReturnData: ret,
 	}, nil
-
 }

--- a/consensus/bor/statefull/processor.go
+++ b/consensus/bor/statefull/processor.go
@@ -31,22 +31,22 @@ func (c ChainContext) GetHeader(hash common.Hash, number uint64) *types.Header {
 }
 
 // callmsg implements core.Message to allow passing it as a transaction simulator.
-type callmsg struct {
+type Callmsg struct {
 	ethereum.CallMsg
 }
 
-func (m callmsg) From() common.Address { return m.CallMsg.From }
-func (m callmsg) Nonce() uint64        { return 0 }
-func (m callmsg) CheckNonce() bool     { return false }
-func (m callmsg) To() *common.Address  { return m.CallMsg.To }
-func (m callmsg) GasPrice() *big.Int   { return m.CallMsg.GasPrice }
-func (m callmsg) Gas() uint64          { return m.CallMsg.Gas }
-func (m callmsg) Value() *big.Int      { return m.CallMsg.Value }
-func (m callmsg) Data() []byte         { return m.CallMsg.Data }
+func (m Callmsg) From() common.Address { return m.CallMsg.From }
+func (m Callmsg) Nonce() uint64        { return 0 }
+func (m Callmsg) CheckNonce() bool     { return false }
+func (m Callmsg) To() *common.Address  { return m.CallMsg.To }
+func (m Callmsg) GasPrice() *big.Int   { return m.CallMsg.GasPrice }
+func (m Callmsg) Gas() uint64          { return m.CallMsg.Gas }
+func (m Callmsg) Value() *big.Int      { return m.CallMsg.Value }
+func (m Callmsg) Data() []byte         { return m.CallMsg.Data }
 
 // get system message
-func GetSystemMessage(toAddress common.Address, data []byte) callmsg {
-	return callmsg{
+func GetSystemMessage(toAddress common.Address, data []byte) Callmsg {
+	return Callmsg{
 		ethereum.CallMsg{
 			From:     systemAddress,
 			Gas:      math.MaxUint64 / 2,
@@ -61,7 +61,7 @@ func GetSystemMessage(toAddress common.Address, data []byte) callmsg {
 // apply message
 func ApplyMessage(
 	_ context.Context,
-	msg callmsg,
+	msg Callmsg,
 	state *state.StateDB,
 	header *types.Header,
 	chainConfig *params.ChainConfig,
@@ -92,4 +92,32 @@ func ApplyMessage(
 	gasUsed := initialGas - gasLeft
 
 	return gasUsed, nil
+
+}
+
+func ApplyBorMessage(vmenv vm.EVM, msg Callmsg) (*core.ExecutionResult, error) {
+
+	initialGas := msg.Gas()
+
+	// Apply the transaction to the current state (included in the env)
+	ret, gasLeft, err := vmenv.Call(
+		vm.AccountRef(msg.From()),
+		*msg.To(),
+		msg.Data(),
+		msg.Gas(),
+		msg.Value(),
+	)
+	// Update the state with pending changes
+	if err != nil {
+		vmenv.StateDB.Finalise(true)
+	}
+
+	gasUsed := initialGas - gasLeft
+
+	return &core.ExecutionResult{
+		UsedGas:    gasUsed,
+		Err:        err,
+		ReturnData: ret,
+	}, nil
+
 }

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -74,6 +74,8 @@ type StateDB interface {
 	AddPreimage(common.Hash, []byte)
 
 	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error
+
+	Finalise(bool)
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -275,6 +275,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 			BorTx:           newBoolPtr(false),
 		}
 	}
+
 	if config.BorTraceEnabled == nil {
 		config.BorTraceEnabled = defaultBorTraceEnabled
 	}
@@ -317,6 +318,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 					txs = txs[:len(txs)-1]
 					stateSyncPresent = false
 				}
+
 				for i, tx := range txs {
 					msg, _ := tx.AsMessage(signer, task.block.BaseFee())
 					txctx := &Context{
@@ -578,6 +580,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 			BorTx:           newBoolPtr(false),
 		}
 	}
+
 	if config.BorTraceEnabled == nil {
 		config.BorTraceEnabled = defaultBorTraceEnabled
 	}
@@ -621,7 +624,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 			vmenv     = vm.NewEVM(vmctx, txContext, statedb, chainConfig, vm.Config{})
 		)
 		statedb.Prepare(tx.Hash(), i)
-
+		//nolint: nestif
 		if stateSyncPresent && i == len(txs)-1 {
 			if *config.BorTraceEnabled {
 				callmsg := prepareCallMessage(msg)
@@ -639,7 +642,6 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 			} else {
 				break
 			}
-
 		} else {
 			if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas())); err != nil {
 				log.Warn("Tracing intermediate roots did not complete", "txindex", i, "txhash", tx.Hash(), "err", err)
@@ -683,6 +685,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 			BorTx:           newBoolPtr(false),
 		}
 	}
+
 	if config.BorTraceEnabled == nil {
 		config.BorTraceEnabled = defaultBorTraceEnabled
 	}
@@ -733,6 +736,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 				var res interface{}
 
 				var err error
+
 				if stateSyncPresent && task.index == len(txs)-1 {
 					if *config.BorTraceEnabled {
 						config.BorTx = newBoolPtr(true)
@@ -763,7 +767,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		statedb.Prepare(tx.Hash(), i)
 
 		vmenv := vm.NewEVM(blockCtx, core.NewEVMTxContext(msg), statedb, api.backend.ChainConfig(), vm.Config{})
-
+		//nolint: nestif
 		if stateSyncPresent && i == len(txs)-1 {
 			if *config.BorTraceEnabled {
 				callmsg := prepareCallMessage(msg)
@@ -809,6 +813,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 			BorTraceEnabled: defaultBorTraceEnabled,
 		}
 	}
+
 	if config.BorTraceEnabled == nil {
 		config.BorTraceEnabled = defaultBorTraceEnabled
 	}
@@ -910,7 +915,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
 		statedb.Prepare(tx.Hash(), i)
-
+		//nolint: nestif
 		if stateSyncPresent && i == len(txs)-1 {
 			if *config.BorTraceEnabled {
 				callmsg := prepareCallMessage(msg)
@@ -967,6 +972,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 			BorTx:           newBoolPtr(false),
 		}
 	}
+
 	if config.BorTraceEnabled == nil {
 		config.BorTraceEnabled = defaultBorTraceEnabled
 	}
@@ -1076,6 +1082,7 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 			BorTx:           newBoolPtr(false),
 		}
 	}
+
 	if config.BorTraceEnabled == nil {
 		config.BorTraceEnabled = defaultBorTraceEnabled
 	}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -270,6 +270,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 	if config == nil {
 		config = &TraceConfig{
 			BorTraceEnabled: newBoolPtr(false),
+			BorTx:           newBoolPtr(false),
 		}
 	}
 	// Tracing a chain is a **long** operation, only do with subscriptions
@@ -567,6 +568,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 	if config == nil {
 		config = &TraceConfig{
 			BorTraceEnabled: newBoolPtr(false),
+			BorTx:           newBoolPtr(false),
 		}
 	}
 
@@ -668,6 +670,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	if config == nil {
 		config = &TraceConfig{
 			BorTraceEnabled: newBoolPtr(false),
+			BorTx:           newBoolPtr(false),
 		}
 	}
 
@@ -937,6 +940,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 	if config == nil {
 		config = &TraceConfig{
 			BorTraceEnabled: newBoolPtr(false),
+			BorTx:           newBoolPtr(false),
 		}
 	}
 	tx, blockHash, blockNumber, index, err := api.backend.GetTransaction(ctx, hash)
@@ -1077,6 +1081,10 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 	statedb.Prepare(txctx.TxHash, txctx.TxIndex)
 
 	var result *core.ExecutionResult
+
+	if config.BorTx == nil {
+		config.BorTx = newBoolPtr(false)
+	}
 
 	if *config.BorTx {
 		callmsg := prepareCallMessage(message)

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -290,7 +290,7 @@ func TestTraceCall(t *testing.T) {
 		},
 	}
 	for _, testspec := range testSuite {
-		result, err := api.TraceCall(context.Background(), testspec.call, rpc.BlockNumberOrHash{BlockNumber: &testspec.blockNumber}, testspec.config, false)
+		result, err := api.TraceCall(context.Background(), testspec.call, rpc.BlockNumberOrHash{BlockNumber: &testspec.blockNumber}, testspec.config)
 		if testspec.expectErr != nil {
 			if err == nil {
 				t.Errorf("Expect error %v, get nothing", testspec.expectErr)
@@ -330,7 +330,7 @@ func TestTraceTransaction(t *testing.T) {
 		b.AddTx(tx)
 		target = tx.Hash()
 	}))
-	result, err := api.TraceTransaction(context.Background(), target, nil, false)
+	result, err := api.TraceTransaction(context.Background(), target, nil)
 	if err != nil {
 		t.Errorf("Failed to trace transaction %v", err)
 	}
@@ -513,7 +513,7 @@ func TestTracingWithOverrides(t *testing.T) {
 		},
 	}
 	for i, tc := range testSuite {
-		result, err := api.TraceCall(context.Background(), tc.call, rpc.BlockNumberOrHash{BlockNumber: &tc.blockNumber}, tc.config, false)
+		result, err := api.TraceCall(context.Background(), tc.call, rpc.BlockNumberOrHash{BlockNumber: &tc.blockNumber}, tc.config)
 		if tc.expectErr != nil {
 			if err == nil {
 				t.Errorf("test %d: want error %v, have nothing", i, tc.expectErr)

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -176,6 +176,11 @@ func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block
 	return nil, vm.BlockContext{}, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, block.Hash())
 }
 
+func (b *testBackend) GetBorBlockTransactionWithBlockHash(ctx context.Context, txHash common.Hash, blockHash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, error) {
+	tx, blockHash, blockNumber, index := rawdb.ReadBorTransactionWithBlockHash(b.ChainDb(), txHash, blockHash)
+	return tx, blockHash, blockNumber, index, nil
+}
+
 func TestTraceCall(t *testing.T) {
 	t.Parallel()
 
@@ -285,7 +290,7 @@ func TestTraceCall(t *testing.T) {
 		},
 	}
 	for _, testspec := range testSuite {
-		result, err := api.TraceCall(context.Background(), testspec.call, rpc.BlockNumberOrHash{BlockNumber: &testspec.blockNumber}, testspec.config)
+		result, err := api.TraceCall(context.Background(), testspec.call, rpc.BlockNumberOrHash{BlockNumber: &testspec.blockNumber}, testspec.config, false)
 		if testspec.expectErr != nil {
 			if err == nil {
 				t.Errorf("Expect error %v, get nothing", testspec.expectErr)
@@ -325,7 +330,7 @@ func TestTraceTransaction(t *testing.T) {
 		b.AddTx(tx)
 		target = tx.Hash()
 	}))
-	result, err := api.TraceTransaction(context.Background(), target, nil)
+	result, err := api.TraceTransaction(context.Background(), target, nil, false)
 	if err != nil {
 		t.Errorf("Failed to trace transaction %v", err)
 	}
@@ -508,7 +513,7 @@ func TestTracingWithOverrides(t *testing.T) {
 		},
 	}
 	for i, tc := range testSuite {
-		result, err := api.TraceCall(context.Background(), tc.call, rpc.BlockNumberOrHash{BlockNumber: &tc.blockNumber}, tc.config)
+		result, err := api.TraceCall(context.Background(), tc.call, rpc.BlockNumberOrHash{BlockNumber: &tc.blockNumber}, tc.config, false)
 		if tc.expectErr != nil {
 			if err == nil {
 				t.Errorf("test %d: want error %v, have nothing", i, tc.expectErr)


### PR DESCRIPTION
# Description

Because state sync transaction is added by bor consensus, it will not be included in `debug_traceByBlockNumber` and `debug_tranceByBlockHash`. The problem seems to be that block.Transactions() doesn’t contain state sync transaction.

In this PR, tracing can be possible on state-sync transactions as well. All the debug_trace functions will contain the traces of state-sync transactions, if present.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mainnet
- [ ] I have created new e2e tests into express-cli
