### PR TITLE
Reduce txArriveTimeout to 100ms

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -55,11 +55,11 @@ const (
 
 	// txArriveTimeout is the time allowance before an announced transaction is
 	// explicitly requested.
-	txArriveTimeout = 500 * time.Millisecond
+	txArriveTimeout = 100 * time.Millisecond
 
 	// txGatherSlack is the interval used to collate almost-expired announces
 	// with network fetches.
-	txGatherSlack = 100 * time.Millisecond
+	txGatherSlack = 20 * time.Millisecond
 )
 
 var (


### PR DESCRIPTION
# Description

I'm suggesting that the polygon team consider lowering the TxFetcher pingback threshold from 500ms to 100ms. This change would have a number of benefits for the network, including faster transaction propagation, improved communication between validators and sentry nodes, and reduced incentives for spamming transactions on the network. Lowering the threshold to 100ms would not significantly increase network load, and is already in use by many power users who care about receiving transactions quickly. This change would improve the overall performance and reliability of the polygon network.

In propagating transactions through the p2p network, a node will send the full transaction directly to a small number of their peers, but the transaction hash to the majority. The TxFetcher is responsible for handling the hash-only announcements on the receiving node. When a hash announcement is received, the TxFetcher will wait some period of time (currently the 500ms), and if it does not receive a direct broadcast in that time, will ping an announcing node to get the full transaction.

This 500ms threshold is a legacy setting from original geth fork. It was quite appropriate for a network with longer block times, and the ability to run on very low end hardware; however for the faster block time and higher infrastructure requirement of polygon, I believe a faster pingback would have a number of benefits.

This is one of the first and most common modifications made by power users who care about receiving transactions faster. I myself have run this setting much lower than 100ms, and noticed no performance issues on my nodes whatsoever. I know several others who have done the same.

Lowering this threshold will have a number of benefits to the network:

- This change speeds up transaction propagation and greatly cuts down on the tail latency of full transaction being received at nodes. In particular this allows higher priority (as measured by gas price) reach validator nodes and be mined more quickly. It also allows nodes to see and react to pending state changes faster and more reliably.
- This greatly improves the communication between validator and sentry nodes. Throughput between the validator and sentry can be limited by this value, as the TxFetcher only supports one active request to a peer. Normally there are not enough transactions going through the network that this is a problem, but at times the traffic spikes. During these times, high gas price transactions that would otherwise get mined in an earlier block get delayed. This would disproportionately effect smaller validators without sophisticated infrastructure.
- Additionally, this will reduce some of the incentive to spam transactions on the network. Within a gas price, transactions are ordered by the time they were received. Due to the longer propagation times, there's significant randomness in when a validator will see a transaction, thereby incentiving spamming if you want a transaction to be ordered earlier *within* a gas price. Speeding up transactions propagation means transactions submitted earlier more reliably make it to the current validator before those submitted later, thereby reducing the incentive to spam.

I log some portion of network traffic packets that are received by my node, and present some data below on the distribute of latency in these network packets. This 100ms was based on data I gathered in these logs.

Here is a histogram of the latency in milliseconds between first hash announcement vs. the first direct transaction received by my node. A negative number indicates the first direct announcement was received earlier than the first hash announcement. This is run on a 16 core machine, with 250 peers in a Hetzner datacenter, so should be fairly typical for most nodes.

<img width="1184" alt="Screen Shot 2022-12-13 at 1 28 18 AM" src="https://user-images.githubusercontent.com/120086761/207279813-3839399d-e6cb-4f52-bdd3-d07e82bc4711.png">

Indeed when we look at percentile latency (below), we see that the current 500ms is on the 98 percentile, meaning that the TxFetcher is used on less than 2% of transactions. 100ms is around the 87 percentile, so would get activated on around 13%, and cut off the tail latency on the difference. This may seems like it should increase load. However when one considers that we expect to rebroadcast a much larger percent of transactions we receive out, we can see that the burden from the p2p layer should not appreciably change. The p2p burden is only a concern for full / sentry nodes, as validators have a very small number of peers due to sentry setups.

<img width="767" alt="Screen Shot 2022-12-13 at 1 34 04 AM" src="https://user-images.githubusercontent.com/120086761/207280974-04c13a8e-3c1f-4784-bb82-2ec0634f0e4a.png">

My node has a pretty good set of static peers, I would expect this advantage to be greater for nodes who don't prune their peerset.


# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli
- [x] I have run these setting on mainnet for several months.
