### PR TITLE
Tx pool reorg optimization

### DIFF
--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"strings"
 
+	"gopkg.in/urfave/cli.v1"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
@@ -32,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/tests"
-	"gopkg.in/urfave/cli.v1"
 )
 
 type result struct {

--- a/common/math/big.go
+++ b/common/math/big.go
@@ -20,6 +20,8 @@ package math
 import (
 	"fmt"
 	"math/big"
+
+	"github.com/holiman/uint256"
 )
 
 // Various big integer limit values.
@@ -132,6 +134,7 @@ func MustParseBig256(s string) *big.Int {
 // BigPow returns a ** b as a big integer.
 func BigPow(a, b int64) *big.Int {
 	r := big.NewInt(a)
+
 	return r.Exp(r, big.NewInt(b), nil)
 }
 
@@ -140,6 +143,15 @@ func BigMax(x, y *big.Int) *big.Int {
 	if x.Cmp(y) < 0 {
 		return y
 	}
+
+	return x
+}
+
+func BigMaxUint(x, y *uint256.Int) *uint256.Int {
+	if x.Lt(y) {
+		return y
+	}
+
 	return x
 }
 
@@ -148,6 +160,15 @@ func BigMin(x, y *big.Int) *big.Int {
 	if x.Cmp(y) > 0 {
 		return y
 	}
+
+	return x
+}
+
+func BigMinUint256(x, y *uint256.Int) *uint256.Int {
+	if x.Gt(y) {
+		return y
+	}
+
 	return x
 }
 
@@ -227,10 +248,10 @@ func U256Bytes(n *big.Int) []byte {
 // S256 interprets x as a two's complement number.
 // x must not exceed 256 bits (the result is undefined if it does) and is not modified.
 //
-//   S256(0)        = 0
-//   S256(1)        = 1
-//   S256(2**255)   = -2**255
-//   S256(2**256-1) = -1
+//	S256(0)        = 0
+//	S256(1)        = 1
+//	S256(2**255)   = -2**255
+//	S256(2**256-1) = -1
 func S256(x *big.Int) *big.Int {
 	if x.Cmp(tt255) < 0 {
 		return x

--- a/common/math/uint.go
+++ b/common/math/uint.go
@@ -1,0 +1,14 @@
+package math
+
+import (
+	"github.com/holiman/uint256"
+)
+
+var (
+	U1   = uint256.NewInt(1)
+	U100 = uint256.NewInt(100)
+)
+
+func U256LTE(a, b *uint256.Int) bool {
+	return a.Lt(b) || a.Eq(b)
+}

--- a/common/math/uint.go
+++ b/common/math/uint.go
@@ -1,14 +1,23 @@
 package math
 
 import (
+	"math/big"
+
 	"github.com/holiman/uint256"
 )
 
 var (
+	U0   = uint256.NewInt(0)
 	U1   = uint256.NewInt(1)
 	U100 = uint256.NewInt(100)
 )
 
 func U256LTE(a, b *uint256.Int) bool {
 	return a.Lt(b) || a.Eq(b)
+}
+
+func FromBig(v *big.Int) *uint256.Int {
+	u, _ := uint256.FromBig(v)
+
+	return u
 }

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -90,4 +92,54 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 			common.Big0,
 		)
 	}
+}
+
+var (
+	initialBaseFeeUint           = uint256.NewInt(params.InitialBaseFee)
+	baseFeeChangeDenominatorUint = uint256.NewInt(params.BaseFeeChangeDenominator)
+)
+
+// CalcBaseFee calculates the basefee of the header.
+func CalcBaseFeeUint(config *params.ChainConfig, parent *types.Header) *uint256.Int {
+	// If the current block is the first EIP-1559 block, return the InitialBaseFee.
+	if !config.IsLondon(parent.Number) {
+		return initialBaseFeeUint.Clone()
+	}
+
+	var (
+		parentGasTarget    = parent.GasLimit / params.ElasticityMultiplier
+		parentGasTargetBig = uint256.NewInt(parentGasTarget)
+	)
+
+	// If the parent gasUsed is the same as the target, the baseFee remains unchanged.
+	if parent.GasUsed == parentGasTarget {
+		return math.FromBig(parent.BaseFee)
+	}
+
+	if parent.GasUsed > parentGasTarget {
+		// If the parent block used more gas than its target, the baseFee should increase.
+		gasUsedDelta := uint256.NewInt(parent.GasUsed - parentGasTarget)
+
+		parentBaseFee := math.FromBig(parent.BaseFee)
+		x := gasUsedDelta.Mul(parentBaseFee, gasUsedDelta)
+		y := x.Div(x, parentGasTargetBig)
+		baseFeeDelta := math.BigMaxUint(
+			x.Div(y, baseFeeChangeDenominatorUint),
+			math.U1,
+		)
+
+		return x.Add(parentBaseFee, baseFeeDelta)
+	}
+
+	// Otherwise if the parent block used less gas than its target, the baseFee should decrease.
+	gasUsedDelta := uint256.NewInt(parentGasTarget - parent.GasUsed)
+	parentBaseFee := math.FromBig(parent.BaseFee)
+	x := gasUsedDelta.Mul(parentBaseFee, gasUsedDelta)
+	y := x.Div(x, parentGasTargetBig)
+	baseFeeDelta := x.Div(y, baseFeeChangeDenominatorUint)
+
+	return math.BigMaxUint(
+		x.Sub(parentBaseFee, baseFeeDelta),
+		math.U0.Clone(),
+	)
 }

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -19,7 +19,6 @@ package core
 import (
 	"container/heap"
 	"math"
-	"math/big"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -466,7 +465,7 @@ func (l *txList) LastElement() *types.Transaction {
 // then the heap is sorted based on the effective tip based on the given base fee.
 // If baseFee is nil then the sorting is based on gasFeeCap.
 type priceHeap struct {
-	baseFee *big.Int // heap should always be re-sorted after baseFee is changed
+	baseFee *uint256.Int // heap should always be re-sorted after baseFee is changed
 	list    []*types.Transaction
 }
 
@@ -487,14 +486,16 @@ func (h *priceHeap) Less(i, j int) bool {
 func (h *priceHeap) cmp(a, b *types.Transaction) int {
 	if h.baseFee != nil {
 		// Compare effective tips if baseFee is specified
-		if c := a.EffectiveGasTipCmp(b, h.baseFee); c != 0 {
+		if c := a.EffectiveGasTipTxUintCmp(b, h.baseFee); c != 0 {
 			return c
 		}
 	}
+
 	// Compare fee caps if baseFee is not specified or effective tips are equal
 	if c := a.GasFeeCapCmp(b); c != 0 {
 		return c
 	}
+
 	// Compare tips if effective tips and fee caps are equal
 	return a.GasTipCapCmp(b)
 }
@@ -674,7 +675,7 @@ func (l *txPricedList) Reheap() {
 
 // SetBaseFee updates the base fee and triggers a re-heap. Note that Removed is not
 // necessary to call right before SetBaseFee when processing a new block.
-func (l *txPricedList) SetBaseFee(baseFee *big.Int) {
+func (l *txPricedList) SetBaseFee(baseFee *uint256.Int) {
 	l.urgent.baseFee = baseFee
 	l.Reheap()
 }

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -268,9 +268,7 @@ func (m *txSortedMap) Flatten() types.Transactions {
 	defer m.m.Unlock()
 
 	// Copy the cache to prevent accidental modifications
-	cache := m.flatten()
-	txs := make(types.Transactions, len(cache))
-	copy(txs, cache)
+	txs := m.flatten()
 
 	return txs
 }

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -341,7 +341,6 @@ func (l *txList) Filter(costLimit *uint256.Int, gasLimit uint64) (types.Transact
 
 	// Filter out all the transactions above the account's funds
 	removed := l.txs.Filter(func(tx *types.Transaction) bool {
-		// SUSP!
 		cost, _ := uint256.FromBig(tx.Cost())
 		return tx.Gas() > gasLimit || cost.Cmp(costLimit) > 0
 	})

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -303,14 +303,18 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 			return false, nil
 		}
 	}
+
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)
+
 	if cost := tx.CostUint(); l.costcap == nil || l.costcap.Cmp(cost) < 0 {
 		l.costcap = cost
 	}
+
 	if gas := tx.Gas(); l.gascap < gas {
 		l.gascap = gas
 	}
+
 	return true, old
 }
 

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -383,9 +383,9 @@ func (l *txList) Filter(costLimit *uint256.Int, gasLimit uint64) (types.Transact
 	l.gascap = gasLimit
 
 	// Filter out all the transactions above the account's funds
-	var cost *uint256.Int
+	cost := uint256.NewInt(0)
 	removed := l.txs.Filter(func(tx *types.Transaction) bool {
-		cost, _ = uint256.FromBig(tx.Cost())
+		cost.SetFromBig(tx.Cost())
 		return tx.Gas() > gasLimit || cost.Gt(costLimit)
 	})
 

--- a/core/tx_list_test.go
+++ b/core/tx_list_test.go
@@ -17,9 +17,10 @@
 package core
 
 import (
-	"math/big"
 	"math/rand"
 	"testing"
+
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -60,7 +61,7 @@ func BenchmarkTxListAdd(b *testing.B) {
 		txs[i] = transaction(uint64(i), 0, key)
 	}
 	// Insert the transactions in a random order
-	priceLimit := big.NewInt(int64(DefaultTxPoolConfig.PriceLimit))
+	priceLimit := uint256.NewInt(DefaultTxPoolConfig.PriceLimit)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		list := newTxList(true)

--- a/core/tx_list_test.go
+++ b/core/tx_list_test.go
@@ -60,11 +60,15 @@ func BenchmarkTxListAdd(b *testing.B) {
 	for i := 0; i < len(txs); i++ {
 		txs[i] = transaction(uint64(i), 0, key)
 	}
+
 	// Insert the transactions in a random order
 	priceLimit := uint256.NewInt(DefaultTxPoolConfig.PriceLimit)
 	b.ResetTimer()
+	b.ReportAllocs()
+
 	for i := 0; i < b.N; i++ {
 		list := newTxList(true)
+
 		for _, v := range rand.Perm(len(txs)) {
 			list.Add(txs[v], DefaultTxPoolConfig.PriceBump)
 			list.Filter(priceLimit, DefaultTxPoolConfig.PriceBump)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1376,8 +1376,9 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 	// Track the promoted transactions to broadcast them at once
 	var (
 		promoted []*types.Transaction
-		balance  *uint256.Int
 	)
+
+	balance := uint256.NewInt(0)
 
 	// Iterate over all accounts and promote any executable transactions
 	for _, addr := range accounts {
@@ -1393,7 +1394,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
 		// Drop all transactions that are too costly (low balance or out of gas)
-		balance, _ = uint256.FromBig(pool.currentState.GetBalance(addr))
+		balance.SetFromBig(pool.currentState.GetBalance(addr))
 		drops, _ := list.Filter(balance, pool.currentMaxGas)
 		for _, tx := range drops {
 			hash := tx.Hash()

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -250,9 +250,8 @@ type TxPool struct {
 	pendingNonces *txNoncer      // Pending state tracking virtual nonces
 	currentMaxGas uint64         // Current gas limit for transaction caps
 
-	locals   *accountSet // Set of local transaction to exempt from eviction rules
-	localsMu sync.RWMutex
-	journal  *txJournal // Journal of local transaction to back up to disk
+	locals  *accountSet // Set of local transaction to exempt from eviction rules
+	journal *txJournal  // Journal of local transaction to back up to disk
 
 	pending      map[common.Address]*txList // All currently processable transactions
 	pendingCount int
@@ -1584,6 +1583,7 @@ func (pool *TxPool) truncatePending() {
 	for addr, list := range pool.pending {
 		// Only evict transactions from high rollers
 		listLen = len(list.txs.items)
+
 		pool.locals.m.RLock()
 
 		if uint64(listLen) > pool.config.AccountSlots {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1683,6 +1683,7 @@ func (pool *TxPool) truncatePending() {
 					pool.pendingNonces.setIfLower(addr, tx.Nonce())
 					log.Trace("Removed fairness-exceeding pending transaction", "hash", hash)
 				}
+
 				pool.priced.Removed(capsLen)
 
 				pendingGauge.Dec(int64(capsLen))
@@ -1737,11 +1738,15 @@ func (pool *TxPool) truncateQueue() {
 
 		addresses = addresses[:len(addresses)-1]
 
-		var listFlatten types.Transactions
+		var (
+			listFlatten types.Transactions
+			isSet       bool
+		)
 
 		// Drop all transactions if they are less than the overflow
 		if size = uint64(list.Len()); size <= drop {
 			listFlatten = list.Flatten()
+			isSet = true
 
 			for _, tx = range listFlatten {
 				pool.removeTx(tx.Hash(), true)
@@ -1754,7 +1759,7 @@ func (pool *TxPool) truncateQueue() {
 		}
 
 		// Otherwise drop only last few transactions
-		if listFlatten == nil {
+		if !isSet {
 			listFlatten = list.Flatten()
 		}
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -809,6 +809,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 		return old != nil, nil
 	}
 
+	// it is not an unlocking of unlocked because of the return in previous 'if'
 	pool.pendingMu.RUnlock()
 
 	// New transaction isn't replacing a pending one, push into queue

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1354,6 +1354,7 @@ func (pool *TxPool) scheduleReorgLoop() {
 }
 
 // runReorg runs reset and promoteExecutables on behalf of scheduleReorgLoop.
+//nolint:gocognit
 func (pool *TxPool) runReorg(ctx context.Context, done chan struct{}, reset *txpoolResetRequest, dirtyAccounts *accountSet, events map[common.Address]*txSortedMap) {
 	tracing.Exec(ctx, "txpool-reorg", func(ctx context.Context, span trace.Span) {
 		defer func(t0 time.Time) {
@@ -1707,6 +1708,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 			delete(pool.beats, addr)
 		}
 	}
+
 	return promoted
 }
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -627,12 +627,13 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrFeeCapVeryHigh
 	}
 
-	if gasFeeCap.BitLen() > 256 {
+	gasTipCap := tx.GasTipCapRef()
+	if gasTipCap.BitLen() > 256 {
 		return ErrTipVeryHigh
 	}
 
 	// Ensure gasFeeCap is greater than or equal to gasTipCap.
-	if tx.GasFeeCapIntCmp(gasFeeCap) < 0 {
+	if tx.GasFeeCapIntCmp(gasTipCap) < 0 {
 		return ErrTipAboveFeeCap
 	}
 

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -2685,23 +2685,23 @@ func BenchmarkPoolBatchInsert(b *testing.B) {
 		{size: 10000, isLocal: true},
 	}
 
-	for _, testCase := range cases {
-		testCase.name = fmt.Sprintf(format, testCase.size, testCase.isLocal)
+	for i := range cases {
+		cases[i].name = fmt.Sprintf(format, cases[i].size, cases[i].isLocal)
 	}
 
 	// Benchmark importing the transactions into the queue
 
 	for _, testCase := range cases {
-		testCase := testCase
+		singleCase := testCase
 
-		b.Run(testCase.name, func(b *testing.B) {
+		b.Run(singleCase.name, func(b *testing.B) {
 			batches := make([]types.Transactions, b.N)
 
 			for i := 0; i < b.N; i++ {
-				batches[i] = make(types.Transactions, testCase.size)
+				batches[i] = make(types.Transactions, singleCase.size)
 
-				for j := 0; j < testCase.size; j++ {
-					batches[i][j] = transaction(uint64(testCase.size*i+j), 100000, key)
+				for j := 0; j < singleCase.size; j++ {
+					batches[i][j] = transaction(uint64(singleCase.size*i+j), 100000, key)
 				}
 			}
 
@@ -2886,11 +2886,15 @@ func BenchmarkPoolAccountsBatchInsert(b *testing.B) {
 	defer pool.Stop()
 
 	batches := make(types.Transactions, b.N)
+
 	for i := 0; i < b.N; i++ {
 		key, _ := crypto.GenerateKey()
 		account := crypto.PubkeyToAddress(key.PublicKey)
+
 		pool.currentState.AddBalance(account, big.NewInt(1000000))
+
 		tx := transaction(uint64(0), 100000, key)
+
 		batches[i] = tx
 	}
 

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -2729,7 +2729,7 @@ func BenchmarkPoolMining(b *testing.B) {
 		{size: 1},
 		{size: 5},
 		{size: 10},
-		//{size: 100},
+		{size: 20},
 	}
 
 	for i := range cases {

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
 	"gonum.org/v1/gonum/floats"
 	"gonum.org/v1/gonum/stat"
 	"pgregory.net/rapid"
@@ -326,6 +327,7 @@ func TestInvalidTransactions(t *testing.T) {
 
 	tx = transaction(1, 100000, key)
 	pool.gasPrice = big.NewInt(1000)
+	pool.gasPriceUint = uint256.NewInt(1000)
 	if err := pool.AddRemote(tx); err != ErrUnderpriced {
 		t.Error("expected", ErrUnderpriced, "got", err)
 	}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -2465,6 +2465,7 @@ func benchmarkPendingDemotion(b *testing.B, size int) {
 	}
 	// Benchmark the speed of pool validation
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		pool.demoteUnexecutables()
 	}
@@ -2521,6 +2522,7 @@ func benchmarkPoolBatchInsert(b *testing.B, size int, local bool) {
 	}
 	// Benchmark importing the transactions into the queue
 	b.ResetTimer()
+	b.ReportAllocs()
 	for _, batch := range batches {
 		if local {
 			pool.AddLocals(batch)

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -2828,6 +2828,7 @@ func newTx(pool *TxPool) *types.Transaction {
 	key, _ := crypto.GenerateKey()
 	account := crypto.PubkeyToAddress(key.PublicKey)
 	tx := transaction(uint64(0), 100000, key)
+
 	pool.currentState.AddBalance(account, big.NewInt(1000000))
 
 	return tx

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -19,18 +19,21 @@ package types
 import (
 	"math/big"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
 // LegacyTx is the transaction data of regular Ethereum transactions.
 type LegacyTx struct {
-	Nonce    uint64          // nonce of sender account
-	GasPrice *big.Int        // wei per gas
-	Gas      uint64          // gas limit
-	To       *common.Address `rlp:"nil"` // nil means contract creation
-	Value    *big.Int        // wei amount
-	Data     []byte          // contract invocation input data
-	V, R, S  *big.Int        // signature values
+	Nonce           uint64          // nonce of sender account
+	GasPrice        *big.Int        // wei per gas
+	gasPriceUint256 *uint256.Int    // wei per gas
+	Gas             uint64          // gas limit
+	To              *common.Address `rlp:"nil"` // nil means contract creation
+	Value           *big.Int        // wei amount
+	Data            []byte          // contract invocation input data
+	V, R, S         *big.Int        // signature values
 }
 
 // NewTransaction creates an unsigned legacy transaction.
@@ -77,6 +80,12 @@ func (tx *LegacyTx) copy() TxData {
 	}
 	if tx.GasPrice != nil {
 		cpy.GasPrice.Set(tx.GasPrice)
+
+		if cpy.gasPriceUint256 != nil {
+			cpy.gasPriceUint256.Set(tx.gasPriceUint256)
+		} else {
+			cpy.gasPriceUint256, _ = uint256.FromBig(tx.GasPrice)
+		}
 	}
 	if tx.V != nil {
 		cpy.V.Set(tx.V)
@@ -97,11 +106,38 @@ func (tx *LegacyTx) accessList() AccessList { return nil }
 func (tx *LegacyTx) data() []byte           { return tx.Data }
 func (tx *LegacyTx) gas() uint64            { return tx.Gas }
 func (tx *LegacyTx) gasPrice() *big.Int     { return tx.GasPrice }
-func (tx *LegacyTx) gasTipCap() *big.Int    { return tx.GasPrice }
-func (tx *LegacyTx) gasFeeCap() *big.Int    { return tx.GasPrice }
-func (tx *LegacyTx) value() *big.Int        { return tx.Value }
-func (tx *LegacyTx) nonce() uint64          { return tx.Nonce }
-func (tx *LegacyTx) to() *common.Address    { return tx.To }
+func (tx *LegacyTx) gasPriceU256() *uint256.Int {
+	if tx.gasPriceUint256 != nil {
+		return tx.gasPriceUint256
+	}
+
+	tx.gasPriceUint256, _ = uint256.FromBig(tx.GasPrice)
+
+	return tx.gasPriceUint256
+}
+func (tx *LegacyTx) gasTipCap() *big.Int { return tx.GasPrice }
+func (tx *LegacyTx) gasTipCapU256() *uint256.Int {
+	if tx.gasPriceUint256 != nil {
+		return tx.gasPriceUint256
+	}
+
+	tx.gasPriceUint256, _ = uint256.FromBig(tx.GasPrice)
+
+	return tx.gasPriceUint256
+}
+func (tx *LegacyTx) gasFeeCap() *big.Int { return tx.GasPrice }
+func (tx *LegacyTx) gasFeeCapU256() *uint256.Int {
+	if tx.gasPriceUint256 != nil {
+		return tx.gasPriceUint256
+	}
+
+	tx.gasPriceUint256, _ = uint256.FromBig(tx.GasPrice)
+
+	return tx.gasPriceUint256
+}
+func (tx *LegacyTx) value() *big.Int     { return tx.Value }
+func (tx *LegacyTx) nonce() uint64       { return tx.Nonce }
+func (tx *LegacyTx) to() *common.Address { return tx.To }
 
 func (tx *LegacyTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -326,7 +326,7 @@ func (tx *Transaction) GasFeeCapCmp(other *Transaction) int {
 }
 
 func (tx *Transaction) GasFeeCapIntCmp(other *big.Int) int {
-	return tx.inner.gasTipCap().Cmp(other)
+	return tx.inner.gasFeeCap().Cmp(other)
 }
 
 func (tx *Transaction) GasFeeCapUIntCmp(other *uint256.Int) int {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -412,7 +412,6 @@ func (tx *Transaction) EffectiveGasTipUintLt(other *uint256.Int, baseFee *uint25
 
 func (tx *Transaction) EffectiveGasTipTxUintCmp(other *Transaction, baseFee *uint256.Int) int {
 	if baseFee == nil {
-		return tx.GasTipCapCmp(other)
 		return tx.inner.gasTipCapU256().Cmp(other.inner.gasTipCapU256())
 	}
 
@@ -430,6 +429,7 @@ func (tx *Transaction) EffectiveGasTipUnit(baseFee *uint256.Int) (*uint256.Int, 
 	}
 
 	var err error
+
 	gasFeeCap := tx.GasFeeCapUint()
 
 	if gasFeeCap.Lt(baseFee) {
@@ -447,8 +447,10 @@ func (tx *Transaction) EffectiveGasTipUnit(baseFee *uint256.Int) (*uint256.Int, 
 	}
 
 	gasFeeCap.Sub(gasFeeCap, baseFee)
+
 	if gasFeeCap.Gt(gasTipCapUint) || gasFeeCap.Eq(gasTipCapUint) {
 		gasFeeCap.Add(gasFeeCap, baseFee)
+
 		return gasTipCapUint, err
 	}
 
@@ -645,6 +647,7 @@ func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transa
 func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transactions, baseFee *uint256.Int) *TransactionsByPriceAndNonce {
 	// Initialize a price and received time based heap with the head transactions
 	heads := make(TxByPriceAndTime, 0, len(txs))
+
 	for from, accTxs := range txs {
 		if len(accTxs) == 0 {
 			continue
@@ -652,14 +655,17 @@ func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transa
 
 		acc, _ := Sender(signer, accTxs[0])
 		wrapped, err := NewTxWithMinerFee(accTxs[0], baseFee)
+
 		// Remove transaction if sender doesn't match from, or if wrapping fails.
 		if acc != from || err != nil {
 			delete(txs, from)
 			continue
 		}
+
 		heads = append(heads, wrapped)
 		txs[from] = accTxs[1:]
 	}
+
 	heap.Init(&heads)
 
 	// Assemble and return the transaction set

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -79,8 +79,11 @@ type TxData interface {
 	data() []byte
 	gas() uint64
 	gasPrice() *big.Int
+	gasPriceU256() *uint256.Int
 	gasTipCap() *big.Int
+	gasTipCapU256() *uint256.Int
 	gasFeeCap() *big.Int
+	gasFeeCapU256() *uint256.Int
 	value() *big.Int
 	nonce() uint64
 	to() *common.Address
@@ -267,28 +270,22 @@ func (tx *Transaction) AccessList() AccessList { return tx.inner.accessList() }
 func (tx *Transaction) Gas() uint64 { return tx.inner.gas() }
 
 // GasPrice returns the gas price of the transaction.
-func (tx *Transaction) GasPrice() *big.Int    { return new(big.Int).Set(tx.inner.gasPrice()) }
-func (tx *Transaction) GasPriceRef() *big.Int { return tx.inner.gasPrice() }
+func (tx *Transaction) GasPrice() *big.Int         { return new(big.Int).Set(tx.inner.gasPrice()) }
+func (tx *Transaction) GasPriceRef() *big.Int      { return tx.inner.gasPrice() }
+func (tx *Transaction) GasPriceUint() *uint256.Int { return tx.inner.gasPriceU256() }
 
 // GasTipCap returns the gasTipCap per gas of the transaction.
-func (tx *Transaction) GasTipCap() *big.Int    { return new(big.Int).Set(tx.inner.gasTipCap()) }
-func (tx *Transaction) GasTipCapRef() *big.Int { return tx.inner.gasTipCap() }
-func (tx *Transaction) GasTipCapUint() *uint256.Int {
-	b, _ := uint256.FromBig(tx.inner.gasTipCap())
-	return b
-}
+func (tx *Transaction) GasTipCap() *big.Int         { return new(big.Int).Set(tx.inner.gasTipCap()) }
+func (tx *Transaction) GasTipCapRef() *big.Int      { return tx.inner.gasTipCap() }
+func (tx *Transaction) GasTipCapUint() *uint256.Int { return tx.inner.gasTipCapU256() }
 
 // GasFeeCap returns the fee cap per gas of the transaction.
-func (tx *Transaction) GasFeeCap() *big.Int    { return new(big.Int).Set(tx.inner.gasFeeCap()) }
-func (tx *Transaction) GasFeeCapRef() *big.Int { return tx.inner.gasFeeCap() }
-func (tx *Transaction) GasFeeCapUint() *uint256.Int {
-	b, _ := uint256.FromBig(tx.inner.gasFeeCap())
-	return b
-}
+func (tx *Transaction) GasFeeCap() *big.Int         { return new(big.Int).Set(tx.inner.gasFeeCap()) }
+func (tx *Transaction) GasFeeCapRef() *big.Int      { return tx.inner.gasFeeCap() }
+func (tx *Transaction) GasFeeCapUint() *uint256.Int { return tx.inner.gasFeeCapU256() }
 
 // Value returns the ether amount of the transaction.
-func (tx *Transaction) Value() *big.Int { return new(big.Int).Set(tx.inner.value()) }
-
+func (tx *Transaction) Value() *big.Int    { return new(big.Int).Set(tx.inner.value()) }
 func (tx *Transaction) ValueRef() *big.Int { return tx.inner.value() }
 
 // Nonce returns the sender account nonce of the transaction.
@@ -328,14 +325,16 @@ func (tx *Transaction) GasFeeCapCmp(other *Transaction) int {
 	return tx.inner.gasFeeCap().Cmp(other.inner.gasFeeCap())
 }
 
-// GasFeeCapIntCmp compares the fee cap of the transaction against the given fee cap.
 func (tx *Transaction) GasFeeCapIntCmp(other *big.Int) int {
-	return tx.inner.gasFeeCap().Cmp(other)
+	return tx.inner.gasTipCap().Cmp(other)
 }
 
 func (tx *Transaction) GasFeeCapUIntCmp(other *uint256.Int) int {
-	b, _ := uint256.FromBig(tx.inner.gasFeeCap())
-	return b.Cmp(other)
+	return tx.inner.gasFeeCapU256().Cmp(other)
+}
+
+func (tx *Transaction) GasFeeCapUIntLt(other *uint256.Int) bool {
+	return tx.inner.gasFeeCapU256().Lt(other)
 }
 
 // GasTipCapCmp compares the gasTipCap of two transactions.
@@ -349,8 +348,11 @@ func (tx *Transaction) GasTipCapIntCmp(other *big.Int) int {
 }
 
 func (tx *Transaction) GasTipCapUIntCmp(other *uint256.Int) int {
-	b, _ := uint256.FromBig(tx.inner.gasTipCap())
-	return b.Cmp(other)
+	return tx.inner.gasTipCapU256().Cmp(other)
+}
+
+func (tx *Transaction) GasTipCapUIntLt(other *uint256.Int) bool {
+	return tx.inner.gasTipCapU256().Lt(other)
 }
 
 // EffectiveGasTip returns the effective miner gasTipCap for the given base fee.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -281,6 +281,10 @@ func (tx *Transaction) GasTipCapUint() *uint256.Int {
 // GasFeeCap returns the fee cap per gas of the transaction.
 func (tx *Transaction) GasFeeCap() *big.Int    { return new(big.Int).Set(tx.inner.gasFeeCap()) }
 func (tx *Transaction) GasFeeCapRef() *big.Int { return tx.inner.gasFeeCap() }
+func (tx *Transaction) GasFeeCapUint() *uint256.Int {
+	b, _ := uint256.FromBig(tx.inner.gasFeeCap())
+	return b
+}
 
 // Value returns the ether amount of the transaction.
 func (tx *Transaction) Value() *big.Int { return new(big.Int).Set(tx.inner.value()) }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -333,6 +333,11 @@ func (tx *Transaction) GasFeeCapIntCmp(other *big.Int) int {
 	return tx.inner.gasFeeCap().Cmp(other)
 }
 
+func (tx *Transaction) GasFeeCapUIntCmp(other *uint256.Int) int {
+	b, _ := uint256.FromBig(tx.inner.gasFeeCap())
+	return b.Cmp(other)
+}
+
 // GasTipCapCmp compares the gasTipCap of two transactions.
 func (tx *Transaction) GasTipCapCmp(other *Transaction) int {
 	return tx.inner.gasTipCap().Cmp(other.inner.gasTipCap())
@@ -341,6 +346,11 @@ func (tx *Transaction) GasTipCapCmp(other *Transaction) int {
 // GasTipCapIntCmp compares the gasTipCap of the transaction against the given gasTipCap.
 func (tx *Transaction) GasTipCapIntCmp(other *big.Int) int {
 	return tx.inner.gasTipCap().Cmp(other)
+}
+
+func (tx *Transaction) GasTipCapUIntCmp(other *uint256.Int) int {
+	b, _ := uint256.FromBig(tx.inner.gasTipCap())
+	return b.Cmp(other)
 }
 
 // EffectiveGasTip returns the effective miner gasTipCap for the given base fee.

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -130,12 +130,11 @@ func MustSignNewTx(prv *ecdsa.PrivateKey, s Signer, txdata TxData) *Transaction 
 // not match the signer used in the current call.
 func Sender(signer Signer, tx *Transaction) (common.Address, error) {
 	if sc := tx.from.Load(); sc != nil {
-		sigCache := sc.(sigCache)
 		// If the signer used to derive from in a previous
 		// call is not the same as used current, invalidate
 		// the cache.
-		if sigCache.signer.Equal(signer) {
-			return sigCache.from, nil
+		if sc.signer.Equal(signer) {
+			return sc.from, nil
 		}
 	}
 
@@ -143,7 +142,9 @@ func Sender(signer Signer, tx *Transaction) (common.Address, error) {
 	if err != nil {
 		return common.Address{}, err
 	}
-	tx.from.Store(sigCache{signer: signer, from: addr})
+
+	tx.from.Store(&sigCache{signer: signer, from: addr})
+
 	return addr, nil
 }
 

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -461,10 +461,10 @@ func (fs FrontierSigner) SignatureValues(tx *Transaction, sig []byte) (r, s, v *
 func (fs FrontierSigner) Hash(tx *Transaction) common.Hash {
 	return rlpHash([]interface{}{
 		tx.Nonce(),
-		tx.GasPrice(),
+		tx.GasPriceRef(),
 		tx.Gas(),
 		tx.To(),
-		tx.Value(),
+		tx.ValueRef(),
 		tx.Data(),
 	})
 }

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -27,7 +27,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/common"
+	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -272,13 +275,18 @@ func TestTransactionPriceNonceSort1559(t *testing.T) {
 // Tests that transactions can be correctly sorted according to their price in
 // decreasing order, but at the same time with increasing nonces when issued by
 // the same account.
-func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
+func testTransactionPriceNonceSort(t *testing.T, baseFeeBig *big.Int) {
 	// Generate a batch of accounts to start with
 	keys := make([]*ecdsa.PrivateKey, 25)
 	for i := 0; i < len(keys); i++ {
 		keys[i], _ = crypto.GenerateKey()
 	}
 	signer := LatestSignerForChainID(common.Big1)
+
+	var baseFee *uint256.Int
+	if baseFeeBig != nil {
+		baseFee = cmath.FromBig(baseFeeBig)
+	}
 
 	// Generate a batch of transactions with overlapping values, but shifted nonces
 	groups := map[common.Address]Transactions{}
@@ -308,7 +316,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 					GasTipCap: big.NewInt(int64(rand.Intn(gasFeeCap + 1))),
 					Data:      nil,
 				})
-				if count == 25 && int64(gasFeeCap) < baseFee.Int64() {
+				if count == 25 && uint64(gasFeeCap) < baseFee.Uint64() {
 					count = i
 				}
 			}
@@ -345,8 +353,20 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 		if i+1 < len(txs) {
 			next := txs[i+1]
 			fromNext, _ := Sender(signer, next)
-			tip, err := txi.EffectiveGasTip(baseFee)
-			nextTip, nextErr := next.EffectiveGasTip(baseFee)
+			tip, err := txi.EffectiveGasTipUnit(baseFee)
+			nextTip, nextErr := next.EffectiveGasTipUnit(baseFee)
+
+			tipBig, _ := txi.EffectiveGasTip(baseFeeBig)
+			nextTipBig, _ := next.EffectiveGasTip(baseFeeBig)
+
+			if tip.Cmp(cmath.FromBig(tipBig)) != 0 {
+				t.Fatalf("EffectiveGasTip incorrect. uint256 %q, big.Int %q", tip.String(), tipBig.String())
+			}
+
+			if nextTip.Cmp(cmath.FromBig(nextTipBig)) != 0 {
+				t.Fatalf("EffectiveGasTip next incorrect. uint256 %q, big.Int %q", nextTip.String(), nextTipBig.String())
+			}
+
 			if err != nil || nextErr != nil {
 				t.Errorf("error calculating effective tip")
 			}

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -275,12 +275,15 @@ func TestTransactionPriceNonceSort1559(t *testing.T) {
 // Tests that transactions can be correctly sorted according to their price in
 // decreasing order, but at the same time with increasing nonces when issued by
 // the same account.
+//
+//nolint:gocognit,thelper
 func testTransactionPriceNonceSort(t *testing.T, baseFeeBig *big.Int) {
 	// Generate a batch of accounts to start with
 	keys := make([]*ecdsa.PrivateKey, 25)
 	for i := 0; i < len(keys); i++ {
 		keys[i], _ = crypto.GenerateKey()
 	}
+
 	signer := LatestSignerForChainID(common.Big1)
 
 	var baseFee *uint256.Int
@@ -349,6 +352,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFeeBig *big.Int) {
 				t.Errorf("invalid nonce ordering: tx #%d (A=%x N=%v) < tx #%d (A=%x N=%v)", i, fromi[:4], txi.Nonce(), i+j, fromj[:4], txj.Nonce())
 			}
 		}
+
 		// If the next tx has different from account, the price must be lower than the current one
 		if i+1 < len(txs) {
 			next := txs[i+1]

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -236,7 +236,14 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 }
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
-	return b.eth.txPool.AddLocal(signedTx)
+	err := b.eth.txPool.AddLocal(signedTx)
+	if err != nil {
+		if unwrapped := errors.Unwrap(err); unwrapped != nil {
+			return unwrapped
+		}
+	}
+
+	return err
 }
 
 func (b *EthAPIBackend) GetPoolTransactions() (types.Transactions, error) {

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -617,7 +617,7 @@ func testTransactionStatus(t *testing.T, protocol int) {
 			sendRequest(rawPeer.app, GetTxStatusMsg, reqID, []common.Hash{tx.Hash()})
 		}
 		if err := expectResponse(rawPeer.app, TxStatusMsg, reqID, testBufLimit, []light.TxStatus{expStatus}); err != nil {
-			t.Errorf("transaction status mismatch")
+			t.Error("transaction status mismatch", err)
 		}
 	}
 	signer := types.HomesteadSigner{}

--- a/les/server_requests.go
+++ b/les/server_requests.go
@@ -523,7 +523,7 @@ func handleSendTx(msg Decoder) (serveRequestFn, uint64, uint64, error) {
 				if backend.AddTxsSync() {
 					addFn = backend.TxPool().AddRemotesSync
 				}
-				if errs := addFn([]*types.Transaction{tx}); errs[0] != nil {
+				if errs := addFn([]*types.Transaction{tx}); len(errs) != 0 {
 					err := errs[0].Error()
 
 					// we receive a wrapped error

--- a/les/server_requests.go
+++ b/les/server_requests.go
@@ -519,8 +519,8 @@ func handleSendTx(msg Decoder) (serveRequestFn, uint64, uint64, error) {
 			stats[i] = txStatus(backend, hash)
 			if stats[i].Status == core.TxStatusUnknown {
 				addFn := backend.TxPool().AddRemotes
-				
-// Add txs synchronously for testing purpose
+
+				// Add txs synchronously for testing purpose
 				if backend.AddTxsSync() {
 					addFn = backend.TxPool().AddRemotesSync
 				}

--- a/les/server_requests.go
+++ b/les/server_requests.go
@@ -523,6 +523,7 @@ func handleSendTx(msg Decoder) (serveRequestFn, uint64, uint64, error) {
 				if backend.AddTxsSync() {
 					addFn = backend.TxPool().AddRemotesSync
 				}
+
 				if errs := addFn([]*types.Transaction{tx}); len(errs) != 0 {
 					err := errs[0].Error()
 

--- a/les/server_requests.go
+++ b/les/server_requests.go
@@ -19,6 +19,7 @@ package les
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -523,7 +524,15 @@ func handleSendTx(msg Decoder) (serveRequestFn, uint64, uint64, error) {
 					addFn = backend.TxPool().AddRemotesSync
 				}
 				if errs := addFn([]*types.Transaction{tx}); errs[0] != nil {
-					stats[i].Error = errs[0].Error()
+					err := errs[0].Error()
+
+					// we receive a wrapped error
+					if unwrapped := errors.Unwrap(errs[0]); unwrapped != nil {
+						err = unwrapped.Error()
+					}
+
+					stats[i].Error = err
+
 					continue
 				}
 				stats[i] = txStatus(backend, hash)


### PR DESCRIPTION
It mostly keeps the same logic and just rearranges variables.

Was BenchmarkPoolMultiAccountBatchInsert-10    	   10000	    168668 ns/op	   19387 B/op	      81 allocs/op
Now BenchmarkPoolMultiAccountBatchInsert-10    	   10000	    100608 ns/op	    2895 B/op	      52 allocs/op

a bit better 'now':
BenchmarkPoolMultiAccountBatchInsert-10    	   12112	    104955 ns/op	    2678 B/op	      47 allocs/op

```
name                                      old time/op    new time/op    delta
PoolBatchInsert100-10                       5.95ms ± 3%    5.97ms ± 0%     ~     (p=0.730 n=5+4)
PoolBatchInsert1000-10                      59.3ms ± 2%    59.0ms ± 0%     ~     (p=0.690 n=5+5)
PoolBatchInsert10000-10                      591ms ± 1%     594ms ± 0%     ~     (p=0.556 n=5+4)
PoolBatchLocalInsert100-10                  6.58ms ± 1%    6.53ms ± 2%     ~     (p=0.151 n=5+5)
PoolBatchLocalInsert1000-10                 68.8ms ± 6%    65.3ms ± 5%     ~     (p=0.056 n=5+5)
PoolBatchLocalInsert10000-10                 665ms ± 3%     639ms ± 4%     ~     (p=0.056 n=5+5)
PoolMultiAccountBatchInsert-10               169µs ±10%     108µs ±16%  -35.88%  (p=0.008 n=5+5)
PoolMultiAccountBatchInsertRace-10          2.94ms ± 9%    0.43ms ±16%  -85.48%  (p=0.008 n=5+5)
PoolMultiAccountBatchInsertNoLockRace-10     10.0s ± 0%     10.0s ± 0%     ~     (p=0.310 n=5+5)


name                                      old allocs/op  new allocs/op  delta
PoolBatchInsert100-10                        5.17k ± 0%     2.99k ± 0%  -42.15%  (p=0.008 n=5+5)
PoolBatchInsert1000-10                       51.7k ± 0%     29.8k ± 0%  -42.31%  (p=0.008 n=5+5)
PoolBatchInsert10000-10                       474k ± 0%      260k ± 0%  -45.17%  (p=0.008 n=5+5)
PoolBatchLocalInsert100-10                   5.95k ± 0%     3.24k ± 0%  -45.44%  (p=0.008 n=5+5)
PoolBatchLocalInsert1000-10                  58.8k ± 0%     31.8k ± 0%  -45.92%  (p=0.008 n=5+5)
PoolBatchLocalInsert10000-10                  587k ± 0%      317k ± 0%  -45.97%  (p=0.008 n=5+5)
PoolMultiAccountBatchInsert-10                79.0 ± 0%      51.0 ± 0%  -35.44%  (p=0.000 n=5+4)
PoolMultiAccountBatchInsertRace-10           14.8k ±10%      2.3k ± 1%  -84.47%  (p=0.008 n=5+5)
PoolMultiAccountBatchInsertNoLockRace-10       148 ±20%       113 ± 8%  -23.56%  (p=0.029 n=4+4)

```

[old.txt](https://github.com/maticnetwork/bor/files/9841925/old.txt)
