### PR TITLE
core, tests/bor: add more tests for state-sync validation

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -422,6 +422,10 @@ func (bc *BlockChain) SetStateSync(stateData []*types.StateSyncData) {
 	bc.stateSyncData = stateData
 }
 
+func (bc *BlockChain) GetStateSync() []*types.StateSyncData {
+	return bc.stateSyncData
+}
+
 // SubscribeStateSyncEvent registers a subscription of StateSyncEvent.
 func (bc *BlockChain) SubscribeStateSyncEvent(ch chan<- StateSyncEvent) event.Subscription {
 	return bc.scope.Track(bc.stateSyncFeed.Subscribe(ch))

--- a/tests/bor/bor_test.go
+++ b/tests/bor/bor_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"math/big"
 	"os"
@@ -458,7 +459,19 @@ func TestFetchStateSyncEvents(t *testing.T) {
 	_bor.SetHeimdallClient(h)
 
 	block = buildNextBlock(t, _bor, chain, block, nil, init.genesis.Config.Bor, nil, res.Result.ValidatorSet.Validators)
+
+	// Validate the state sync transactions set by consensus
+	validateStateSyncEvents(t, eventRecords, chain.GetStateSync())
+
 	insertNewBlock(t, chain, block)
+}
+
+func validateStateSyncEvents(t *testing.T, expected []*clerk.EventRecordWithTime, got []*types.StateSyncData) {
+	require.Equal(t, len(expected), len(got), "number of state sync events should be equal")
+
+	for i := 0; i < len(expected); i++ {
+		require.Equal(t, expected[i].ID, got[i].ID, fmt.Sprintf("state sync ids should be equal - index: %d, expected: %d, got: %d", i, expected[i].ID, got[i].ID))
+	}
 }
 
 func TestFetchStateSyncEvents_2(t *testing.T) {

--- a/tests/bor/helper.go
+++ b/tests/bor/helper.go
@@ -360,7 +360,7 @@ func generateFakeStateSyncEvents(sample *clerk.EventRecordWithTime, count int) [
 	*events[0] = event
 
 	for i := 1; i < count; i++ {
-		event.ID = uint64(i)
+		event.ID = uint64(i + 1)
 		event.Time = event.Time.Add(1 * time.Second)
 		events[i] = &clerk.EventRecordWithTime{}
 		*events[i] = event


### PR DESCRIPTION
# Description

This PR adds some additional check for state sync transactions to validate the nil state-sync bug ([issue](https://github.com/maticnetwork/bor/issues/686) and [bug fix PR](https://github.com/maticnetwork/bor/pull/695)).

Please provide a detailed description of what was done in this PR

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
