### PR TITLE
metrics: handle equal to separated config flag

### DIFF
--- a/builder/files/bor.service
+++ b/builder/files/bor.service
@@ -6,7 +6,7 @@
 [Service]
   Restart=on-failure
   RestartSec=5s
-  ExecStart=/usr/local/bin/bor server -config="/var/lib/bor/config.toml"
+  ExecStart=/usr/local/bin/bor server -config "/var/lib/bor/config.toml"
   Type=simple
   User=bor
   KillSignal=SIGINT

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -235,7 +235,13 @@ func (s *Server) Stop() {
 func (s *Server) setupMetrics(config *TelemetryConfig, serviceName string) error {
 	// Check the global metrics if they're matching with the provided config
 	if metrics.Enabled != config.Enabled || metrics.EnabledExpensive != config.Expensive {
-		log.Warn("Metric misconfiguration, some of them might not be visible")
+		log.Warn(
+			"Metric misconfiguration, some of them might not be visible",
+			"metrics", metrics.Enabled,
+			"config.metrics", config.Enabled,
+			"expensive", metrics.EnabledExpensive,
+			"config.expensive", config.Expensive,
+		)
 	}
 
 	// Update the values anyways (for services which don't need immediate attention)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -49,6 +49,9 @@ func init() {
 		// check for existence of `config` flag
 		if flag == configFlag && i < len(os.Args)-1 {
 			configFile = strings.TrimLeft(os.Args[i+1], "-") // find the value of flag
+		} else if len(flag) > 6 && flag[:6] == configFlag {
+			// Checks for `=` separated flag (e.g. config=path)
+			configFile = strings.TrimLeft(flag[6:], "=")
 		}
 
 		for _, enabler := range enablerFlags {

--- a/packaging/templates/systemd/bor.service
+++ b/packaging/templates/systemd/bor.service
@@ -6,7 +6,7 @@
 [Service]
   Restart=on-failure
   RestartSec=5s
-  ExecStart=/usr/bin/bor server -config="/var/lib/bor/config.toml"
+  ExecStart=/usr/bin/bor server -config "/var/lib/bor/config.toml"
   Type=simple
   KillSignal=SIGINT
   User=bor


### PR DESCRIPTION
# Description

The `init()` function in metrics used to read the config file provided by the user during start up and abstract the `metrics` and `metrics.expensive` flags. The case where the config file is provided using an "=" separated value (e.g. config=path) was breaking as it was considering the flag=value as the flag name itself. This PR fixes it. It also updates the bor.service files to not use that convention as a space separated key value pair is an ideal format. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- x ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli