### PR TITLE
Update default flags

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -52,7 +52,7 @@ syncmode = "full"
   # pricebump = 10
 
 [miner]
-  gaslimit = 20000000
+  gaslimit = 30000000
   gasprice = "30000000000"
   # mine = true
   # etherbase = "VALIDATOR ADDRESS"
@@ -87,11 +87,11 @@ syncmode = "full"
     # vhosts = ["*"]
     # corsdomain = ["*"]
 
-# [gpo]
+[gpo]
   # blocks = 20
   # percentile = 60
   # maxprice = "5000000000000"
-  # ignoreprice = "2"
+  ignoreprice = "30000000000"
 
 [telemetry]
   metrics = true

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -428,7 +428,7 @@ func DefaultConfig() *Config {
 			NoLocals:     false,
 			Journal:      "transactions.rlp",
 			Rejournal:    1 * time.Hour,
-			PriceLimit:   30000000000,
+			PriceLimit:   1, // geth's default
 			PriceBump:    10,
 			AccountSlots: 16,
 			GlobalSlots:  32768,
@@ -439,8 +439,8 @@ func DefaultConfig() *Config {
 		Sealer: &SealerConfig{
 			Enabled:   false,
 			Etherbase: "",
-			GasCeil:   30_000_000,
-			GasPrice:  big.NewInt(1 * params.GWei),
+			GasCeil:   30_000_000,                  // geth's default
+			GasPrice:  big.NewInt(1 * params.GWei), // geth's default
 			ExtraData: "",
 		},
 		Gpo: &GpoConfig{

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -497,7 +497,7 @@ func DefaultConfig() *Config {
 			},
 		},
 		Cache: &CacheConfig{
-			Cache:         1024,
+			Cache:         1024, // geth's default (suitable for mumbai)
 			PercDatabase:  50,
 			PercTrie:      15,
 			PercGc:        25,
@@ -624,13 +624,6 @@ func (c *Config) loadChain() error {
 	// preload some default values that depend on the chain file
 	if c.P2P.Discovery.DNS == nil {
 		c.P2P.Discovery.DNS = c.chain.DNS
-	}
-
-	// depending on the chain we have different cache values
-	if c.Chain == "mainnet" {
-		c.Cache.Cache = 4096
-	} else {
-		c.Cache.Cache = 1024
 	}
 
 	return nil

--- a/packaging/templates/mainnet-v1/archive/config.toml
+++ b/packaging/templates/mainnet-v1/archive/config.toml
@@ -102,8 +102,8 @@ gcmode = "archive"
         # organization = ""
     # [telemetry.influx.tags]
 
-# [cache]
-    # cache = 1024
+[cache]
+    cache = 4096
     # gc = 25
     # snapshot = 10
     # database = 50

--- a/packaging/templates/mainnet-v1/archive/config.toml
+++ b/packaging/templates/mainnet-v1/archive/config.toml
@@ -45,7 +45,7 @@ gcmode = "archive"
     # pricebump = 10
 
 [miner]
-    gaslimit = 20000000
+    gaslimit = 30000000
     gasprice = "30000000000"
     # mine = false
     # etherbase = ""
@@ -79,11 +79,11 @@ gcmode = "archive"
         # vhosts = ["*"]
         # corsdomain = ["*"]
 
-# [gpo]
+[gpo]
     # blocks = 20
     # percentile = 60
     # maxprice = "5000000000000"
-    # ignoreprice = "2"
+    ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
@@ -45,7 +45,7 @@ syncmode = "full"
     # pricebump = 10
 
 [miner]
-    gaslimit = 20000000
+    gaslimit = 30000000
     gasprice = "30000000000"
     # mine = false
     # etherbase = ""
@@ -79,11 +79,11 @@ syncmode = "full"
         # vhosts = ["*"]
         # corsdomain = ["*"]
 
-# [gpo]
+[gpo]
     # blocks = 20
     # percentile = 60
     # maxprice = "5000000000000"
-    # ignoreprice = "2"
+    ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
@@ -102,8 +102,8 @@ syncmode = "full"
         # organization = ""
     # [telemetry.influx.tags]
 
-# [cache]
-    # cache = 1024
+[cache]
+    cache = 4096
     # gc = 25
     # snapshot = 10
     # database = 50

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
@@ -48,7 +48,7 @@ syncmode = "full"
 
 [miner]
     mine = true
-    gaslimit = 20000000
+    gaslimit = 30000000
     gasprice = "30000000000"
     # etherbase = ""
     # extradata = ""
@@ -81,11 +81,11 @@ syncmode = "full"
         # vhosts = ["*"]
         # corsdomain = ["*"]
 
-# [gpo]
+[gpo]
     # blocks = 20
     # percentile = 60
     # maxprice = "5000000000000"
-    # ignoreprice = "2"
+    ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
@@ -104,8 +104,8 @@ syncmode = "full"
         # organization = ""
     # [telemetry.influx.tags]
 
-# [cache]
-    # cache = 1024
+[cache]
+    cache = 4096
     # gc = 25
     # snapshot = 10
     # database = 50

--- a/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
@@ -48,7 +48,7 @@ syncmode = "full"
 
 [miner]
     mine = true
-    gaslimit = 20000000
+    gaslimit = 30000000
     gasprice = "30000000000"
     # etherbase = ""
     # extradata = ""
@@ -81,11 +81,11 @@ syncmode = "full"
         # vhosts = ["*"]
         # corsdomain = ["*"]
 
-# [gpo]
+[gpo]
 #     blocks = 20
 #     percentile = 60
 #     maxprice = "5000000000000"
-#     ignoreprice = "2"
+    ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
@@ -104,8 +104,8 @@ syncmode = "full"
         # organization = ""
     # [telemetry.influx.tags]
 
-# [cache]
-#     cache = 1024
+[cache]
+    cache = 4096
 #     gc = 25
 #     snapshot = 10
 #     database = 50

--- a/packaging/templates/testnet-v4/archive/config.toml
+++ b/packaging/templates/testnet-v4/archive/config.toml
@@ -41,12 +41,12 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 1
     # pricebump = 10
 
 [miner]
-    gaslimit = 20000000
-    # gasprice = "30000000000"
+    gaslimit = 30000000
+    # gasprice = "1000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""

--- a/packaging/templates/testnet-v4/archive/config.toml
+++ b/packaging/templates/testnet-v4/archive/config.toml
@@ -4,7 +4,7 @@ chain = "mumbai"
 datadir = "/var/lib/bor/data"
 # keystore = ""
 syncmode = "full"
-# gcmode = "full"
+gcmode = "archive"
 # snapshot = true
 # ethstats = ""
 

--- a/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
@@ -41,12 +41,12 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 1
     # pricebump = 10
 
 [miner]
-    gaslimit = 20000000
-    # gasprice = "30000000000"
+    gaslimit = 30000000
+    # gasprice = "1000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""

--- a/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
@@ -43,13 +43,13 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 1
     # pricebump = 10
 
 [miner]
     mine = true
-    gaslimit = 20000000
-    # gasprice = "30000000000"
+    gaslimit = 30000000
+    # gasprice = "1000000000"
     # etherbase = ""
     # extradata = ""
 

--- a/packaging/templates/testnet-v4/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/without-sentry/bor/config.toml
@@ -43,13 +43,13 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 1
     # pricebump = 10
 
 [miner]
     mine = true
-    gaslimit = 20000000
-    # gasprice = "30000000000"
+    gaslimit = 30000000
+    # gasprice = "1000000000"
     # etherbase = ""
     # extradata = ""
 


### PR DESCRIPTION
This PR updates the default flags in the toml based config files. The defaults present in the code are kept as similar to geth. The config files for mumbai and mainnet are updated. The new values are as below

||miner.gaslimit|miner.gasprice|txpool.gaslimit|gpo.ignoreprice|
|---|---|---|---|---|
|mainnet|30M|30 Gwei|30 Gwei|30 Gwei|
|mumbai|30M|1 Gwei|1 wei|2 wei|

Additionally, this PR also changes the cache override mechanism. Instead it keeps geth's default values in code (which are also same as mumbai - 1024) and the mainnet config files are updated with a mainnet suitable value (which is 4096). 