### PR TITLE
add : bor.logs in custom GetFilterLogs

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -419,6 +419,7 @@ func (api *PublicFilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*ty
 	borConfig := api.chainConfig.Bor
 
 	var filter *Filter
+
 	var borLogsFilter *BorBlockLogsFilter
 
 	if f.crit.BlockHash != nil {

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -460,7 +460,7 @@ func (api *PublicFilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*ty
 			return nil, err
 		}
 
-		return returnLogs(types.MergeBorLogs(logs, borBlockLogs)), err
+		return returnLogs(types.MergeBorLogs(logs, borBlockLogs)), nil
 	}
 
 	return returnLogs(logs), nil


### PR DESCRIPTION
In this PR, we add state-sync logs configurable using `--bor.logs` flag to the `GetFilterLogs` function, to also get state-sync transaction logs in the custom filters. 