### PR TITLE
Add default values to CLI helper and docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 
 # Documentation
 
-- [The new command line interface](./cli)
+[The new command line interface (CLI)](./cli) in this version of Bor aims to give users more control over the codebase when interacting with and starting a node. We have made every effort to keep most of the flags similar to the old CLI, except for a few notable changes. One major change is the use of the --config flag, which previously represented fields without available flags. It now represents all flags available to the user, and will overwrite any other flags if provided. As a node operator, you still have the flexibility to modify flags as needed. Please note that this change does not affect the internal functionality of the node, and it remains compatible with Geth and the Ethereum Virtual Machine (EVM).
 
 ## Additional notes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@
   $ bor server <flags>
   ```
 
+  See [here](./cli/server.md) for more flag details.
+
 - The `bor dumpconfig` sub-command prints the default configurations, in the TOML format, on the terminal. One can `pipe (>)` this to a file (say `config.toml`) and use it to start bor. 
 
 - A toml file now can be used instead of flags and can contain all configuration for the node to run. To simply run bor with a configuration file, the following command can be used. 

--- a/docs/cli/bootnode.md
+++ b/docs/cli/bootnode.md
@@ -2,16 +2,16 @@
 
 ## Options
 
-- ```listen-addr```: listening address of bootnode (<ip>:<port>)
+- ```listen-addr```: listening address of bootnode (<ip>:<port>) (default: 0.0.0.0:30303)
 
-- ```v5```: Enable UDP v5
+- ```v5```: Enable UDP v5 (default: false)
 
-- ```log-level```: Log level (trace|debug|info|warn|error|crit)
+- ```log-level```: Log level (trace|debug|info|warn|error|crit) (default: info)
 
-- ```nat```: port mapping mechanism (any|none|upnp|pmp|extip:<IP>)
+- ```nat```: port mapping mechanism (any|none|upnp|pmp|extip:<IP>) (default: none)
 
 - ```node-key```: file or hex node key
 
 - ```save-key```: path to save the ecdsa private key
 
-- ```dry-run```: validates parameters and prints bootnode configurations, but does not start bootnode
+- ```dry-run```: validates parameters and prints bootnode configurations, but does not start bootnode (default: false)

--- a/docs/cli/chain_sethead.md
+++ b/docs/cli/chain_sethead.md
@@ -8,6 +8,6 @@ The ```chain sethead <number>``` command sets the current chain to a certain blo
 
 ## Options
 
-- ```address```: Address of the grpc endpoint
+- ```address```: Address of the grpc endpoint (default: 127.0.0.1:3131)
 
-- ```yes```: Force set head
+- ```yes```: Force set head (default: false)

--- a/docs/cli/debug_block.md
+++ b/docs/cli/debug_block.md
@@ -4,6 +4,6 @@ The ```bor debug block <number>``` command will create an archive containing tra
 
 ## Options
 
-- ```address```: Address of the grpc endpoint
+- ```address```: Address of the grpc endpoint (default: 127.0.0.1:3131)
 
 - ```output```: Output directory

--- a/docs/cli/debug_pprof.md
+++ b/docs/cli/debug_pprof.md
@@ -4,8 +4,8 @@ The ```debug pprof <enode>``` command will create an archive containing bor ppro
 
 ## Options
 
-- ```address```: Address of the grpc endpoint
+- ```address```: Address of the grpc endpoint (default: 127.0.0.1:3131)
 
-- ```seconds```: seconds to trace
+- ```seconds```: seconds to trace (default: 2)
 
 - ```output```: Output directory

--- a/docs/cli/peers_add.md
+++ b/docs/cli/peers_add.md
@@ -4,6 +4,6 @@ The ```peers add <enode>``` command joins the local client to another remote pee
 
 ## Options
 
-- ```address```: Address of the grpc endpoint
+- ```address```: Address of the grpc endpoint (default: 127.0.0.1:3131)
 
-- ```trusted```: Add the peer as a trusted
+- ```trusted```: Add the peer as a trusted (default: false)

--- a/docs/cli/peers_list.md
+++ b/docs/cli/peers_list.md
@@ -4,4 +4,4 @@ The ```peers list``` command lists the connected peers.
 
 ## Options
 
-- ```address```: Address of the grpc endpoint
+- ```address```: Address of the grpc endpoint (default: 127.0.0.1:3131)

--- a/docs/cli/peers_remove.md
+++ b/docs/cli/peers_remove.md
@@ -4,6 +4,6 @@ The ```peers remove <enode>``` command disconnects the local client from a conne
 
 ## Options
 
-- ```address```: Address of the grpc endpoint
+- ```address```: Address of the grpc endpoint (default: 127.0.0.1:3131)
 
-- ```trusted```: Add the peer as a trusted
+- ```trusted```: Add the peer as a trusted (default: false)

--- a/docs/cli/peers_status.md
+++ b/docs/cli/peers_status.md
@@ -4,4 +4,4 @@ The ```peers status <peer id>``` command displays the status of a peer by its id
 
 ## Options
 
-- ```address```: Address of the grpc endpoint
+- ```address```: Address of the grpc endpoint (default: 127.0.0.1:3131)

--- a/docs/cli/removedb.md
+++ b/docs/cli/removedb.md
@@ -4,6 +4,6 @@ The ```bor removedb``` command will remove the blockchain and state databases at
 
 ## Options
 
-- ```address```: Address of the grpc endpoint
+- ```address```: Address of the grpc endpoint (default: 127.0.0.1:3131)
 
 - ```datadir```: Path of the data directory to store information

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -4,49 +4,51 @@ The ```bor server``` command runs the Bor client.
 
 ## Options
 
-- ```chain```: Name of the chain to sync ('mumbai', 'mainnet') or path to a genesis file
+- ```chain```: Name of the chain to sync ('mumbai', 'mainnet') or path to a genesis file (default: mainnet)
 
 - ```identity```: Name/Identity of the node
 
-- ```log-level```: Set log level for the server
+- ```log-level```: Set log level for the server (default: INFO)
 
 - ```datadir```: Path of the data directory to store information
+
+- ```datadir.ancient```: Data directory for ancient chain segments (default = inside chaindata)
 
 - ```keystore```: Path of the directory where keystores are located
 
 - ```config```: File for the config file
 
-- ```syncmode```: Blockchain sync mode (only "full" sync supported)
+- ```syncmode```: Blockchain sync mode (only "full" sync supported) (default: full)
 
-- ```gcmode```: Blockchain garbage collection mode ("full", "archive")
+- ```gcmode```: Blockchain garbage collection mode ("full", "archive") (default: full)
 
 - ```eth.requiredblocks```: Comma separated block number-to-hash mappings to require for peering (<number>=<hash>)
 
-- ```snapshot```: Enables the snapshot-database mode (default = true)
+- ```snapshot```: Enables the snapshot-database mode (default: true)
 
-- ```bor.logs```: Enables bor log retrieval (default = false)
+- ```bor.logs```: Enables bor log retrieval (default: false)
 
-- ```bor.heimdall```: URL of Heimdall service
+- ```bor.heimdall```: URL of Heimdall service (default: http://localhost:1317)
 
-- ```bor.withoutheimdall```: Run without Heimdall service (for testing purpose)
+- ```bor.withoutheimdall```: Run without Heimdall service (for testing purpose) (default: false)
 
 - ```ethstats```: Reporting URL of a ethstats service (nodename:secret@host:port)
 
-- ```gpo.blocks```: Number of recent blocks to check for gas prices
+- ```gpo.blocks```: Number of recent blocks to check for gas prices (default: 20)
 
-- ```gpo.percentile```: Suggested gas price is the given percentile of a set of recent transaction gas prices
+- ```gpo.percentile```: Suggested gas price is the given percentile of a set of recent transaction gas prices (default: 60)
 
-- ```gpo.maxprice```: Maximum gas price will be recommended by gpo
+- ```gpo.maxprice```: Maximum gas price will be recommended by gpo (default: 5000000000000)
 
-- ```gpo.ignoreprice```: Gas price below which gpo will ignore transactions
+- ```gpo.ignoreprice```: Gas price below which gpo will ignore transactions (default: 2)
 
-- ```disable-bor-wallet```: Disable the personal wallet endpoints
+- ```disable-bor-wallet```: Disable the personal wallet endpoints (default: true)
 
-- ```grpc.addr```: Address and port to bind the GRPC server
+- ```grpc.addr```: Address and port to bind the GRPC server (default: :3131)
 
-- ```dev```: Enable developer mode with ephemeral proof-of-authority network and a pre-funded developer account, mining enabled
+- ```dev```: Enable developer mode with ephemeral proof-of-authority network and a pre-funded developer account, mining enabled (default: false)
 
-- ```dev.period```: Block period to use in developer mode (0 = mine only if transaction pending)
+- ```dev.period```: Block period to use in developer mode (0 = mine only if transaction pending) (default: 0)
 
 ### Account Management Options
 
@@ -54,111 +56,111 @@ The ```bor server``` command runs the Bor client.
 
 - ```password```: Password file to use for non-interactive password input
 
-- ```allow-insecure-unlock```: Allow insecure account unlocking when account-related RPCs are exposed by http
+- ```allow-insecure-unlock```: Allow insecure account unlocking when account-related RPCs are exposed by http (default: false)
 
-- ```lightkdf```: Reduce key-derivation RAM & CPU usage at some expense of KDF strength
+- ```lightkdf```: Reduce key-derivation RAM & CPU usage at some expense of KDF strength (default: false)
 
 ### Cache Options
 
-- ```cache```: Megabytes of memory allocated to internal caching (default = 4096 mainnet full node)
+- ```cache```: Megabytes of memory allocated to internal caching (default: 1024)
 
-- ```cache.database```: Percentage of cache memory allowance to use for database io
+- ```cache.database```: Percentage of cache memory allowance to use for database io (default: 50)
 
-- ```cache.trie```: Percentage of cache memory allowance to use for trie caching (default = 15% full mode, 30% archive mode)
+- ```cache.trie```: Percentage of cache memory allowance to use for trie caching (default: 15)
 
-- ```cache.trie.journal```: Disk journal directory for trie cache to survive node restarts
+- ```cache.trie.journal```: Disk journal directory for trie cache to survive node restarts (default: triecache)
 
-- ```cache.trie.rejournal```: Time interval to regenerate the trie cache journal
+- ```cache.trie.rejournal```: Time interval to regenerate the trie cache journal (default: 1h0m0s)
 
-- ```cache.gc```: Percentage of cache memory allowance to use for trie pruning (default = 25% full mode, 0% archive mode)
+- ```cache.gc```: Percentage of cache memory allowance to use for trie pruning (default: 25)
 
-- ```cache.snapshot```: Percentage of cache memory allowance to use for snapshot caching (default = 10% full mode, 20% archive mode)
+- ```cache.snapshot```: Percentage of cache memory allowance to use for snapshot caching (default: 10)
 
-- ```cache.noprefetch```: Disable heuristic state prefetch during block import (less CPU and disk IO, more time waiting for data)
+- ```cache.noprefetch```: Disable heuristic state prefetch during block import (less CPU and disk IO, more time waiting for data) (default: false)
 
-- ```cache.preimages```: Enable recording the SHA3/keccak preimages of trie keys
+- ```cache.preimages```: Enable recording the SHA3/keccak preimages of trie keys (default: false)
 
-- ```txlookuplimit```: Number of recent blocks to maintain transactions index for (default = about 56 days, 0 = entire chain)
+- ```txlookuplimit```: Number of recent blocks to maintain transactions index for (default: 2350000)
 
 ### JsonRPC Options
 
-- ```rpc.gascap```: Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite)
+- ```rpc.gascap```: Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite) (default: 50000000)
 
-- ```rpc.txfeecap```: Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap)
+- ```rpc.txfeecap```: Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap) (default: 5)
 
-- ```ipcdisable```: Disable the IPC-RPC server
+- ```ipcdisable```: Disable the IPC-RPC server (default: false)
 
 - ```ipcpath```: Filename for IPC socket/pipe within the datadir (explicit paths escape it)
 
-- ```http.corsdomain```: Comma separated list of domains from which to accept cross origin requests (browser enforced)
+- ```http.corsdomain```: Comma separated list of domains from which to accept cross origin requests (browser enforced) (default: localhost)
 
-- ```http.vhosts```: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.
+- ```http.vhosts```: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. (default: localhost)
 
-- ```ws.origins```: Origins from which to accept websockets requests
+- ```ws.origins```: Origins from which to accept websockets requests (default: localhost)
 
-- ```graphql.corsdomain```: Comma separated list of domains from which to accept cross origin requests (browser enforced)
+- ```graphql.corsdomain```: Comma separated list of domains from which to accept cross origin requests (browser enforced) (default: localhost)
 
-- ```graphql.vhosts```: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.
+- ```graphql.vhosts```: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. (default: localhost)
 
-- ```http```: Enable the HTTP-RPC server
+- ```http```: Enable the HTTP-RPC server (default: false)
 
-- ```http.addr```: HTTP-RPC server listening interface
+- ```http.addr```: HTTP-RPC server listening interface (default: localhost)
 
-- ```http.port```: HTTP-RPC server listening port
+- ```http.port```: HTTP-RPC server listening port (default: 8545)
 
 - ```http.rpcprefix```: HTTP path path prefix on which JSON-RPC is served. Use '/' to serve on all paths.
 
-- ```http.api```: API's offered over the HTTP-RPC interface
+- ```http.api```: API's offered over the HTTP-RPC interface (default: eth,net,web3,txpool,bor)
 
-- ```ws```: Enable the WS-RPC server
+- ```ws```: Enable the WS-RPC server (default: false)
 
-- ```ws.addr```: WS-RPC server listening interface
+- ```ws.addr```: WS-RPC server listening interface (default: localhost)
 
-- ```ws.port```: WS-RPC server listening port
+- ```ws.port```: WS-RPC server listening port (default: 8546)
 
 - ```ws.rpcprefix```: HTTP path prefix on which JSON-RPC is served. Use '/' to serve on all paths.
 
-- ```ws.api```: API's offered over the WS-RPC interface
+- ```ws.api```: API's offered over the WS-RPC interface (default: net,web3)
 
-- ```graphql```: Enable GraphQL on the HTTP-RPC server. Note that GraphQL can only be started if an HTTP server is started as well.
+- ```graphql```: Enable GraphQL on the HTTP-RPC server. Note that GraphQL can only be started if an HTTP server is started as well. (default: false)
 
 ### P2P Options
 
-- ```bind```: Network binding address
+- ```bind```: Network binding address (default: 0.0.0.0)
 
-- ```port```: Network listening port
+- ```port```: Network listening port (default: 30303)
 
 - ```bootnodes```: Comma separated enode URLs for P2P discovery bootstrap
 
-- ```maxpeers```: Maximum number of network peers (network disabled if set to 0)
+- ```maxpeers```: Maximum number of network peers (network disabled if set to 0) (default: 50)
 
-- ```maxpendpeers```: Maximum number of pending connection attempts
+- ```maxpendpeers```: Maximum number of pending connection attempts (default: 50)
 
-- ```nat```: NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>)
+- ```nat```: NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>) (default: any)
 
-- ```nodiscover```: Disables the peer discovery mechanism (manual peer addition)
+- ```nodiscover```: Disables the peer discovery mechanism (manual peer addition) (default: false)
 
-- ```v5disc```: Enables the experimental RLPx V5 (Topic Discovery) mechanism
+- ```v5disc```: Enables the experimental RLPx V5 (Topic Discovery) mechanism (default: false)
 
 ### Sealer Options
 
-- ```mine```: Enable mining
+- ```mine```: Enable mining (default: false)
 
 - ```miner.etherbase```: Public address for block mining rewards
 
 - ```miner.extradata```: Block extra data set by the miner (default = client version)
 
-- ```miner.gaslimit```: Target gas ceiling (gas limit) for mined blocks
+- ```miner.gaslimit```: Target gas ceiling (gas limit) for mined blocks (default: 30000000)
 
-- ```miner.gasprice```: Minimum gas price for mining a transaction
+- ```miner.gasprice```: Minimum gas price for mining a transaction (default: 1000000000)
 
 ### Telemetry Options
 
-- ```metrics```: Enable metrics collection and reporting
+- ```metrics```: Enable metrics collection and reporting (default: false)
 
-- ```metrics.expensive```: Enable expensive metrics collection and reporting
+- ```metrics.expensive```: Enable expensive metrics collection and reporting (default: false)
 
-- ```metrics.influxdb```: Enable metrics export/push to an external InfluxDB database (v1)
+- ```metrics.influxdb```: Enable metrics export/push to an external InfluxDB database (v1) (default: false)
 
 - ```metrics.influxdb.endpoint```: InfluxDB API endpoint to report metrics to
 
@@ -170,11 +172,11 @@ The ```bor server``` command runs the Bor client.
 
 - ```metrics.influxdb.tags```: Comma-separated InfluxDB tags (key/values) attached to all measurements
 
-- ```metrics.prometheus-addr```: Address for Prometheus Server
+- ```metrics.prometheus-addr```: Address for Prometheus Server (default: 127.0.0.1:7071)
 
-- ```metrics.opencollector-endpoint```: OpenCollector Endpoint (host:port)
+- ```metrics.opencollector-endpoint```: OpenCollector Endpoint (host:port) (default: 127.0.0.1:4317)
 
-- ```metrics.influxdbv2```: Enable metrics export/push to an external InfluxDB v2 database
+- ```metrics.influxdbv2```: Enable metrics export/push to an external InfluxDB v2 database (default: false)
 
 - ```metrics.influxdb.token```: Token to authorize access to the database (v2 only)
 
@@ -186,22 +188,22 @@ The ```bor server``` command runs the Bor client.
 
 - ```txpool.locals```: Comma separated accounts to treat as locals (no flush, priority inclusion)
 
-- ```txpool.nolocals```: Disables price exemptions for locally submitted transactions
+- ```txpool.nolocals```: Disables price exemptions for locally submitted transactions (default: false)
 
-- ```txpool.journal```: Disk journal for local transaction to survive node restarts
+- ```txpool.journal```: Disk journal for local transaction to survive node restarts (default: transactions.rlp)
 
-- ```txpool.rejournal```: Time interval to regenerate the local transaction journal
+- ```txpool.rejournal```: Time interval to regenerate the local transaction journal (default: 1h0m0s)
 
-- ```txpool.pricelimit```: Minimum gas price limit to enforce for acceptance into the pool
+- ```txpool.pricelimit```: Minimum gas price limit to enforce for acceptance into the pool (default: 1)
 
-- ```txpool.pricebump```: Price bump percentage to replace an already existing transaction
+- ```txpool.pricebump```: Price bump percentage to replace an already existing transaction (default: 10)
 
-- ```txpool.accountslots```: Minimum number of executable transaction slots guaranteed per account
+- ```txpool.accountslots```: Minimum number of executable transaction slots guaranteed per account (default: 16)
 
-- ```txpool.globalslots```: Maximum number of executable transaction slots for all accounts
+- ```txpool.globalslots```: Maximum number of executable transaction slots for all accounts (default: 32768)
 
-- ```txpool.accountqueue```: Maximum number of non-executable transaction slots permitted per account
+- ```txpool.accountqueue```: Maximum number of non-executable transaction slots permitted per account (default: 16)
 
-- ```txpool.globalqueue```: Maximum number of non-executable transaction slots for all accounts
+- ```txpool.globalqueue```: Maximum number of non-executable transaction slots for all accounts (default: 32768)
 
-- ```txpool.lifetime```: Maximum amount of time non-executable transaction are queued
+- ```txpool.lifetime```: Maximum amount of time non-executable transaction are queued (default: 3h0m0s)

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -16,10 +16,11 @@ func (c *Command) Flags() *flagset.Flagset {
 		Default: c.cliConfig.Chain,
 	})
 	f.StringFlag(&flagset.StringFlag{
-		Name:    "identity",
-		Usage:   "Name/Identity of the node",
-		Value:   &c.cliConfig.Identity,
-		Default: c.cliConfig.Identity,
+		Name:               "identity",
+		Usage:              "Name/Identity of the node",
+		Value:              &c.cliConfig.Identity,
+		Default:            c.cliConfig.Identity,
+		HideDefaultFromDoc: true,
 	})
 	f.StringFlag(&flagset.StringFlag{
 		Name:    "log-level",
@@ -28,10 +29,11 @@ func (c *Command) Flags() *flagset.Flagset {
 		Default: c.cliConfig.LogLevel,
 	})
 	f.StringFlag(&flagset.StringFlag{
-		Name:    "datadir",
-		Usage:   "Path of the data directory to store information",
-		Value:   &c.cliConfig.DataDir,
-		Default: c.cliConfig.DataDir,
+		Name:               "datadir",
+		Usage:              "Path of the data directory to store information",
+		Value:              &c.cliConfig.DataDir,
+		Default:            c.cliConfig.DataDir,
+		HideDefaultFromDoc: true,
 	})
 	f.StringFlag(&flagset.StringFlag{
 		Name:    "datadir.ancient",
@@ -62,19 +64,20 @@ func (c *Command) Flags() *flagset.Flagset {
 		Default: c.cliConfig.GcMode,
 	})
 	f.MapStringFlag(&flagset.MapStringFlag{
-		Name:  "eth.requiredblocks",
-		Usage: "Comma separated block number-to-hash mappings to require for peering (<number>=<hash>)",
-		Value: &c.cliConfig.RequiredBlocks,
+		Name:    "eth.requiredblocks",
+		Usage:   "Comma separated block number-to-hash mappings to require for peering (<number>=<hash>)",
+		Value:   &c.cliConfig.RequiredBlocks,
+		Default: c.cliConfig.RequiredBlocks,
 	})
 	f.BoolFlag(&flagset.BoolFlag{
 		Name:    "snapshot",
-		Usage:   `Enables the snapshot-database mode (default = true)`,
+		Usage:   `Enables the snapshot-database mode`,
 		Value:   &c.cliConfig.Snapshot,
 		Default: c.cliConfig.Snapshot,
 	})
 	f.BoolFlag(&flagset.BoolFlag{
 		Name:    "bor.logs",
-		Usage:   `Enables bor log retrieval (default = false)`,
+		Usage:   `Enables bor log retrieval`,
 		Value:   &c.cliConfig.BorLogs,
 		Default: c.cliConfig.BorLogs,
 	})
@@ -202,10 +205,11 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "Sealer",
 	})
 	f.BigIntFlag(&flagset.BigIntFlag{
-		Name:  "miner.gasprice",
-		Usage: "Minimum gas price for mining a transaction",
-		Value: c.cliConfig.Sealer.GasPrice,
-		Group: "Sealer",
+		Name:    "miner.gasprice",
+		Usage:   "Minimum gas price for mining a transaction",
+		Value:   c.cliConfig.Sealer.GasPrice,
+		Group:   "Sealer",
+		Default: c.cliConfig.Sealer.GasPrice,
 	})
 
 	// ethstats
@@ -230,20 +234,22 @@ func (c *Command) Flags() *flagset.Flagset {
 		Default: c.cliConfig.Gpo.Percentile,
 	})
 	f.BigIntFlag(&flagset.BigIntFlag{
-		Name:  "gpo.maxprice",
-		Usage: "Maximum gas price will be recommended by gpo",
-		Value: c.cliConfig.Gpo.MaxPrice,
+		Name:    "gpo.maxprice",
+		Usage:   "Maximum gas price will be recommended by gpo",
+		Value:   c.cliConfig.Gpo.MaxPrice,
+		Default: c.cliConfig.Gpo.MaxPrice,
 	})
 	f.BigIntFlag(&flagset.BigIntFlag{
-		Name:  "gpo.ignoreprice",
-		Usage: "Gas price below which gpo will ignore transactions",
-		Value: c.cliConfig.Gpo.IgnorePrice,
+		Name:    "gpo.ignoreprice",
+		Usage:   "Gas price below which gpo will ignore transactions",
+		Value:   c.cliConfig.Gpo.IgnorePrice,
+		Default: c.cliConfig.Gpo.IgnorePrice,
 	})
 
 	// cache options
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "cache",
-		Usage:   "Megabytes of memory allocated to internal caching (default = 4096 mainnet full node)",
+		Usage:   "Megabytes of memory allocated to internal caching",
 		Value:   &c.cliConfig.Cache.Cache,
 		Default: c.cliConfig.Cache.Cache,
 		Group:   "Cache",
@@ -257,7 +263,7 @@ func (c *Command) Flags() *flagset.Flagset {
 	})
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "cache.trie",
-		Usage:   "Percentage of cache memory allowance to use for trie caching (default = 15% full mode, 30% archive mode)",
+		Usage:   "Percentage of cache memory allowance to use for trie caching",
 		Value:   &c.cliConfig.Cache.PercTrie,
 		Default: c.cliConfig.Cache.PercTrie,
 		Group:   "Cache",
@@ -278,14 +284,14 @@ func (c *Command) Flags() *flagset.Flagset {
 	})
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "cache.gc",
-		Usage:   "Percentage of cache memory allowance to use for trie pruning (default = 25% full mode, 0% archive mode)",
+		Usage:   "Percentage of cache memory allowance to use for trie pruning",
 		Value:   &c.cliConfig.Cache.PercGc,
 		Default: c.cliConfig.Cache.PercGc,
 		Group:   "Cache",
 	})
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "cache.snapshot",
-		Usage:   "Percentage of cache memory allowance to use for snapshot caching (default = 10% full mode, 20% archive mode)",
+		Usage:   "Percentage of cache memory allowance to use for snapshot caching",
 		Value:   &c.cliConfig.Cache.PercSnapshot,
 		Default: c.cliConfig.Cache.PercSnapshot,
 		Group:   "Cache",
@@ -306,7 +312,7 @@ func (c *Command) Flags() *flagset.Flagset {
 	})
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "txlookuplimit",
-		Usage:   "Number of recent blocks to maintain transactions index for (default = about 56 days, 0 = entire chain)",
+		Usage:   "Number of recent blocks to maintain transactions index for",
 		Value:   &c.cliConfig.Cache.TxLookupLimit,
 		Default: c.cliConfig.Cache.TxLookupLimit,
 		Group:   "Cache",
@@ -569,10 +575,11 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "Telemetry",
 	})
 	f.MapStringFlag(&flagset.MapStringFlag{
-		Name:  "metrics.influxdb.tags",
-		Usage: "Comma-separated InfluxDB tags (key/values) attached to all measurements",
-		Value: &c.cliConfig.Telemetry.InfluxDB.Tags,
-		Group: "Telemetry",
+		Name:    "metrics.influxdb.tags",
+		Usage:   "Comma-separated InfluxDB tags (key/values) attached to all measurements",
+		Value:   &c.cliConfig.Telemetry.InfluxDB.Tags,
+		Group:   "Telemetry",
+		Default: c.cliConfig.Telemetry.InfluxDB.Tags,
 	})
 	f.StringFlag(&flagset.StringFlag{
 		Name:    "metrics.prometheus-addr",


### PR DESCRIPTION
This commit adds default values to CLI helper and docs. When the default value of a string flag, slice string flag, or map string flag is empty, its helper message won't show any default value.

Example server CLI helper output:

```bash
$ bor server -h
Usage: bor [options]

	Run the Bor server.
  Options:

  -chain
    Name of the chain to sync ('mumbai', 'mainnet') or path to a genesis file (default: mainnet)

  -identity
    Name/Identity of the node

  -log-level
    Set log level for the server (default: INFO)

  -datadir
    Path of the data directory to store information

  -datadir.ancient
    Data directory for ancient chain segments (default = inside chaindata)

  -keystore
    Path of the directory where keystores are located

  -config
    File for the config file

  -syncmode
    Blockchain sync mode (only "full" sync supported) (default: full)

  -gcmode
    Blockchain garbage collection mode ("full", "archive") (default: full)

  -eth.requiredblocks
    Comma separated block number-to-hash mappings to require for peering (<number>=<hash>)

  -snapshot
    Enables the snapshot-database mode (default = true) (default: true)

  -bor.logs
    Enables bor log retrieval (default = false) (default: false)

  -bor.heimdall
    URL of Heimdall service (default: http://localhost:1317)

  -bor.withoutheimdall
    Run without Heimdall service (for testing purpose) (default: false)

  -txpool.locals
    Comma separated accounts to treat as locals (no flush, priority inclusion)

  -txpool.nolocals
    Disables price exemptions for locally submitted transactions (default: false)

  -txpool.journal
    Disk journal for local transaction to survive node restarts (default: transactions.rlp)

  -txpool.rejournal
    Time interval to regenerate the local transaction journal (default: 1h0m0s)

  -txpool.pricelimit
    Minimum gas price limit to enforce for acceptance into the pool (default: 1)

  -txpool.pricebump
    Price bump percentage to replace an already existing transaction (default: 10)

  -txpool.accountslots
    Minimum number of executable transaction slots guaranteed per account (default: 16)

  -txpool.globalslots
    Maximum number of executable transaction slots for all accounts (default: 32768)

  -txpool.accountqueue
    Maximum number of non-executable transaction slots permitted per account (default: 16)

  -txpool.globalqueue
    Maximum number of non-executable transaction slots for all accounts (default: 32768)

  -txpool.lifetime
    Maximum amount of time non-executable transaction are queued (default: 3h0m0s)

  -mine
    Enable mining (default: false)

  -miner.etherbase
    Public address for block mining rewards

  -miner.extradata
    Block extra data set by the miner (default = client version)

  -miner.gaslimit
    Target gas ceiling (gas limit) for mined blocks (default: 30000000)

  -miner.gasprice
    Minimum gas price for mining a transaction (default: 1000000000)

  -ethstats
    Reporting URL of a ethstats service (nodename:secret@host:port)

  -gpo.blocks
    Number of recent blocks to check for gas prices (default: 20)

  -gpo.percentile
    Suggested gas price is the given percentile of a set of recent transaction gas prices (default: 60)

  -gpo.maxprice
    Maximum gas price will be recommended by gpo (default: 5000000000000)

  -gpo.ignoreprice
    Gas price below which gpo will ignore transactions (default: 2)

  -cache
    Megabytes of memory allocated to internal caching (default = 4096 mainnet full node) (default: 1024)

  -cache.database
    Percentage of cache memory allowance to use for database io (default: 50)

  -cache.trie
    Percentage of cache memory allowance to use for trie caching (default = 15% full mode, 30% archive mode) (default: 15)

  -cache.trie.journal
    Disk journal directory for trie cache to survive node restarts (default: triecache)

  -cache.trie.rejournal
    Time interval to regenerate the trie cache journal (default: 1h0m0s)

  -cache.gc
    Percentage of cache memory allowance to use for trie pruning (default = 25% full mode, 0% archive mode) (default: 25)

  -cache.snapshot
    Percentage of cache memory allowance to use for snapshot caching (default = 10% full mode, 20% archive mode) (default: 10)

  -cache.noprefetch
    Disable heuristic state prefetch during block import (less CPU and disk IO, more time waiting for data) (default: false)

  -cache.preimages
    Enable recording the SHA3/keccak preimages of trie keys (default: false)

  -txlookuplimit
    Number of recent blocks to maintain transactions index for (default = about 56 days, 0 = entire chain) (default: 2350000)

  -rpc.gascap
    Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite) (default: 50000000)

  -rpc.txfeecap
    Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap) (default: 5)

  -ipcdisable
    Disable the IPC-RPC server (default: false)

  -ipcpath
    Filename for IPC socket/pipe within the datadir (explicit paths escape it)

  -http.corsdomain
    Comma separated list of domains from which to accept cross origin requests (browser enforced) (default: localhost)

  -http.vhosts
    Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. (default: localhost)

  -ws.origins
    Origins from which to accept websockets requests (default: localhost)

  -graphql.corsdomain
    Comma separated list of domains from which to accept cross origin requests (browser enforced) (default: localhost)

  -graphql.vhosts
    Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. (default: localhost)

  -http
    Enable the HTTP-RPC server (default: false)

  -http.addr
    HTTP-RPC server listening interface (default: localhost)

  -http.port
    HTTP-RPC server listening port (default: 8545)

  -http.rpcprefix
    HTTP path path prefix on which JSON-RPC is served. Use '/' to serve on all paths.

  -http.api
    API's offered over the HTTP-RPC interface (default: eth,net,web3,txpool,bor)

  -ws
    Enable the WS-RPC server (default: false)

  -ws.addr
    WS-RPC server listening interface (default: localhost)

  -ws.port
    WS-RPC server listening port (default: 8546)

  -ws.rpcprefix
    HTTP path prefix on which JSON-RPC is served. Use '/' to serve on all paths.

  -ws.api
    API's offered over the WS-RPC interface (default: net,web3)

  -graphql
    Enable GraphQL on the HTTP-RPC server. Note that GraphQL can only be started if an HTTP server is started as well. (default: false)

  -bind
    Network binding address (default: 0.0.0.0)

  -port
    Network listening port (default: 30303)

  -bootnodes
    Comma separated enode URLs for P2P discovery bootstrap

  -maxpeers
    Maximum number of network peers (network disabled if set to 0) (default: 50)

  -maxpendpeers
    Maximum number of pending connection attempts (default: 50)

  -nat
    NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>) (default: any)

  -nodiscover
    Disables the peer discovery mechanism (manual peer addition) (default: false)

  -v5disc
    Enables the experimental RLPx V5 (Topic Discovery) mechanism (default: false)

  -metrics
    Enable metrics collection and reporting (default: false)

  -metrics.expensive
    Enable expensive metrics collection and reporting (default: false)

  -metrics.influxdb
    Enable metrics export/push to an external InfluxDB database (v1) (default: false)

  -metrics.influxdb.endpoint
    InfluxDB API endpoint to report metrics to

  -metrics.influxdb.database
    InfluxDB database name to push reported metrics to

  -metrics.influxdb.username
    Username to authorize access to the database

  -metrics.influxdb.password
    Password to authorize access to the database

  -metrics.influxdb.tags
    Comma-separated InfluxDB tags (key/values) attached to all measurements

  -metrics.prometheus-addr
    Address for Prometheus Server (default: 127.0.0.1:7071)

  -metrics.opencollector-endpoint
    OpenCollector Endpoint (host:port) (default: 127.0.0.1:4317)

  -metrics.influxdbv2
    Enable metrics export/push to an external InfluxDB v2 database (default: false)

  -metrics.influxdb.token
    Token to authorize access to the database (v2 only)

  -metrics.influxdb.bucket
    InfluxDB bucket name to push reported metrics to (v2 only)

  -metrics.influxdb.organization
    InfluxDB organization name (v2 only)

  -unlock
    Comma separated list of accounts to unlock

  -password
    Password file to use for non-interactive password input

  -allow-insecure-unlock
    Allow insecure account unlocking when account-related RPCs are exposed by http (default: false)

  -lightkdf
    Reduce key-derivation RAM & CPU usage at some expense of KDF strength (default: false)

  -disable-bor-wallet
    Disable the personal wallet endpoints (default: true)

  -grpc.addr
    Address and port to bind the GRPC server (default: :3131)

  -dev
    Enable developer mode with ephemeral proof-of-authority network and a pre-funded developer account, mining enabled (default: false)

  -dev.period
    Block period to use in developer mode (0 = mine only if transaction pending) (default: 0)
```

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it