### PR TITLE
fix incorrect geth merge

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -715,9 +715,11 @@ func (d *Downloader) fetchHead(p *peerConnection) (head *types.Header, pivot *ty
 // calculateRequestSpan calculates what headers to request from a peer when trying to determine the
 // common ancestor.
 // It returns parameters to be used for peer.RequestHeadersByNumber:
-//  from - starting block number
-//  count - number of headers to request
-//  skip - number of headers to skip
+//
+//	from - starting block number
+//	count - number of headers to request
+//	skip - number of headers to skip
+//
 // and also returns 'max', the last block which is expected to be returned by the remote peers,
 // given the (from,count,skip)
 func calculateRequestSpan(remoteHeight, localHeight uint64) (int64, int, int, uint64) {
@@ -828,7 +830,7 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 		return 0, err
 	}
 
-	ancestor, err = d.findAncestorBinarySearch(p, mode, localHeight+1, floor)
+	ancestor, err = d.findAncestorBinarySearch(p, mode, remoteHeight, floor)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
comparing to https://github.com/ethereum/go-ethereum/blame/master/eth/downloader/downloader.go#L859 we had an incorrect merge of one line

it might cause panics like:

```
Oct 22 09:48:54 XXX bash[4119]: WARN [10-22|09:48:54.146] Synchronisation failed, dropping peer  peer=6959798c87a0590d91137ef301940581df9a4a5e2c3c21514ebcf6fcbb41ecab err=timeout
Oct 22 09:48:54 XXX bash[4119]: panic: runtime error: invalid memory address or nil pointer dereference
Oct 22 09:48:54 XXX bash[4119]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x1c0 pc=0xafbb99]
Oct 22 09:48:54 XXX bash[4119]: goroutine 8219 [running]:
Oct 22 09:48:54 XXX bash[4119]: github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).findAncestorBinarySearch(0xc000184900, 0xc0302f9b00, 0x0, 0x20fbfd2, 0x20e6041)
Oct 22 09:48:54 XXX bash[4119]:     github.com/ethereum/go-ethereum/eth/downloader/downloader.go:939 +0x319
Oct 22 09:48:54 XXX bash[4119]: github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).findAncestor(0xc000184900, 0xc0302f9b00, 0x1e?)
Oct 22 09:48:54 XXX bash[4119]:     github.com/ethereum/go-ethereum/eth/downloader/downloader.go:831 +0x2df
Oct 22 09:48:54 XXX bash[4119]: github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).syncWithPeer(0xc000184900, 0xc0302f9b00, {0x58, 0x25, 0xe6, 0x45, 0xea, 0x2a, 0x2a, 0x89, ...}, ...)
Oct 22 09:48:54 XXX bash[4119]:     github.com/ethereum/go-ethereum/eth/downloader/downloader.go:495 +0x5fa
Oct 22 09:48:54 XXX bash[4119]: github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).synchronise(0x1?, {0xc035979240, 0x40}, {0x58, 0x25, 0xe6, 0x45, 0xea, 0x2a, 0x2a, ...}, ...)
Oct 22 09:48:54 XXX bash[4119]:     github.com/ethereum/go-ethereum/eth/downloader/downloader.go:434 +0x505
Oct 22 09:48:54 XXX bash[4119]: github.com/ethereum/go-ethereum/eth/downloader.(*Downloader).LegacySync(0xc000184900, {0xc035979240, 0x40}, {0x58, 0x25, 0xe6, 0x45, 0xea, 0x2a, 0x2a, ...}, ...)
Oct 22 09:48:54 XXX bash[4119]:     github.com/ethereum/go-ethereum/eth/downloader/downloader.go:329 +0x65
Oct 22 09:48:54 XXX bash[4119]: github.com/ethereum/go-ethereum/eth.(*handler).doSync(0xc01e9b8800, 0xc038799768?)
Oct 22 09:48:54 XXX bash[4119]:     github.com/ethereum/go-ethereum/eth/sync.go:255 +0x225
Oct 22 09:48:54 XXX bash[4119]: github.com/ethereum/go-ethereum/eth.(*chainSyncer).startSync.func1()
Oct 22 09:48:54 XXX bash[4119]:     github.com/ethereum/go-ethereum/eth/sync.go:231 +0x29
Oct 22 09:48:54 XXX bash[4119]: created by github.com/ethereum/go-ethereum/eth.(*chainSyncer).startSync
Oct 22 09:48:54 XXX bash[4119]:     github.com/ethereum/go-ethereum/eth/sync.go:231 +0xaa
Oct 22 09:48:54 XXX systemd[1]: bor.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Oct 22 09:48:54 XXX systemd[1]: bor.service: Failed with result 'exit-code'.

```