### PR TITLE
consensus/bor: handle unauthorized signer in consensus.Prepare

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -676,6 +676,13 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header) e
 
 	currentSigner := *c.authorizedSigner.Load()
 
+	// Bail out early if we're unauthorized to sign a block. This check also takes
+	// place before block is signed in `Seal`.
+	if !snap.ValidatorSet.HasAddress(currentSigner.signer) {
+		// Check the UnauthorizedSignerError.Error() msg to see why we pass number-1
+		return &UnauthorizedSignerError{number - 1, currentSigner.signer.Bytes()}
+	}
+
 	// Set the correct difficulty
 	header.Difficulty = new(big.Int).SetUint64(Difficulty(snap.ValidatorSet, currentSigner.signer))
 


### PR DESCRIPTION
# Description

This PR checks if the current signer (of a node) is eligible for mining (i.e. existing in a validator set) very early in `consensus.Prepare()`. Earlier it used to perform this check in `consensus.Seal()` which is too late in our case. It seems suitable for a PoW based network where you're not supposed to check eligibility to mine a block and try mining it whatever the case. In our case, a node which is not in the validator set will try to produce a block (prepare header, pick transactions by performing sorting in txpool, execute them, add state-sync by interacting with heimdall) and then in the last step before signing, it will know that it's not authorized to produce this block (i.e. does not exist in the validator set). This seems very unoptimised as we're wasting resources on things we're not supposed to do. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it