### PR TITLE
eth/downloader/whitelist: remove future chain validation

### DIFF
--- a/eth/downloader/whitelist/service.go
+++ b/eth/downloader/whitelist/service.go
@@ -99,18 +99,23 @@ func (w *Service) IsValidChain(currentHeader *types.Header, chain []*types.Heade
 	}
 
 	// Split the chain into past and future chain
-	pastChain, futureChain := splitChain(current, chain)
+	pastChain, _ := splitChain(current, chain)
+
+	// (NOTE): The code below would prevent very large chains from getting
+	// accepted and was causing peer drops and affecting the sync process.
+	// For now, accept all future chains without any validation. This will be
+	// handled in future milestones.
 
 	// Add an offset to future chain if it's not in continuity
-	offset := 0
-	if len(futureChain) != 0 {
-		offset += int(futureChain[0].Number.Uint64()-currentHeader.Number.Uint64()) - 1
-	}
+	// offset := 0
+	// if len(futureChain) != 0 {
+	// 	offset += int(futureChain[0].Number.Uint64()-currentHeader.Number.Uint64()) - 1
+	// }
 
 	// Don't accept future chain of unacceptable length (from current block)
-	if len(futureChain)+offset > int(w.checkpointInterval) {
-		return false
-	}
+	// if len(futureChain)+offset > int(w.checkpointInterval) {
+	// 	return false
+	// }
 
 	// Iterate over the chain and validate against the last checkpoint
 	// It will handle all cases where the incoming chain has atleast one checkpoint

--- a/eth/downloader/whitelist/service_test.go
+++ b/eth/downloader/whitelist/service_test.go
@@ -166,7 +166,7 @@ func TestIsValidChain(t *testing.T) {
 	res = s.IsValidChain(chainA[len(chainA)-1], chainB)
 	require.Equal(t, res, true, "expected chain to be valid")
 
-	// (NOTE): Skipping this test and the future chain validations
+	// (NOTE): Skipping this test as the future chain validations
 	// are commented for the time being.
 
 	// create a future chain to be imported of length > `checkpointInterval`

--- a/eth/downloader/whitelist/service_test.go
+++ b/eth/downloader/whitelist/service_test.go
@@ -166,12 +166,15 @@ func TestIsValidChain(t *testing.T) {
 	res = s.IsValidChain(chainA[len(chainA)-1], chainB)
 	require.Equal(t, res, true, "expected chain to be valid")
 
+	// (NOTE): Skipping this test and the future chain validations
+	// are commented for the time being.
+
 	// create a future chain to be imported of length > `checkpointInterval`
-	chainB = createMockChain(21, 40) // C21->C22...C39->C40
+	// chainB = createMockChain(21, 40) // C21->C22...C39->C40
 
 	// case5: Try importing a future chain of unacceptable length
-	res = s.IsValidChain(chainA[len(chainA)-1], chainB)
-	require.Equal(t, res, false, "expected chain to be invalid")
+	// res = s.IsValidChain(chainA[len(chainA)-1], chainB)
+	// require.Equal(t, res, false, "expected chain to be invalid")
 }
 
 func TestSplitChain(t *testing.T) {


### PR DESCRIPTION
# Description

With introduction of RFC35 (validating chains through checkpoints), a check was added when a future chain import was done to prevent import of very long chains (>256 blocks long) without any validation. As the function `InsertChain` is being called by downloader, this error floated till the top and was responsible to drop peers. Well, ideally such long chains (~500-1500 blocks) are anyways dropped at some later point of time without any peers drops. 

This PR removes the validation check for importing any kind of future chain and will prevent peer connections from dropping leading to better sync. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it