### PR TITLE
Docker v0.3.0 release for QA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
 FROM golang:latest
 
-ARG BOR_DIR=/bor
+ARG BOR_DIR=/var/lib/bor
 ENV BOR_DIR=$BOR_DIR
 
 RUN apt-get update -y && apt-get upgrade -y \
     && apt install build-essential git -y \
-    && mkdir -p /bor
+    && mkdir -p ${BOR_DIR}
 
 WORKDIR ${BOR_DIR}
 COPY . .
 RUN make bor
 
-RUN cp build/bin/bor /usr/local/bin/
+RUN cp build/bin/bor /usr/bin/
+RUN groupadd -g 10137 bor \
+    && useradd -u 10137 --no-log-init --create-home -r -g bor bor \
+    && chown -R bor:bor ${BOR_DIR}
 
 ENV SHELL /bin/bash
 EXPOSE 8545 8546 8547 30303 30303/udp

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -13,6 +13,6 @@ RUN set -x \
     && apk add --update --no-cache \
        ca-certificates \
     && rm -rf /var/cache/apk/*
-COPY --from=builder /bor/build/bin/* /usr/local/bin/
+COPY --from=builder /bor/build/bin/* /usr/bin/
 
 EXPOSE 8545 8546 30303 30303/udp

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,10 +1,20 @@
 FROM alpine:3.14
 
+ARG BOR_DIR=/var/lib/bor
+ENV BOR_DIR=$BOR_DIR
+
 RUN apk add --no-cache ca-certificates && \
-    mkdir -p /etc/bor
-COPY bor /usr/local/bin/
-COPY builder/files/genesis-mainnet-v1.json /etc/bor/
-COPY builder/files/genesis-testnet-v4.json /etc/bor/
+    mkdir -p ${BOR_DIR}
+
+WORKDIR ${BOR_DIR}
+COPY bor /usr/bin/
+COPY builder/files/genesis-mainnet-v1.json ${BOR_DIR}
+COPY builder/files/genesis-testnet-v4.json ${BOR_DIR}
+RUN groupadd -g 10137 bor \
+    && useradd -u 10137 --no-log-init --create-home -r -g bor bor \
+    && chown -R bor:bor ${BOR_DIR}
+
+USER bor
 
 EXPOSE 8545 8546 8547 30303 30303/udp
 ENTRYPOINT ["bor"]


### PR DESCRIPTION
# Description

This PR updates the bor working directory to /var/lib/bor and runs the docker container as a non-root user (bor) as part of the v0.3.0 release. Same code changes as #591 but for the QA branch.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli
