### PR TITLE
Shivam/pos 1041

### DIFF
--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -937,13 +937,13 @@ func unlockAccount(ks *keystore.KeyStore, address string, i int, passwords []str
 }
 
 func ambiguousAddrRecovery(ks *keystore.KeyStore, err *keystore.AmbiguousAddrError, auth string) accounts.Account {
-	fmt.Printf("Multiple key files exist for address %x:\n", err.Addr)
+	log.Warn("Multiple key files exist for", "address", err.Addr)
 
 	for _, a := range err.Matches {
-		fmt.Println("  ", a.URL)
+		log.Info("Multiple keys", "file", a.URL)
 	}
 
-	fmt.Println("Testing your password against all of them...")
+	log.Info("Testing your password against all of them...")
 
 	var match *accounts.Account
 
@@ -959,8 +959,8 @@ func ambiguousAddrRecovery(ks *keystore.KeyStore, err *keystore.AmbiguousAddrErr
 		utils.Fatalf("None of the listed files could be unlocked.")
 	}
 
-	fmt.Printf("Your password unlocked %s\n", match.URL)
-	fmt.Println("In order to avoid this warning, you need to remove the following duplicate key files:")
+	log.Info("Your password unlocked", "key", match.URL)
+	log.Warn("In order to avoid this warning, you need to remove the following duplicate key files:")
 
 	for _, a := range err.Matches {
 		if a != *match {

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/fdlimit"
 	"github.com/ethereum/go-ethereum/eth/downloader"
@@ -720,10 +721,7 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 		}
 
 		for i, account := range c.Accounts.Unlock {
-			err = ks.Unlock(accounts.Account{Address: common.HexToAddress(account)}, passwords[i])
-			if err != nil {
-				log.Warn("Could not unlock account", "account", account, "err", err)
-			}
+			unlockAccount(ks, account, i, passwords)
 		}
 	}
 
@@ -903,6 +901,61 @@ var (
 	gitCommit        = "" // Git SHA1 commit hash of the release (set via linker flags)
 	gitDate          = "" // Git commit date YYYYMMDD of the release (set via linker flags)
 )
+
+// tries unlocking the specified account a few times.
+func unlockAccount(ks *keystore.KeyStore, address string, i int, passwords []string) (accounts.Account, string) {
+	account, err := utils.MakeAddress(ks, address)
+	if err != nil {
+		utils.Fatalf("Could not list accounts: %v", err)
+	}
+	for trials := 0; trials < 3; trials++ {
+		prompt := fmt.Sprintf("Unlocking account %s | Attempt %d/%d", address, trials+1, 3)
+		password := utils.GetPassPhraseWithList(prompt, false, i, passwords)
+		err = ks.Unlock(account, password)
+		if err == nil {
+			log.Info("Unlocked account", "address", account.Address.Hex())
+			return account, password
+		}
+		if err, ok := err.(*keystore.AmbiguousAddrError); ok {
+			log.Info("Unlocked account", "address", account.Address.Hex())
+			return ambiguousAddrRecovery(ks, err, password), password
+		}
+		if err != keystore.ErrDecrypt {
+			// No need to prompt again if the error is not decryption-related.
+			break
+		}
+	}
+	// All trials expended to unlock account, bail out
+	utils.Fatalf("Failed to unlock account %s (%v)", address, err)
+
+	return accounts.Account{}, ""
+}
+
+func ambiguousAddrRecovery(ks *keystore.KeyStore, err *keystore.AmbiguousAddrError, auth string) accounts.Account {
+	fmt.Printf("Multiple key files exist for address %x:\n", err.Addr)
+	for _, a := range err.Matches {
+		fmt.Println("  ", a.URL)
+	}
+	fmt.Println("Testing your password against all of them...")
+	var match *accounts.Account
+	for _, a := range err.Matches {
+		if err := ks.Unlock(a, auth); err == nil {
+			match = &a
+			break
+		}
+	}
+	if match == nil {
+		utils.Fatalf("None of the listed files could be unlocked.")
+	}
+	fmt.Printf("Your password unlocked %s\n", match.URL)
+	fmt.Println("In order to avoid this warning, you need to remove the following duplicate key files:")
+	for _, a := range err.Matches {
+		if a != *match {
+			fmt.Println("  ", a.URL)
+		}
+	}
+	return *match
+}
 
 func (c *Config) buildNode() (*node.Config, error) {
 	ipcPath := ""

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -722,7 +722,7 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 		for i, account := range c.Accounts.Unlock {
 			err = ks.Unlock(accounts.Account{Address: common.HexToAddress(account)}, passwords[i])
 			if err != nil {
-				return nil, fmt.Errorf("could not unlock an account %q", account)
+				log.Warn("Could not unlock account", "account", account, "err", err)
 			}
 		}
 	}

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -940,7 +940,7 @@ func ambiguousAddrRecovery(ks *keystore.KeyStore, err *keystore.AmbiguousAddrErr
 	log.Warn("Multiple key files exist for", "address", err.Addr)
 
 	for _, a := range err.Matches {
-		log.Info("Multiple keys", "file", a.URL)
+		log.Info("Multiple keys", "file", a.URL.String())
 	}
 
 	log.Info("Testing your password against all of them...")
@@ -959,12 +959,12 @@ func ambiguousAddrRecovery(ks *keystore.KeyStore, err *keystore.AmbiguousAddrErr
 		utils.Fatalf("None of the listed files could be unlocked.")
 	}
 
-	log.Info("Your password unlocked", "key", match.URL)
+	log.Info("Your password unlocked", "key", match.URL.String())
 	log.Warn("In order to avoid this warning, you need to remove the following duplicate key files:")
 
 	for _, a := range err.Matches {
 		if a != *match {
-			fmt.Println("  ", a.URL)
+			log.Warn("Duplicate", "key", a.URL.String())
 		}
 	}
 


### PR DESCRIPTION
In this PR, we add tolerance of multiple keystore files error. Earlier, bor would exit when multiple keystores are found. Now, it can recover from that and will select the correct keystore from multiple files.