### PR TITLE
metrics: handle nil telemetry check

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -93,7 +93,8 @@ func updateMetricsFromConfig(path string) {
 
 	conf := &CliConfig{}
 
-	if _, err := toml.Decode(tomlData, &conf); err != nil || conf == nil {
+	_, err = toml.Decode(tomlData, &conf)
+	if err != nil || conf == nil || conf.Telemetry == nil {
 		return
 	}
 


### PR DESCRIPTION
This PR handles nil telemetry config case (which occurs when an unknown toml file is being passed in config flag). 