### PR TITLE
Revert "Reduce txArriveTimeout to 100ms"

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -55,11 +55,11 @@ const (
 
 	// txArriveTimeout is the time allowance before an announced transaction is
 	// explicitly requested.
-	txArriveTimeout = 100 * time.Millisecond
+	txArriveTimeout = 500 * time.Millisecond
 
 	// txGatherSlack is the interval used to collate almost-expired announces
 	// with network fetches.
-	txGatherSlack = 20 * time.Millisecond
+	txGatherSlack = 100 * time.Millisecond
 )
 
 var (


### PR DESCRIPTION
This reverts commit 243d231fe45bc02f33678bb4f69e941167d7f466.

# Description

I'm part of the team at FastLane Labs who are building out an ecosystem friendly MEV protocol for Polygon. Currently, we are in open beta and have validators representing more than 20% of new block production onboard.

This PR reverts a recent commit that has made it into the current develop branch which significantly reduces the txArriveTimeout variable in the `eth/fetcher/tx_fetcher.go` file.

This change seems to have been committed straight into develop, rather than going through a PR so it's hard for us to understand the rationale behind it, but we'd be keen to discuss that here.

## Potential issues introduced by the change

Reducing the txArriveTimeout value to from 500 ms to 100 ms seems likely to increase the amount of noise in the p2p layer of the network, and will also likely increase bandwidth consumption for full node operators.

This is because the 100ms value that is being introduced here is much less than the worst case round-the-world P95 latency of around 350ms-400ms. This means that if a transaction originates in another part of the world, this change will increase the likelihood that a node which is the recipient of an announcement makes a request for the full body of a transaction that it likely would have received by direct propagation anyway.

This has the effect of both increasing the number of redundant messages being sent through the p2p layer, but also increasing the number of full transactions that are being sent, both of which have an impact on the network resources of node operators.

## Impact on the FastLane System

The current delay of 500ms on validator nodes is a key element that keeps the design of the FastLane MEV protocol simple, and makes the [patch](https://github.com/Polygon-Fast-Lane/sentry-patch/blob/main/announce_only.patch) that needs to be applied to validators sentries easy to understand.

One of the main goals of the FastLane protocol is to be as ecosystem friendly as possible, and to help improve the health of the p2p layer of the network by eliminating one of the primary incentives for network participants to spam: namely trying to be directly propagated from the validators sentry to the validator itself, rather than going through the announce mechanism. For a backrunner, your chance to be directly propagated is directly proportional to the number of transactions you send. As adoption of the FastLane protocol increases and we remove this mechanism, the incentive to spam on the network will drop proportionally which will eventually result in a much healthier network for both users and node operators.

As things are today, this presents a breaking change to the design of the FastLane protocol and we would be interested in working with the Polygon team to understand the intent of this change, figure out if this is the best way to achieve this goal, and finally if it is to coordinate between FastLane and Polygon to ensure a seamless release for all users of the network.

# Additional comments

I have gone and reviewed geth and the bsc node fork to confirm that the original 500 ms setting is still being used on both of these chains as well, and that is still the case:

https://github.com/bnb-chain/bsc/blob/master/eth/fetcher/tx_fetcher.go
https://github.com/ethereum/go-ethereum/blame/master/eth/fetcher/tx_fetcher.go

The FastLane mechanism is outlined in our whitepaper [here](https://www.fastlane.finance/PFL_WHITE_PAPER_1_5.pdf).
