### PR TITLE
handle future chain import and skip peer drop

### DIFF
--- a/core/forkchoice.go
+++ b/core/forkchoice.go
@@ -114,9 +114,7 @@ func (f *ForkChoice) ReorgNeeded(current *types.Header, header *types.Header) (b
 func (f *ForkChoice) ValidateReorg(current *types.Header, chain []*types.Header) (bool, error) {
 	// Call the bor chain validator service
 	if f.validator != nil {
-		if isValid := f.validator.IsValidChain(current, chain); !isValid {
-			return false, nil
-		}
+		return f.validator.IsValidChain(current, chain)
 	}
 
 	return true, nil

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -1426,8 +1426,8 @@ func (w *whitelistFake) IsValidPeer(_ *types.Header, _ func(number uint64, amoun
 	return w.validate(w.count)
 }
 
-func (w *whitelistFake) IsValidChain(current *types.Header, headers []*types.Header) bool {
-	return true
+func (w *whitelistFake) IsValidChain(current *types.Header, headers []*types.Header) (bool, error) {
+	return true, nil
 }
 func (w *whitelistFake) ProcessCheckpoint(_ uint64, _ common.Hash) {}
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -242,7 +242,7 @@ type StateSyncFilter struct {
 // interface for whitelist service
 type ChainValidator interface {
 	IsValidPeer(remoteHeader *types.Header, fetchHeadersByNumber func(number uint64, amount int, skip int, reverse bool) ([]*types.Header, []common.Hash, error)) (bool, error)
-	IsValidChain(currentHeader *types.Header, chain []*types.Header) bool
+	IsValidChain(currentHeader *types.Header, chain []*types.Header) (bool, error)
 	ProcessCheckpoint(endBlockNum uint64, endBlockHash common.Hash)
 	GetCheckpointWhitelist() map[uint64]common.Hash
 	PurgeCheckpointWhitelist()

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 0        // Major version component of the current release
 	VersionMinor = 3        // Minor version component of the current release
-	VersionPatch = 2        // Patch version component of the current release
+	VersionPatch = 3        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
# Description

With introduction of RFC35 (validating chains through checkpoints), a check was added when a future chain import was done to prevent import of very long chains (>256 blocks long) without any validation. As the function `InsertChain` is being called by downloader, this error floated till the top and was responsible to drop peers. Ideally we just want to reject the chain and do not want to drop peers when we're receiving a long chain (as this is quite frequent). Also, pre-RFC35, it would behave in the same way i.e. reject long chains (at some later point in time) but won't drop peers. 

This PR adds a new error type for such scenarios i.e. long imports for future chains. At the downloader level, the invalid chain error won't be floated at the top and hence it won't drop peers. It will still inform that there's a sync issue with appropriate error. This will surely improve the sync mechanism and remove all the issues we're facing currently. 

This PR also adds a metric under the name `chain_imports`, which denotes the length of chains we're receiving from different peers. Note that it does not denote the actual chain which is being inserted into db. It passes through lot of filters and checks before the final chain is imported. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it