### PR TITLE
chg : trieTimeout from 60 to 10 mins

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -127,7 +127,7 @@ syncmode = "full"
   # preimages = false
   # txlookuplimit = 2350000
   # triesinmemory = 128
-  # timeout = "1h0m0s"
+  # timeout = "10m0s"
 
 [accounts]
   # allow-insecure-unlock = true

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -130,7 +130,7 @@ ethstats = ""                # Reporting URL of a ethstats service (nodename:sec
   preimages = false        # Enable recording the SHA3/keccak preimages of trie keys
   txlookuplimit = 2350000  # Number of recent blocks to maintain transactions index for (default = about 56 days, 0 = entire chain)
   triesinmemory = 128      # Number of block states (tries) to keep in memory
-  timeout = "1h0m0s"       # Time after which the Merkle Patricia Trie is stored to disc from memory
+  timeout = "10m0s"       # Time after which the Merkle Patricia Trie is stored to disc from memory
 
 [accounts]
   unlock = []                    # Comma separated list of accounts to unlock

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -564,7 +564,7 @@ func DefaultConfig() *Config {
 			Preimages:     false,
 			TxLookupLimit: 2350000,
 			TriesInMemory: 128,
-			TrieTimeout:   60 * time.Minute,
+			TrieTimeout:   10 * time.Minute,
 		},
 		Accounts: &AccountsConfig{
 			Unlock:              []string{},

--- a/packaging/templates/mainnet-v1/archive/config.toml
+++ b/packaging/templates/mainnet-v1/archive/config.toml
@@ -118,7 +118,7 @@ gcmode = "archive"
     # noprefetch = false
     # preimages = false
     # txlookuplimit = 2350000
-    # timeout = "1h0m0s"
+    # timeout = "10m0s"
 
 # [accounts]
     # unlock = []

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
@@ -118,7 +118,7 @@ syncmode = "full"
     # noprefetch = false
     # preimages = false
     # txlookuplimit = 2350000
-    # timeout = "1h0m0s"
+    # timeout = "10m0s"
 
 # [accounts]
     # unlock = []

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
@@ -120,7 +120,7 @@ syncmode = "full"
     # noprefetch = false
     # preimages = false
     # txlookuplimit = 2350000
-    # timeout = "1h0m0s"
+    # timeout = "10m0s"
 
 [accounts]
     allow-insecure-unlock = true

--- a/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
@@ -120,7 +120,7 @@ syncmode = "full"
 #     noprefetch = false
 #     preimages = false
 #     txlookuplimit = 2350000
-#     timeout = "1h0m0s"
+#     timeout = "10m0s"
 
 [accounts]
     allow-insecure-unlock = true

--- a/packaging/templates/testnet-v4/archive/config.toml
+++ b/packaging/templates/testnet-v4/archive/config.toml
@@ -118,7 +118,7 @@ gcmode = "archive"
     # noprefetch = false
     # preimages = false
     # txlookuplimit = 2350000
-    # timeout = "1h0m0s"
+    # timeout = "10m0s"
 
 # [accounts]
     # unlock = []

--- a/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
@@ -118,7 +118,7 @@ syncmode = "full"
     # noprefetch = false
     # preimages = false
     # txlookuplimit = 2350000
-    # timeout = "1h0m0s"
+    # timeout = "10m0s"
 
 # [accounts]
     # unlock = []

--- a/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
@@ -120,7 +120,7 @@ syncmode = "full"
     # noprefetch = false
     # preimages = false
     # txlookuplimit = 2350000
-    # timeout = "1h0m0s"
+    # timeout = "10m0s"
 
 [accounts]
     allow-insecure-unlock = true

--- a/packaging/templates/testnet-v4/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/without-sentry/bor/config.toml
@@ -120,7 +120,7 @@ syncmode = "full"
 #     noprefetch = false
 #     preimages = false
 #     txlookuplimit = 2350000
-#     timeout = "1h0m0s"
+#     timeout = "10m0s"
 
 [accounts]
     allow-insecure-unlock = true


### PR DESCRIPTION
# Description
In this PR we resolve an issue of huge rewinds. `trieTimeout`/`trieTimeLimit` is responsible for the frequency of storing block state to the persistent db for a full node. It was set to 60 minutes which resulted in huge gap between states of blocks in the persistent memory. We have reduced this gap to 10 minutes which will increase the frequency of storing the block states to the persistent database.


# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

