### PR TITLE
optimize RPC

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -635,7 +635,6 @@ func (c *Client) drainRead() {
 func (c *Client) read(codec ServerCodec) {
 	for {
 		msgs, batch, err := codec.readBatch()
-		fmt.Println("=====-9999", err)
 		if errors.Is(err, new(json.SyntaxError)) {
 			codec.writeJSON(context.Background(), errorMessage(&parseError{err.Error()}))
 		}

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -34,21 +34,20 @@ import (
 //
 // The entry points for incoming messages are:
 //
-//    h.handleMsg(message)
-//    h.handleBatch(message)
+//	h.handleMsg(message)
+//	h.handleBatch(message)
 //
 // Outgoing calls use the requestOp struct. Register the request before sending it
 // on the connection:
 //
-//    op := &requestOp{ids: ...}
-//    h.addRequestOp(op)
+//	op := &requestOp{ids: ...}
+//	h.addRequestOp(op)
 //
 // Now send the request, then wait for the reply to be delivered through handleMsg:
 //
-//    if err := op.wait(...); err != nil {
-//        h.removeRequestOp(op) // timeout, etc.
-//    }
-//
+//	if err := op.wait(...); err != nil {
+//	    h.removeRequestOp(op) // timeout, etc.
+//	}
 type handler struct {
 	reg            *serviceRegistry
 	unsubscribeCb  *callback
@@ -250,7 +249,7 @@ func (h *handler) handleImmediate(msg *jsonrpcMessage) bool {
 // handleSubscriptionResult processes subscription notifications.
 func (h *handler) handleSubscriptionResult(msg *jsonrpcMessage) {
 	var result subscriptionResult
-	if err := json.Unmarshal(msg.Params, &result); err != nil {
+	if err := ji.Unmarshal(msg.Params, &result); err != nil {
 		h.log.Debug("Dropping invalid subscription message")
 		return
 	}
@@ -280,7 +279,7 @@ func (h *handler) handleResponse(msg *jsonrpcMessage) {
 		op.err = msg.Error
 		return
 	}
-	if op.err = json.Unmarshal(msg.Result, &op.sub.subid); op.err == nil {
+	if op.err = ji.Unmarshal(msg.Result, &op.sub.subid); op.err == nil {
 		go op.sub.run()
 		h.clientSubs[op.sub.subid] = op.sub
 	}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -19,7 +19,6 @@ package rpc
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -147,7 +146,7 @@ func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}) e
 	defer respBody.Close()
 
 	var respmsg jsonrpcMessage
-	if err := json.NewDecoder(respBody).Decode(&respmsg); err != nil {
+	if err := ji.NewDecoder(respBody).Decode(&respmsg); err != nil {
 		return err
 	}
 	op.resp <- &respmsg
@@ -162,7 +161,7 @@ func (c *Client) sendBatchHTTP(ctx context.Context, op *requestOp, msgs []*jsonr
 	}
 	defer respBody.Close()
 	var respmsgs []jsonrpcMessage
-	if err := json.NewDecoder(respBody).Decode(&respmsgs); err != nil {
+	if err := ji.NewDecoder(respBody).Decode(&respmsgs); err != nil {
 		return err
 	}
 	for i := 0; i < len(respmsgs); i++ {
@@ -172,7 +171,7 @@ func (c *Client) sendBatchHTTP(ctx context.Context, op *requestOp, msgs []*jsonr
 }
 
 func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadCloser, error) {
-	body, err := json.Marshal(msg)
+	body, err := ji.Marshal(msg)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -211,7 +211,6 @@ func (c *jsonCodec) readBatch() (messages []*jsonrpcMessage, batch bool, err err
 	// Decode the next JSON object in the input stream.
 	// This verifies basic syntax, etc.
 	var rawmsg json.RawMessage
-	fmt.Println("=====-0")
 	if err := c.decode(&rawmsg); err != nil {
 		if errors.Is(err, io.EOF) {
 			// todo: need to make a suitable json.syntax error here
@@ -220,7 +219,6 @@ func (c *jsonCodec) readBatch() (messages []*jsonrpcMessage, batch bool, err err
 
 		return nil, false, err
 	}
-	fmt.Println("=====-1")
 	messages, batch = parseMessage(rawmsg)
 	for i, msg := range messages {
 		if msg == nil {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -18,7 +18,6 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"sync/atomic"
 
@@ -104,18 +103,15 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 	h.allowSubscribe = false
 	defer h.close(io.EOF, nil)
 
-	fmt.Println("=====- -1")
 	reqs, batch, err := codec.readBatch()
 	if err != nil {
-		fmt.Println("=====-3")
 		if err != io.EOF {
-			fmt.Println("=====-4")
 			codec.writeJSON(ctx, errorMessage(&invalidMessageError{"parse error"}))
 		}
-		fmt.Println("=====-5")
+
 		return
 	}
-	fmt.Println("=====-6")
+
 	if batch {
 		h.handleBatch(reqs)
 	} else {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -18,10 +18,12 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync/atomic"
 
 	mapset "github.com/deckarep/golang-set"
+
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -102,13 +104,18 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 	h.allowSubscribe = false
 	defer h.close(io.EOF, nil)
 
+	fmt.Println("=====- -1")
 	reqs, batch, err := codec.readBatch()
 	if err != nil {
+		fmt.Println("=====-3")
 		if err != io.EOF {
+			fmt.Println("=====-4")
 			codec.writeJSON(ctx, errorMessage(&invalidMessageError{"parse error"}))
 		}
+		fmt.Println("=====-5")
 		return
 	}
+	fmt.Println("=====-6")
 	if batch {
 		h.handleBatch(reqs)
 	} else {

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -125,9 +125,14 @@ func TestServerShortLivedConn(t *testing.T) {
 	go server.ServeListener(listener)
 
 	var (
-		request  = `{"jsonrpc":"2.0","id":1,"method":"rpc_modules"}` + "\n"
-		wantResp = `{"jsonrpc":"2.0","id":1,"result":{"nftest":"1.0","rpc":"1.0","test":"1.0"}}` + "\n"
-		deadline = time.Now().Add(10 * time.Second)
+		request   = `{"jsonrpc":"2.0","id":1,"method":"rpc_modules"}` + "\n"
+		wantResp  = `{"jsonrpc":"2.0","id":1,"result":{"nftest":"1.0","rpc":"1.0","test":"1.0"}}` + "\n"
+		wantResp1 = `{"jsonrpc":"2.0","id":1,"result":{"nftest":"1.0","test":"1.0","rpc":"1.0"}}` + "\n"
+		wantResp2 = `{"jsonrpc":"2.0","id":1,"result":{"rpc":"1.0","test":"1.0","nftest":"1.0"}}` + "\n"
+		wantResp3 = `{"jsonrpc":"2.0","id":1,"result":{"rpc":"1.0","nftest":"1.0","test":"1.0"}}` + "\n"
+		wantResp4 = `{"jsonrpc":"2.0","id":1,"result":{"test":"1.0","rpc":"1.0","nftest":"1.0"}}` + "\n"
+		wantResp5 = `{"jsonrpc":"2.0","id":1,"result":{"test":"1.0","nftest":"1.0","rpc":"1.0"}}` + "\n"
+		deadline  = time.Now().Add(10 * time.Second)
 	)
 	for i := 0; i < 20; i++ {
 		conn, err := net.Dial("tcp", listener.Addr().String())
@@ -147,8 +152,10 @@ func TestServerShortLivedConn(t *testing.T) {
 		if err != nil {
 			t.Fatal("read error:", err)
 		}
-		if !bytes.Equal(buf[:n], []byte(wantResp)) {
-			t.Fatalf("wrong response: %s", buf[:n])
+		if !bytes.Equal(buf[:n], []byte(wantResp)) && !bytes.Equal(buf[:n], []byte(wantResp1)) &&
+			!bytes.Equal(buf[:n], []byte(wantResp2)) && !bytes.Equal(buf[:n], []byte(wantResp3)) &&
+			!bytes.Equal(buf[:n], []byte(wantResp4)) && !bytes.Equal(buf[:n], []byte(wantResp5)) {
+			t.Fatalf("wrong response: %s - %s", buf[:n], []byte(wantResp))
 		}
 	}
 }

--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -121,7 +121,7 @@ func (n *Notifier) CreateSubscription() *Subscription {
 // Notify sends a notification to the client with the given data as payload.
 // If an error occurs the RPC connection is closed and the error is returned.
 func (n *Notifier) Notify(id ID, data interface{}) error {
-	enc, err := json.Marshal(data)
+	enc, err := ji.Marshal(data)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (n *Notifier) activate() error {
 }
 
 func (n *Notifier) send(sub *Subscription, data json.RawMessage) error {
-	params, _ := json.Marshal(&subscriptionResult{ID: string(sub.ID), Result: data})
+	params, _ := ji.Marshal(&subscriptionResult{ID: string(sub.ID), Result: data})
 	ctx := context.Background()
 	return n.h.conn.writeJSON(ctx, &jsonrpcMessage{
 		Version: vsn,
@@ -197,7 +197,7 @@ func (s *Subscription) Err() <-chan error {
 
 // MarshalJSON marshals a subscription as its ID.
 func (s *Subscription) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.ID)
+	return ji.Marshal(s.ID)
 }
 
 // ClientSubscription is a subscription established through the Client's Subscribe or
@@ -365,7 +365,7 @@ func (sub *ClientSubscription) forward() (unsubscribeServer bool, err error) {
 
 func (sub *ClientSubscription) unmarshal(result json.RawMessage) (interface{}, error) {
 	val := reflect.New(sub.etype)
-	err := json.Unmarshal(result, val.Interface())
+	err := ji.Unmarshal(result, val.Interface())
 	return val.Elem().Interface(), err
 }
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -18,7 +18,6 @@ package rpc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -132,7 +131,7 @@ type BlockNumberOrHash struct {
 func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 	type erased BlockNumberOrHash
 	e := erased{}
-	err := json.Unmarshal(data, &e)
+	err := ji.Unmarshal(data, &e)
 	if err == nil {
 		if e.BlockNumber != nil && e.BlockHash != nil {
 			return fmt.Errorf("cannot specify both BlockHash and BlockNumber, choose one or the other")
@@ -143,7 +142,7 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	var input string
-	err = json.Unmarshal(data, &input)
+	err = ji.Unmarshal(data, &input)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

RPC is one of the slowest and mist garbage producing thing in Bor. The best solution is to rewrite it with barely no reflection and unnecessary memory allocation. However, a new RPC package is a topic of another discussion.
This PR is aiming for quick and cheap optimization with replacing standard json with more efficient one.

To test this PR we need to run a node and profile it with and without the PR on the same load and compare results of profiling and benchmarking. It it gives us >10% of performance, I believe, we need to fix tests and merge the PR.

# Changes

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

PRC error messages might change with the PR.
