### PR TITLE
internal/cli/server : fix : added triesInMemory in config

### DIFF
--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -889,6 +889,7 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 		n.Preimages = c.Cache.Preimages
 		n.TxLookupLimit = c.Cache.TxLookupLimit
 		n.TrieTimeout = c.Cache.TrieTimeout
+		n.TriesInMemory = c.Cache.TriesInMemory
 	}
 
 	n.RPCGasCap = c.JsonRPC.GasCap


### PR DESCRIPTION
In this PR, we fix the misconfiguration of `triesInMemory` flag. After this fix, a user can modify the number of block states ( tries ) to be stored in the memory.