### PR TITLE
consensus/bor, eth/filter: handle nil state-syncs in subscriptions

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1161,7 +1161,7 @@ func (c *Bor) CommitStates(
 	processStart := time.Now()
 	totalGas := 0 /// limit on gas for state sync per block
 	chainID := c.chainConfig.ChainID.String()
-	stateSyncs := make([]*types.StateSyncData, len(eventRecords))
+	stateSyncs := make([]*types.StateSyncData, 0, len(eventRecords))
 
 	var gasUsed uint64
 

--- a/eth/filters/bor_api.go
+++ b/eth/filters/bor_api.go
@@ -67,8 +67,8 @@ func (api *PublicFilterAPI) NewDeposits(ctx context.Context, crit ethereum.State
 		for {
 			select {
 			case h := <-stateSyncData:
-				if h != nil || crit.ID == h.ID || bytes.Equal(crit.Contract.Bytes(), h.Contract.Bytes()) ||
-					(crit.ID == 0 && crit.Contract == common.Address{}) {
+				if h != nil && (crit.ID == h.ID || bytes.Equal(crit.Contract.Bytes(), h.Contract.Bytes()) ||
+					(crit.ID == 0 && crit.Contract == common.Address{})) {
 					notifier.Notify(rpcSub.ID, h)
 				}
 			case <-rpcSub.Err():

--- a/eth/filters/bor_api.go
+++ b/eth/filters/bor_api.go
@@ -67,7 +67,7 @@ func (api *PublicFilterAPI) NewDeposits(ctx context.Context, crit ethereum.State
 		for {
 			select {
 			case h := <-stateSyncData:
-				if crit.ID == h.ID || bytes.Compare(crit.Contract.Bytes(), h.Contract.Bytes()) == 0 ||
+				if h != nil || crit.ID == h.ID || bytes.Equal(crit.Contract.Bytes(), h.Contract.Bytes()) ||
 					(crit.ID == 0 && crit.Contract == common.Address{}) {
 					notifier.Notify(rpcSub.ID, h)
 				}


### PR DESCRIPTION
# Description

Due to a nil value in state sync slice, a filter receiving it's subscription panics. This PR fixes it. 

Additional context: 
The issue was because the slice which was to be returned was initialised with all empty state sync objects before even it was filled with data. Due to some cause (mostly a validation issue), if the execution loop breaks, it will return that half-filled slice which has some nil elements. Others (filter services in this case) assume that there can’t be a nil element and hence they panic on receiving one.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
