### PR TITLE
update requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We believe one of the things that makes Polygon special is its coherent design a
 
 ### Building the source
 
-- Building `bor` requires both a Go (version 1.14 or later) and a C compiler. You can install
+- Building `bor` requires both a Go (version 1.19 or later) and a C compiler. You can install
 them using your favourite package manager. Once the dependencies are installed, run
 
      ```shell


### PR DESCRIPTION
v0.3.3 won't build with go 1.18:
```
$ make bor
mkdir -p /home/matic/go/bin/
go build -o /home/matic/src/bor/build/bin/bor ./cmd/cli/main.go
# github.com/ethereum/go-ethereum/log
log/handler_go14.go:9:6: swapHandler redeclared in this block
        log/handler_go119.go:9:6: other declaration of swapHandler
log/handler_go14.go:13:23: swapHandler.Log redeclared in this block
        log/handler_go119.go:13:23: other declaration of Log
log/handler_go14.go:17:23: swapHandler.Swap redeclared in this block
        log/handler_go119.go:17:23: other declaration of Swap
log/handler_go14.go:21:23: swapHandler.Get redeclared in this block
        log/handler_go119.go:21:23: other declaration of Get
log/handler_go119.go:10:17: undefined: atomic.Pointer
note: module requires Go 1.19
make: *** [Makefile:30: bor] Error 2
```

Updating go to 1.19 fixed this.
Thus, the README should ask for go 1.19+.