### PR TITLE
core,eth,internal/cli,internal/ethapi: add --rpc.allow-unprotected-txs flag to allow txs to get replayed (for shadow node) 

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -13,7 +13,7 @@ syncmode = "full"
 # snapshot = true
 # "bor.logs" = false
 # ethstats = ""
-
+# devfakeauthor = false
 # ["eth.requiredblocks"]
 
 [p2p]
@@ -65,6 +65,7 @@ syncmode = "full"
 #   ipcpath = ""
 #   gascap = 50000000
 #   txfeecap = 5.0
+#   allow-unprotected-txs = false
 #   [jsonrpc.http]
 #     enabled = false
 #     port = 8545

--- a/consensus/bor/valset/validator_set.go
+++ b/consensus/bor/valset/validator_set.go
@@ -305,7 +305,7 @@ func (vals *ValidatorSet) UpdateTotalVotingPower() error {
 // It recomputes the total voting power if required.
 func (vals *ValidatorSet) TotalVotingPower() int64 {
 	if vals.totalVotingPower == 0 {
-		log.Info("invoking updateTotalVotingPower before returning it")
+		log.Debug("invoking updateTotalVotingPower before returning it")
 
 		if err := vals.UpdateTotalVotingPower(); err != nil {
 			// Can/should we do better?
@@ -641,14 +641,15 @@ func (vals *ValidatorSet) UpdateValidatorMap() {
 
 // UpdateWithChangeSet attempts to update the validator set with 'changes'.
 // It performs the following steps:
-// - validates the changes making sure there are no duplicates and splits them in updates and deletes
-// - verifies that applying the changes will not result in errors
-// - computes the total voting power BEFORE removals to ensure that in the next steps the priorities
-//   across old and newly added validators are fair
-// - computes the priorities of new validators against the final set
-// - applies the updates against the validator set
-// - applies the removals against the validator set
-// - performs scaling and centering of priority values
+//   - validates the changes making sure there are no duplicates and splits them in updates and deletes
+//   - verifies that applying the changes will not result in errors
+//   - computes the total voting power BEFORE removals to ensure that in the next steps the priorities
+//     across old and newly added validators are fair
+//   - computes the priorities of new validators against the final set
+//   - applies the updates against the validator set
+//   - applies the removals against the validator set
+//   - performs scaling and centering of priority values
+//
 // If an error is detected during verification steps, it is returned and the validator set
 // is not changed.
 func (vals *ValidatorSet) UpdateWithChangeSet(changes []*Validator) error {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -174,7 +174,8 @@ type TxPoolConfig struct {
 	AccountQueue uint64 // Maximum number of non-executable transaction slots permitted per account
 	GlobalQueue  uint64 // Maximum number of non-executable transaction slots for all accounts
 
-	Lifetime time.Duration // Maximum amount of time non-executable transaction are queued
+	Lifetime            time.Duration // Maximum amount of time non-executable transaction are queued
+	AllowUnprotectedTxs bool          // Allow non-EIP-155 transactions
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction
@@ -191,7 +192,8 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	AccountQueue: 64,
 	GlobalQueue:  1024,
 
-	Lifetime: 3 * time.Hour,
+	Lifetime:            3 * time.Hour,
+	AllowUnprotectedTxs: false,
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -759,7 +761,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 
 	// Make sure the transaction is signed properly.
 	from, err := types.Sender(pool.signer, tx)
-	if err != nil {
+	if err != nil && !pool.config.AllowUnprotectedTxs {
 		return ErrInvalidSender
 	}
 
@@ -1096,6 +1098,11 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 		// Exclude transactions with invalid signatures as soon as
 		// possible and cache senders in transactions before
 		// obtaining lock
+
+		if pool.config.AllowUnprotectedTxs {
+			pool.signer = types.NewFakeSigner(tx.ChainId())
+		}
+
 		_, err = types.Sender(pool.signer, tx)
 		if err != nil {
 			errs = append(errs, ErrInvalidSender)
@@ -1149,11 +1156,16 @@ func (pool *TxPool) addTx(tx *types.Transaction, local, sync bool) error {
 		// Exclude transactions with invalid signatures as soon as
 		// possible and cache senders in transactions before
 		// obtaining lock
+		if pool.config.AllowUnprotectedTxs {
+			pool.signer = types.NewFakeSigner(tx.ChainId())
+		}
+
 		_, err = types.Sender(pool.signer, tx)
 		if err != nil {
 			invalidTxMeter.Mark(1)
-
 			return
+		} else {
+			err = nil
 		}
 	}()
 

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -470,6 +470,42 @@ func (fs FrontierSigner) Hash(tx *Transaction) common.Hash {
 	})
 }
 
+// FakeSigner implements the Signer interface and accepts unprotected transactions
+type FakeSigner struct{ londonSigner }
+
+var _ Signer = FakeSigner{}
+
+func NewFakeSigner(chainId *big.Int) Signer {
+	signer := NewLondonSigner(chainId)
+	ls, _ := signer.(londonSigner)
+
+	return FakeSigner{londonSigner: ls}
+}
+
+func (f FakeSigner) Sender(tx *Transaction) (common.Address, error) {
+	return f.londonSigner.Sender(tx)
+}
+
+func (f FakeSigner) SignatureValues(tx *Transaction, sig []byte) (r, s, v *big.Int, err error) {
+	return f.londonSigner.SignatureValues(tx, sig)
+}
+
+func (f FakeSigner) ChainID() *big.Int {
+	return f.londonSigner.ChainID()
+}
+
+// Hash returns 'signature hash', i.e. the transaction hash that is signed by the
+// private key. This hash does not uniquely identify the transaction.
+func (f FakeSigner) Hash(tx *Transaction) common.Hash {
+	return f.londonSigner.Hash(tx)
+}
+
+// Equal returns true if the given signer is the same as the receiver.
+func (f FakeSigner) Equal(Signer) bool {
+	// Always return true
+	return true
+}
+
 func decodeSignature(sig []byte) (r, s, v *big.Int) {
 	if len(sig) != crypto.SignatureLength {
 		panic(fmt.Sprintf("wrong size for signature: got %d, want %d", len(sig), crypto.SignatureLength))

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -13,6 +13,7 @@ gcmode = "full"              # Blockchain garbage collection mode ("full", "arch
 snapshot = true              # Enables the snapshot-database mode
 "bor.logs" = false           # Enables bor log retrieval
 ethstats = ""                # Reporting URL of a ethstats service (nodename:secret@host:port)
+devfakeauthor = false        # Run miner without validator set authorization [dev mode] : Use with '--bor.withoutheimdall' (default: false)
 
 ["eth.requiredblocks"]  # Comma separated block number-to-hash mappings to require for peering (<number>=<hash>) (default = empty map)
   "31000000" = "0x2087b9e2b353209c2c21e370c82daa12278efd0fe5f0febe6c29035352cf050e"
@@ -64,6 +65,7 @@ ethstats = ""                # Reporting URL of a ethstats service (nodename:sec
   ipcpath = ""                                     # Filename for IPC socket/pipe within the datadir (explicit paths escape it)
   gascap = 50000000                                # Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite)
   txfeecap = 5.0                                   # Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap)
+  allow-unprotected-txs = false                    # Allow for unprotected (non EIP155 signed) transactions to be submitted via RPC (default: false)
   [jsonrpc.http]
     enabled = false                                # Enable the HTTP-RPC server
     port = 8545                                    # http.port

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -32,7 +32,13 @@ The ```bor server``` command runs the Bor client.
 
 - ```bor.withoutheimdall```: Run without Heimdall service (for testing purpose) (default: false)
 
+- ```bor.devfakeauthor```: Run miner without validator set authorization [dev mode] : Use with '--bor.withoutheimdall' (default: false)
+
 - ```bor.heimdallgRPC```: Address of Heimdall gRPC service
+
+- ```bor.runheimdall```: Run Heimdall service as a child process (default: false)
+
+- ```bor.runheimdallargs```: Arguments to pass to Heimdall service
 
 - ```ethstats```: Reporting URL of a ethstats service (nodename:secret@host:port)
 
@@ -91,6 +97,8 @@ The ```bor server``` command runs the Bor client.
 - ```rpc.gascap```: Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite) (default: 50000000)
 
 - ```rpc.txfeecap```: Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap) (default: 5)
+
+- ```rpc.allow-unprotected-txs```: Allow for unprotected (non EIP155 signed) transactions to be submitted via RPC (default: false)
 
 - ```ipcdisable```: Disable the IPC-RPC server (default: false)
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -174,7 +174,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	// START: Bor changes
 	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
-		log.Info("Unprotected transactions allowed")
+		log.Debug(" ###########", "Unprotected transactions allowed")
+
+		config.TxPool.AllowUnprotectedTxs = true
 	}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -108,6 +108,9 @@ type Config struct {
 
 	// Developer has the developer mode related settings
 	Developer *DeveloperConfig `hcl:"developer,block" toml:"developer,block"`
+
+	// Develop Fake Author mode to produce blocks without authorisation
+	DevFakeAuthor bool `hcl:"devfakeauthor,optional" toml:"devfakeauthor,optional"`
 }
 
 type P2PConfig struct {
@@ -580,6 +583,7 @@ func DefaultConfig() *Config {
 			Enabled: false,
 			Period:  0,
 		},
+		DevFakeAuthor: false,
 	}
 }
 
@@ -712,6 +716,9 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 	n.HeimdallgRPCAddress = c.Heimdall.GRPCAddress
 	n.RunHeimdall = c.Heimdall.RunHeimdall
 	n.RunHeimdallArgs = c.Heimdall.RunHeimdallArgs
+
+	// Developer Fake Author for producing blocks without authorisation on bor consensus
+	n.DevFakeAuthor = c.DevFakeAuthor
 
 	// gas price oracle
 	{

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -254,6 +254,8 @@ type JsonRPCConfig struct {
 	Graphql *APIConfig `hcl:"graphql,block" toml:"graphql,block"`
 
 	HttpTimeout *HttpTimeouts `hcl:"timeouts,block" toml:"timeouts,block"`
+
+	AllowUnprotectedTxs bool `hcl:"unprotectedtxs,optional" toml:"unprotectedtxs,optional"`
 }
 
 type GRPCConfig struct {
@@ -504,10 +506,11 @@ func DefaultConfig() *Config {
 			IgnorePrice: gasprice.DefaultIgnorePrice,
 		},
 		JsonRPC: &JsonRPCConfig{
-			IPCDisable: false,
-			IPCPath:    "",
-			GasCap:     ethconfig.Defaults.RPCGasCap,
-			TxFeeCap:   ethconfig.Defaults.RPCTxFeeCap,
+			IPCDisable:          false,
+			IPCPath:             "",
+			GasCap:              ethconfig.Defaults.RPCGasCap,
+			TxFeeCap:            ethconfig.Defaults.RPCTxFeeCap,
+			AllowUnprotectedTxs: false,
 			Http: &APIConfig{
 				Enabled: false,
 				Port:    8545,
@@ -1049,6 +1052,7 @@ func (c *Config) buildNode() (*node.Config, error) {
 		InsecureUnlockAllowed: c.Accounts.AllowInsecureUnlock,
 		Version:               params.VersionWithCommit(gitCommit, gitDate),
 		IPCPath:               ipcPath,
+		AllowUnprotectedTxs:   c.JsonRPC.AllowUnprotectedTxs,
 		P2P: p2p.Config{
 			MaxPeers:        int(c.P2P.MaxPeers),
 			MaxPendingPeers: int(c.P2P.MaxPendPeers),

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -255,7 +255,7 @@ type JsonRPCConfig struct {
 
 	HttpTimeout *HttpTimeouts `hcl:"timeouts,block" toml:"timeouts,block"`
 
-	AllowUnprotectedTxs bool `hcl:"unprotectedtxs,optional" toml:"unprotectedtxs,optional"`
+	AllowUnprotectedTxs bool `hcl:"allow-unprotected-txs,optional" toml:"allow-unprotected-txs,optional"`
 }
 
 type GRPCConfig struct {

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -95,6 +95,12 @@ func (c *Command) Flags() *flagset.Flagset {
 		Value:   &c.cliConfig.Heimdall.Without,
 		Default: c.cliConfig.Heimdall.Without,
 	})
+	f.BoolFlag(&flagset.BoolFlag{
+		Name:    "bor.devfakeauthor",
+		Usage:   "Run miner without validator set authorization [dev mode] : Use with '--bor.withoutheimdall'",
+		Value:   &c.cliConfig.DevFakeAuthor,
+		Default: c.cliConfig.DevFakeAuthor,
+	})
 	f.StringFlag(&flagset.StringFlag{
 		Name:    "bor.heimdallgRPC",
 		Usage:   "Address of Heimdall gRPC service",

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -365,6 +365,13 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "JsonRPC",
 	})
 	f.BoolFlag(&flagset.BoolFlag{
+		Name:    "rpc.allow-unprotected-txs",
+		Usage:   "Allow for unprotected (non EIP155 signed) transactions to be submitted via RPC",
+		Value:   &c.cliConfig.JsonRPC.AllowUnprotectedTxs,
+		Default: c.cliConfig.JsonRPC.AllowUnprotectedTxs,
+		Group:   "JsonRPC",
+	})
+	f.BoolFlag(&flagset.BoolFlag{
 		Name:    "ipcdisable",
 		Usage:   "Disable the IPC-RPC server",
 		Value:   &c.cliConfig.JsonRPC.IPCDisable,

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1856,7 +1856,8 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	// Print a log with full tx details for manual investigations and interventions
 	signer := types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Number())
 	from, err := types.Sender(signer, tx)
-	if err != nil {
+
+	if err != nil && (!b.UnprotectedAllowed() || (b.UnprotectedAllowed() && err != types.ErrInvalidChainId)) {
 		return common.Hash{}, err
 	}
 
@@ -2046,6 +2047,10 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs Transact
 	for _, p := range pending {
 		wantSigHash := s.signer.Hash(matchTx)
 		pFrom, err := types.Sender(s.signer, p)
+
+		if err != nil && (s.b.UnprotectedAllowed() && err == types.ErrInvalidChainId) {
+			err = nil
+		}
 		if err == nil && pFrom == sendArgs.from() && s.signer.Hash(p) == wantSigHash {
 			// Match. Re-sign and send the transaction.
 			if gasPrice != nil && (*big.Int)(gasPrice).Sign() != 0 {

--- a/miner/fake_miner.go
+++ b/miner/fake_miner.go
@@ -152,7 +152,7 @@ func NewFakeBor(t TensingObject, chainDB ethdb.Database, chainConfig *params.Cha
 		chainConfig.Bor = params.BorUnittestChainConfig.Bor
 	}
 
-	return bor.New(chainConfig, chainDB, ethAPIMock, spanner, heimdallClientMock, contractMock)
+	return bor.New(chainConfig, chainDB, ethAPIMock, spanner, heimdallClientMock, contractMock, false)
 }
 
 type mockBackend struct {

--- a/packaging/templates/mainnet-v1/archive/config.toml
+++ b/packaging/templates/mainnet-v1/archive/config.toml
@@ -8,6 +8,7 @@ syncmode = "full"
 gcmode = "archive"
 # snapshot = true
 # ethstats = ""
+# devfakeauthor = false
 
 # ["eth.requiredblocks"]
 
@@ -57,6 +58,7 @@ gcmode = "archive"
     # ipcdisable = false
     # gascap = 50000000
     # txfeecap = 5.0
+    # allow-unprotected-txs = false
     [jsonrpc.http]
         enabled = true
         port = 8545

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
@@ -8,6 +8,7 @@ syncmode = "full"
 # gcmode = "full"
 # snapshot = true
 # ethstats = ""
+# devfakeauthor = false
 
 # ["eth.requiredblocks"]
 
@@ -57,6 +58,7 @@ syncmode = "full"
     # ipcdisable = false
     # gascap = 50000000
     # txfeecap = 5.0
+    # allow-unprotected-txs = false
     [jsonrpc.http]
         enabled = true
         port = 8545

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
@@ -10,6 +10,7 @@ syncmode = "full"
 # gcmode = "full"
 # snapshot = true
 # ethstats = ""
+# devfakeauthor = false
 
 # ["eth.requiredblocks"]
 
@@ -59,6 +60,7 @@ syncmode = "full"
     # ipcdisable = false
     # gascap = 50000000
     # txfeecap = 5.0
+    # allow-unprotected-txs = false
     [jsonrpc.http]
         enabled = true
         port = 8545

--- a/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
@@ -10,6 +10,7 @@ syncmode = "full"
 # gcmode = "full"
 # snapshot = true
 # ethstats = ""
+# devfakeauthor = false
 
 # ["eth.requiredblocks"]
 
@@ -59,6 +60,7 @@ syncmode = "full"
     # ipcdisable = false
     # gascap = 50000000
     # txfeecap = 5.0
+    # allow-unprotected-txs = false
     [jsonrpc.http]
         enabled = true
         port = 8545

--- a/packaging/templates/testnet-v4/archive/config.toml
+++ b/packaging/templates/testnet-v4/archive/config.toml
@@ -8,6 +8,7 @@ syncmode = "full"
 gcmode = "archive"
 # snapshot = true
 # ethstats = ""
+# devfakeauthor = false
 
 # ["eth.requiredblocks"]
 
@@ -57,6 +58,7 @@ gcmode = "archive"
     # ipcdisable = false
     # gascap = 50000000
     # txfeecap = 5.0
+    # allow-unprotected-txs = false
     [jsonrpc.http]
         enabled = true
         port = 8545

--- a/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
@@ -8,6 +8,7 @@ syncmode = "full"
 # gcmode = "full"
 # snapshot = true
 # ethstats = ""
+# devfakeauthor = false
 
 # ["eth.requiredblocks"]
 
@@ -57,6 +58,7 @@ syncmode = "full"
     # ipcdisable = false
     # gascap = 50000000
     # txfeecap = 5.0
+    # allow-unprotected-txs = false
     [jsonrpc.http]
         enabled = true
         port = 8545

--- a/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
@@ -10,6 +10,7 @@ syncmode = "full"
 # gcmode = "full"
 # snapshot = true
 # ethstats = ""
+# devfakeauthor = false
 
 # ["eth.requiredblocks"]
 
@@ -59,6 +60,7 @@ syncmode = "full"
     # ipcdisable = false
     # gascap = 50000000
     # txfeecap = 5.0
+    # allow-unprotected-txs = false
     [jsonrpc.http]
         enabled = true
         port = 8545

--- a/packaging/templates/testnet-v4/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/without-sentry/bor/config.toml
@@ -10,6 +10,7 @@ syncmode = "full"
 # gcmode = "full"
 # snapshot = true
 # ethstats = ""
+# devfakeauthor = false
 
 # ["eth.requiredblocks"]
 
@@ -59,6 +60,7 @@ syncmode = "full"
     # ipcdisable = false
     # gascap = 50000000
     # txfeecap = 5.0
+    # allow-unprotected-txs = false
     [jsonrpc.http]
         enabled = true
         port = 8545


### PR DESCRIPTION
# Description

This PR introduces `rpc.allow-unprotected-txs` flag to facilitate replaying of transactions from a different network to a shadow node (i.e a node producing blocks in isolation with the state of the network from which transactions are being relayed). 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Nodes audience

Currently, this flag is only meant to be enabled if we are running a shadow node.

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

