### PR TITLE
Changed default value of maxpeers from 200 to 50,  update docs

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -327,7 +327,7 @@ func setDefaultMumbaiGethConfig(ctx *cli.Context, config *gethConfig) {
 	config.Eth.TxPool.AccountQueue = 64
 	config.Eth.TxPool.GlobalQueue = 131072
 	config.Eth.TxPool.Lifetime = 90 * time.Minute
-	config.Node.P2P.MaxPeers = 200
+	config.Node.P2P.MaxPeers = 50
 	config.Metrics.Enabled = true
 	// --pprof is enabled in 'internal/debug/flags.go'
 }
@@ -350,7 +350,7 @@ func setDefaultBorMainnetGethConfig(ctx *cli.Context, config *gethConfig) {
 	config.Eth.TxPool.AccountQueue = 64
 	config.Eth.TxPool.GlobalQueue = 131072
 	config.Eth.TxPool.Lifetime = 90 * time.Minute
-	config.Node.P2P.MaxPeers = 200
+	config.Node.P2P.MaxPeers = 50
 	config.Metrics.Enabled = true
 	// --pprof is enabled in 'internal/debug/flags.go'
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@
   $ bor server <flags>
   ```
 
-- Toml files used earlier to configure static/trusted nodes are being deprecated. Instead, a toml file now can be used instead of flags and can contain all configuration for the node to run. The link to a sample config file is given above. To simply run bor with a configuration file, the following command can be used. 
+- Toml files used earlier just to configure static/trusted nodes are being deprecated. Instead, a toml file now can be used instead of flags and can contain all configuration for the node to run. The link to a sample config file is given above. To simply run bor with a configuration file, the following command can be used. 
 
   ```
   $ bor server --config <path_to_config.toml>

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,18 +5,16 @@
 
 - [Configuration file](./config.md)
 
-## Deprecation notes
+## Additional notes
 
 - The new entrypoint to run the Bor client is ```server```.
 
-```
-$ bor server
-```
+  ```
+  $ bor server <flags>
+  ```
 
-- Toml files to configure nodes are being deprecated. Currently, we only allow for static and trusted nodes to be configured using toml files.
+- Toml files used earlier to configure static/trusted nodes are being deprecated. Instead, a toml file now can be used instead of flags and can contain all configuration for the node to run. The link to a sample config file is given above. To simply run bor with a configuration file, the following command can be used. 
 
-```
-$ bor server --config ./legacy.toml
-```
-
-- ```Admin```, ```Personal``` and account related endpoints in ```Eth``` are being removed from the JsonRPC interface. Some of this functionality will be moved to the new GRPC server for operational tasks.
+  ```
+  $ bor server --config <path_to_config.toml>
+  ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,7 +22,7 @@ ethstats = ""
 ["eth.requiredblocks"]
 
 [p2p]
-maxpeers = 30
+maxpeers = 50
 maxpendpeers = 50
 bind = "0.0.0.0"
 port = 30303

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -399,7 +399,7 @@ func DefaultConfig() *Config {
 		LogLevel:       "INFO",
 		DataDir:        DefaultDataDir(),
 		P2P: &P2PConfig{
-			MaxPeers:     30,
+			MaxPeers:     50,
 			MaxPendPeers: 50,
 			Bind:         "0.0.0.0",
 			Port:         30303,

--- a/scripts/getconfig.sh
+++ b/scripts/getconfig.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 set -e
 
 # Instructions:


### PR DESCRIPTION
Reference for this [commit](https://github.com/maticnetwork/bor/pull/555/commits/70cc54425847ca5c1707b9cb4cd01a6d424a64d0): https://askubuntu.com/questions/180873/shopt-works-in-command-line-not-found-when-run-in-a-script