### PR TITLE
fixed static-nodes related buf (os independent)

### DIFF
--- a/scripts/getconfig.go
+++ b/scripts/getconfig.go
@@ -375,7 +375,7 @@ func getStaticTrustedNodes(args []string) {
 			fmt.Println("only TOML config file is supported through CLI")
 		}
 	} else {
-		path := "~/.bor/data/bor/static-nodes.json"
+		path := "./static-nodes.json"
 		if !checkFileExists(path) {
 			return
 		}

--- a/scripts/getconfig.sh
+++ b/scripts/getconfig.sh
@@ -24,6 +24,14 @@ then
 fi
 read -p "* Your validator address (e.g. 0xca67a8D767e45056DC92384b488E9Af654d78DE2), or press Enter to skip if running a sentry node: " ADD
 
+if [[ -f $HOME/.bor/data/bor/static-nodes.json ]]
+then
+cp $HOME/.bor/data/bor/static-nodes.json ./static-nodes.json
+else
+read -p "* You dont have '~/.bor/data/bor/static-nodes.json' file. If you want to use static nodes, enter the path to 'static-nodes.json' here (press Enter to skip): " STAT
+if [[ -f $STAT ]]; then cp $STAT ./static-nodes.json; fi
+fi
+
 printf "\nThank you, your inputs are:\n"
 echo "Path to start.sh: "$startPath
 echo "Address: "$ADD
@@ -42,11 +50,6 @@ cleanup() {
     rm -rf "$tmpDir"
 }
 trap cleanup EXIT INT QUIT TERM
-
-if [[ -f $HOME/.bor/data/bor/static-nodes.json ]]
-then
-cp $HOME/.bor/data/bor/static-nodes.json ./static-nodes.json
-fi
 
 # SHA1 hash of `tempStart` -> `3305fe263dd4a999d58f96deb064e21bb70123d9`
 sed 's/bor --/go run getconfig.go notYet --/g' $startPath > $tmpDir/3305fe263dd4a999d58f96deb064e21bb70123d9.sh

--- a/scripts/getconfig.sh
+++ b/scripts/getconfig.sh
@@ -43,6 +43,11 @@ cleanup() {
 }
 trap cleanup EXIT INT QUIT TERM
 
+if [[ -f $HOME/.bor/data/bor/static-nodes.json ]]
+then
+cp $HOME/.bor/data/bor/static-nodes.json ./static-nodes.json
+fi
+
 # SHA1 hash of `tempStart` -> `3305fe263dd4a999d58f96deb064e21bb70123d9`
 sed 's/bor --/go run getconfig.go notYet --/g' $startPath > $tmpDir/3305fe263dd4a999d58f96deb064e21bb70123d9.sh
 chmod +x $tmpDir/3305fe263dd4a999d58f96deb064e21bb70123d9.sh
@@ -112,5 +117,10 @@ sed "s%bor --%go run getconfig.go ${confPath} --%" $startPath > $tmpDir/3305fe26
 chmod +x $tmpDir/3305fe263dd4a999d58f96deb064e21bb70123d9.sh
 $tmpDir/3305fe263dd4a999d58f96deb064e21bb70123d9.sh $ADD
 rm $tmpDir/3305fe263dd4a999d58f96deb064e21bb70123d9.sh
+
+if [[ -f $HOME/.bor/data/bor/static-nodes.json ]]
+then
+rm ./static-nodes.json
+fi
 
 exit 0


### PR DESCRIPTION
# Description

This PR fixed an issue with the conversion script's static-nodes part (`start.sh` to `config.toml`) by making it OS-independent.

Please provide a detailed description of what was done in this PR

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it