### PR TITLE
metrics: handle values from config file

### DIFF
--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -253,6 +253,12 @@ func (s *Server) Stop() {
 }
 
 func (s *Server) setupMetrics(config *TelemetryConfig, serviceName string) error {
+	// Check the global metrics if they're matching with the provided config
+	if metrics.Enabled != config.Enabled || metrics.EnabledExpensive != config.Expensive {
+		log.Warn("Metric misconfiguration, some of them might not be visible")
+	}
+
+	// Update the values anyways (for services which don't need immediate attention)
 	metrics.Enabled = config.Enabled
 	metrics.EnabledExpensive = config.Expensive
 
@@ -262,6 +268,10 @@ func (s *Server) setupMetrics(config *TelemetryConfig, serviceName string) error
 	}
 
 	log.Info("Enabling metrics collection")
+
+	if metrics.EnabledExpensive {
+		log.Info("Enabling expensive metrics collection")
+	}
 
 	// influxdb
 	if v1Enabled, v2Enabled := config.InfluxDB.V1Enabled, config.InfluxDB.V2Enabled; v1Enabled || v2Enabled {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
+	"github.com/BurntSushi/toml"
 )
 
 // Enabled is checked by the constructor functions for all of the
@@ -32,26 +32,71 @@ var enablerFlags = []string{"metrics"}
 // expensiveEnablerFlags is the CLI flag names to use to enable metrics collections.
 var expensiveEnablerFlags = []string{"metrics.expensive"}
 
+// configFlag is the CLI flag name to use to start node by providing a toml based config
+var configFlag = "config"
+
 // Init enables or disables the metrics system. Since we need this to run before
 // any other code gets to create meters and timers, we'll actually do an ugly hack
 // and peek into the command line args for the metrics flag.
 func init() {
-	for _, arg := range os.Args {
+	var configFile string
+
+	for i := 0; i < len(os.Args); i++ {
+		arg := os.Args[i]
+
 		flag := strings.TrimLeft(arg, "-")
+
+		// check for existence of `config` flag
+		if flag == configFlag && i < len(os.Args)-1 {
+			configFile = strings.TrimLeft(os.Args[i+1], "-") // find the value of flag
+		}
 
 		for _, enabler := range enablerFlags {
 			if !Enabled && flag == enabler {
-				log.Info("Enabling metrics collection")
 				Enabled = true
 			}
 		}
+
 		for _, enabler := range expensiveEnablerFlags {
 			if !EnabledExpensive && flag == enabler {
-				log.Info("Enabling expensive metrics collection")
 				EnabledExpensive = true
 			}
 		}
 	}
+
+	// Update the global metrics value, if they're provided in the config file
+	updateMetricsFromConfig(configFile)
+}
+
+func updateMetricsFromConfig(path string) {
+	// Don't act upon any errors here. They're already taken into
+	// consideration when the toml config file will be parsed in the cli.
+	data, err := os.ReadFile(path)
+	tomlData := string(data)
+
+	if err != nil {
+		return
+	}
+
+	// Create a minimal config to decode
+	type TelemetryConfig struct {
+		Enabled   bool `hcl:"metrics,optional" toml:"metrics,optional"`
+		Expensive bool `hcl:"expensive,optional" toml:"expensive,optional"`
+	}
+
+	type CliConfig struct {
+		Telemetry *TelemetryConfig `hcl:"telemetry,block" toml:"telemetry,block"`
+	}
+
+	conf := &CliConfig{}
+
+	if _, err := toml.Decode(tomlData, &conf); err != nil || conf == nil {
+		return
+	}
+
+	// We have the values now, update them
+	Enabled = conf.Telemetry.Enabled
+	EnabledExpensive = conf.Telemetry.Expensive
 }
 
 // CollectProcessMetrics periodically collects various metrics about the running


### PR DESCRIPTION
# Description

The metrics package uses global variables to enable metrics collection (with the flag `--metrics` and `--metrics.expensive`). As we're moving towards a toml config based approach, we found out that the values of these 2 parameters from toml file weren't being honoured in some cases. On further investigation we found out that due to the call to `init()` (in metrics/metrics.go), OS arguments were being read and metrics were being set based on those arguments. 

Now, there are some metrics which needs to be registered as soon the bor process starts. We were setting these global values but at much later point in the code when we're done setting up the node related processes which caused all the metric (meters, counters, gauges, etc) registrations to fail and hence leading to 0 values in prometheus. If we were to start bor using cli, it would work as it finds the flags in OS args but not in case of toml. 

This PR fixes this by reading the config file itself in the `init()` function of metrics package and enabling/disabling the global variables before any other process starts. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have tested this code manually on local environment
- [x] I have tested this code manually on mumbai/mainnet