### PR TITLE
Docker User

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,6 @@ COPY . .
 RUN make bor
 
 RUN cp build/bin/bor /usr/bin/
-RUN groupadd -g 10137 bor \
-    && useradd -u 10137 --no-log-init --create-home -r -g bor bor \
-    && chown -R bor:bor ${BOR_DIR}
 
 ENV SHELL /bin/bash
 EXPOSE 8545 8546 8547 30303 30303/udp

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -10,11 +10,6 @@ WORKDIR ${BOR_DIR}
 COPY bor /usr/bin/
 COPY builder/files/genesis-mainnet-v1.json ${BOR_DIR}
 COPY builder/files/genesis-testnet-v4.json ${BOR_DIR}
-RUN groupadd -g 10137 bor \
-    && useradd -u 10137 --no-log-init --create-home -r -g bor bor \
-    && chown -R bor:bor ${BOR_DIR}
-
-USER bor
 
 EXPOSE 8545 8546 8547 30303 30303/udp
 ENTRYPOINT ["bor"]


### PR DESCRIPTION
Reverts use of `bor` user in docker containers, reverting to previously used `root` user due to hard-coded file paths used in matic-cli