### PR TITLE
Align config gpo.ignoreprice with txpool.pricelimit

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -87,11 +87,11 @@ syncmode = "full"
     # vhosts = ["*"]
     # corsdomain = ["*"]
 
-# [gpo]
+[gpo]
   # blocks = 20
   # percentile = 60
   # maxprice = "5000000000000"
-  # ignoreprice = "2"
+  ignoreprice = "30000000000"
 
 [telemetry]
   metrics = true


### PR DESCRIPTION
# Description

Just a config change, part of maticnetwork/launch#62.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it