### PR TITLE
Ratelimit RPC concurrent requests

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -73,6 +73,7 @@ syncmode = "full"
 #     api = ["eth", "net", "web3", "txpool", "bor"]
 #     vhosts = ["*"]
 #     corsdomain = ["*"]
+#     maxconcreq = 0
 #   [jsonrpc.ws]
 #     enabled = false
 #     port = 8546
@@ -80,6 +81,7 @@ syncmode = "full"
 #     host = "localhost"
 #     api = ["web3", "net"]
 #     origins = ["*"]
+#     maxconcreq = 0
 #   [jsonrpc.graphql]
 #     enabled = false
 #     port = 0

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -656,7 +656,7 @@ func signer(c *cli.Context) error {
 		vhosts := utils.SplitAndTrim(c.GlobalString(utils.HTTPVirtualHostsFlag.Name))
 		cors := utils.SplitAndTrim(c.GlobalString(utils.HTTPCORSDomainFlag.Name))
 
-		srv := rpc.NewServer()
+		srv := rpc.NewServer(0)
 		err := node.RegisterApis(rpcAPI, []string{"account"}, srv, false)
 		if err != nil {
 			utils.Fatalf("Could not register API: %w", err)

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -72,6 +72,7 @@ ethstats = ""                # Reporting URL of a ethstats service (nodename:sec
     api = ["eth", "net", "web3", "txpool", "bor"]  # API's offered over the HTTP-RPC interface
     vhosts = ["localhost"]                         # Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.
     corsdomain = ["localhost"]                     # Comma separated list of domains from which to accept cross origin requests (browser enforced)
+    maxconcreq = 0                                 # Maximum concurrent rpc requests
   [jsonrpc.ws]
     enabled = false          # Enable the WS-RPC server
     port = 8546              # WS-RPC server listening port
@@ -79,6 +80,7 @@ ethstats = ""                # Reporting URL of a ethstats service (nodename:sec
     host = "localhost"       # ws.addr
     api = ["net", "web3"]    # API's offered over the WS-RPC interface
     origins = ["localhost"]  # Origins from which to accept websockets requests
+    maxconcreq = 0           # Maximum concurrent rpc requests
   [jsonrpc.graphql]
     enabled = false             # Enable GraphQL on the HTTP-RPC server. Note that GraphQL can only be started if an HTTP server is started as well.
     port = 0                    # 

--- a/internal/cli/server/command.go
+++ b/internal/cli/server/command.go
@@ -103,8 +103,6 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	// TODO 0xsharma : remove debug logs
-	fmt.Printf("###$$$ 1111 %v\n", c.config.JsonRPC.Http.MaxConcReq)
 	srv, err := NewServer(c.config, WithGRPCAddress())
 	if err != nil {
 		c.UI.Error(err.Error())

--- a/internal/cli/server/command.go
+++ b/internal/cli/server/command.go
@@ -103,6 +103,8 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
+	// TODO 0xsharma : remove debug logs
+	fmt.Printf("###$$$ 1111 %v\n", c.config.JsonRPC.Http.MaxConcReq)
 	srv, err := NewServer(c.config, WithGRPCAddress())
 	if err != nil {
 		c.UI.Error(err.Error())

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -1071,7 +1071,6 @@ func (c *Config) buildNode() (*node.Config, error) {
 		},
 	}
 
-	fmt.Printf("########$$$$$$$$$$ %v\n", cfg.HTTPMaxConcurrentRequests)
 	// dev mode
 	if c.Developer.Enabled {
 		cfg.UseLightweightKDF = true

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -284,7 +284,7 @@ type APIConfig struct {
 	Origins []string `hcl:"origins,optional" toml:"origins,optional"`
 
 	// MaxConcRequests is the maximum number of concurrent requests. 0 means unlimited
-	MaxConcurrentRequests uint64 `hcl:"maxconcurrentrequests,optional" toml:"maxconcurrentrequests,optional"`
+	MaxConcReq uint64 `hcl:"maxconcreq,optional" toml:"maxconcreq,optional"`
 }
 
 // Used from rpc.HTTPTimeouts
@@ -509,23 +509,23 @@ func DefaultConfig() *Config {
 			GasCap:     ethconfig.Defaults.RPCGasCap,
 			TxFeeCap:   ethconfig.Defaults.RPCTxFeeCap,
 			Http: &APIConfig{
-				Enabled:               false,
-				Port:                  8545,
-				Prefix:                "",
-				Host:                  "localhost",
-				API:                   []string{"eth", "net", "web3", "txpool", "bor"},
-				Cors:                  []string{"localhost"},
-				VHost:                 []string{"localhost"},
-				MaxConcurrentRequests: 0,
+				Enabled:    false,
+				Port:       8545,
+				Prefix:     "",
+				Host:       "localhost",
+				API:        []string{"eth", "net", "web3", "txpool", "bor"},
+				Cors:       []string{"localhost"},
+				VHost:      []string{"localhost"},
+				MaxConcReq: 0,
 			},
 			Ws: &APIConfig{
-				Enabled:               false,
-				Port:                  8546,
-				Prefix:                "",
-				Host:                  "localhost",
-				API:                   []string{"net", "web3"},
-				Origins:               []string{"localhost"},
-				MaxConcurrentRequests: 0,
+				Enabled:    false,
+				Port:       8546,
+				Prefix:     "",
+				Host:       "localhost",
+				API:        []string{"net", "web3"},
+				Origins:    []string{"localhost"},
+				MaxConcReq: 0,
 			},
 			Graphql: &APIConfig{
 				Enabled: false,
@@ -1057,11 +1057,11 @@ func (c *Config) buildNode() (*node.Config, error) {
 		HTTPCors:                  c.JsonRPC.Http.Cors,
 		HTTPVirtualHosts:          c.JsonRPC.Http.VHost,
 		HTTPPathPrefix:            c.JsonRPC.Http.Prefix,
-		HTTPMaxConcurrentRequests: c.JsonRPC.Http.MaxConcurrentRequests,
+		HTTPMaxConcurrentRequests: c.JsonRPC.Http.MaxConcReq,
 		WSModules:                 c.JsonRPC.Ws.API,
 		WSOrigins:                 c.JsonRPC.Ws.Origins,
 		WSPathPrefix:              c.JsonRPC.Ws.Prefix,
-		WSMaxConcurrentRequests:   c.JsonRPC.Ws.MaxConcurrentRequests,
+		WSMaxConcurrentRequests:   c.JsonRPC.Ws.MaxConcReq,
 		GraphQLCors:               c.JsonRPC.Graphql.Cors,
 		GraphQLVirtualHosts:       c.JsonRPC.Graphql.VHost,
 		HTTPTimeouts: rpc.HTTPTimeouts{
@@ -1071,6 +1071,7 @@ func (c *Config) buildNode() (*node.Config, error) {
 		},
 	}
 
+	fmt.Printf("########$$$$$$$$$$ %v\n", cfg.HTTPMaxConcurrentRequests)
 	// dev mode
 	if c.Developer.Enabled {
 		cfg.UseLightweightKDF = true

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -282,6 +282,9 @@ type APIConfig struct {
 
 	// Origins is the list of endpoints to accept requests from (only consumed for websockets)
 	Origins []string `hcl:"origins,optional" toml:"origins,optional"`
+
+	// MaxConcRequests is the maximum number of concurrent requests. 0 means unlimited
+	MaxConcurrentRequests uint64 `hcl:"maxconcurrentrequests,optional" toml:"maxconcurrentrequests,optional"`
 }
 
 // Used from rpc.HTTPTimeouts
@@ -506,21 +509,23 @@ func DefaultConfig() *Config {
 			GasCap:     ethconfig.Defaults.RPCGasCap,
 			TxFeeCap:   ethconfig.Defaults.RPCTxFeeCap,
 			Http: &APIConfig{
-				Enabled: false,
-				Port:    8545,
-				Prefix:  "",
-				Host:    "localhost",
-				API:     []string{"eth", "net", "web3", "txpool", "bor"},
-				Cors:    []string{"localhost"},
-				VHost:   []string{"localhost"},
+				Enabled:               false,
+				Port:                  8545,
+				Prefix:                "",
+				Host:                  "localhost",
+				API:                   []string{"eth", "net", "web3", "txpool", "bor"},
+				Cors:                  []string{"localhost"},
+				VHost:                 []string{"localhost"},
+				MaxConcurrentRequests: 0,
 			},
 			Ws: &APIConfig{
-				Enabled: false,
-				Port:    8546,
-				Prefix:  "",
-				Host:    "localhost",
-				API:     []string{"net", "web3"},
-				Origins: []string{"localhost"},
+				Enabled:               false,
+				Port:                  8546,
+				Prefix:                "",
+				Host:                  "localhost",
+				API:                   []string{"net", "web3"},
+				Origins:               []string{"localhost"},
+				MaxConcurrentRequests: 0,
 			},
 			Graphql: &APIConfig{
 				Enabled: false,
@@ -1048,15 +1053,17 @@ func (c *Config) buildNode() (*node.Config, error) {
 			ListenAddr:      c.P2P.Bind + ":" + strconv.Itoa(int(c.P2P.Port)),
 			DiscoveryV5:     c.P2P.Discovery.V5Enabled,
 		},
-		HTTPModules:         c.JsonRPC.Http.API,
-		HTTPCors:            c.JsonRPC.Http.Cors,
-		HTTPVirtualHosts:    c.JsonRPC.Http.VHost,
-		HTTPPathPrefix:      c.JsonRPC.Http.Prefix,
-		WSModules:           c.JsonRPC.Ws.API,
-		WSOrigins:           c.JsonRPC.Ws.Origins,
-		WSPathPrefix:        c.JsonRPC.Ws.Prefix,
-		GraphQLCors:         c.JsonRPC.Graphql.Cors,
-		GraphQLVirtualHosts: c.JsonRPC.Graphql.VHost,
+		HTTPModules:               c.JsonRPC.Http.API,
+		HTTPCors:                  c.JsonRPC.Http.Cors,
+		HTTPVirtualHosts:          c.JsonRPC.Http.VHost,
+		HTTPPathPrefix:            c.JsonRPC.Http.Prefix,
+		HTTPMaxConcurrentRequests: c.JsonRPC.Http.MaxConcurrentRequests,
+		WSModules:                 c.JsonRPC.Ws.API,
+		WSOrigins:                 c.JsonRPC.Ws.Origins,
+		WSPathPrefix:              c.JsonRPC.Ws.Prefix,
+		WSMaxConcurrentRequests:   c.JsonRPC.Ws.MaxConcurrentRequests,
+		GraphQLCors:               c.JsonRPC.Graphql.Cors,
+		GraphQLVirtualHosts:       c.JsonRPC.Graphql.VHost,
 		HTTPTimeouts: rpc.HTTPTimeouts{
 			ReadTimeout:  c.JsonRPC.HttpTimeout.ReadTimeout,
 			WriteTimeout: c.JsonRPC.HttpTimeout.WriteTimeout,

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -447,8 +447,8 @@ func (c *Command) Flags() *flagset.Flagset {
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "http.maxconcreq",
 		Usage:   "HTTP-RPC max concurrent requests",
-		Value:   &c.cliConfig.JsonRPC.Http.MaxConcurrentRequests,
-		Default: c.cliConfig.JsonRPC.Http.MaxConcurrentRequests,
+		Value:   &c.cliConfig.JsonRPC.Http.MaxConcReq,
+		Default: c.cliConfig.JsonRPC.Http.MaxConcReq,
 		Group:   "JsonRPC",
 	})
 
@@ -491,8 +491,8 @@ func (c *Command) Flags() *flagset.Flagset {
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "ws.maxconcreq",
 		Usage:   "WS-RPC max concurrent requests",
-		Value:   &c.cliConfig.JsonRPC.Ws.MaxConcurrentRequests,
-		Default: c.cliConfig.JsonRPC.Ws.MaxConcurrentRequests,
+		Value:   &c.cliConfig.JsonRPC.Ws.MaxConcReq,
+		Default: c.cliConfig.JsonRPC.Ws.MaxConcReq,
 		Group:   "JsonRPC",
 	})
 

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -444,6 +444,13 @@ func (c *Command) Flags() *flagset.Flagset {
 		Default: c.cliConfig.JsonRPC.Http.API,
 		Group:   "JsonRPC",
 	})
+	f.Uint64Flag(&flagset.Uint64Flag{
+		Name:    "http.maxconcreq",
+		Usage:   "HTTP-RPC max concurrent requests",
+		Value:   &c.cliConfig.JsonRPC.Http.MaxConcurrentRequests,
+		Default: c.cliConfig.JsonRPC.Http.MaxConcurrentRequests,
+		Group:   "JsonRPC",
+	})
 
 	// ws options
 	f.BoolFlag(&flagset.BoolFlag{
@@ -479,6 +486,13 @@ func (c *Command) Flags() *flagset.Flagset {
 		Usage:   "API's offered over the WS-RPC interface",
 		Value:   &c.cliConfig.JsonRPC.Ws.API,
 		Default: c.cliConfig.JsonRPC.Ws.API,
+		Group:   "JsonRPC",
+	})
+	f.Uint64Flag(&flagset.Uint64Flag{
+		Name:    "ws.maxconcreq",
+		Usage:   "WS-RPC max concurrent requests",
+		Value:   &c.cliConfig.JsonRPC.Ws.MaxConcurrentRequests,
+		Default: c.cliConfig.JsonRPC.Ws.MaxConcurrentRequests,
 		Group:   "JsonRPC",
 	})
 

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -196,6 +196,16 @@ web3._extend({
 			name: 'getMaxConcReq',
 			call: 'admin_getMaxConcReq'
 		}),
+		new web3._extend.Method({
+			name: 'setHTTPMaxConcReq',
+			params : 1,
+			call: 'admin_setHTTPMaxConcReq'
+		}),
+		new web3._extend.Method({
+			name: 'setWSMaxConcReq',
+			params : 1,
+			call: 'admin_setWSMaxConcReq'
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -192,6 +192,10 @@ web3._extend({
 			name: 'stopWS',
 			call: 'admin_stopWS'
 		}),
+		new web3._extend.Method({
+			name: 'getMaxConcReq',
+			call: 'admin_getMaxConcReq'
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/node/api.go
+++ b/node/api.go
@@ -78,6 +78,24 @@ func (api *privateAdminAPI) AddPeer(url string) (bool, error) {
 	return true, nil
 }
 
+type MaxConcReq struct {
+	HttpLimit uint64 // max concurrent requests for http requests. 0(Default) means no limit
+	WSLimit   uint64 // max concurrent requests for ws requests. 0(Default) means no limit
+}
+
+// get max concurrent requests parameter for rpc requests
+func (api *privateAdminAPI) GetMaxConcReq() *MaxConcReq {
+	httpLimit := api.node.http.httpConfig.maxConcReq
+	wsLimit := api.node.ws.wsConfig.maxConcReq
+
+	maxConcReq := &MaxConcReq{
+		HttpLimit: httpLimit,
+		WSLimit:   wsLimit,
+	}
+
+	return maxConcReq
+}
+
 // RemovePeer disconnects from a remote node if the connection exists
 func (api *privateAdminAPI) RemovePeer(url string) (bool, error) {
 	// Make sure the server is running, fail otherwise

--- a/node/api.go
+++ b/node/api.go
@@ -96,6 +96,24 @@ func (api *privateAdminAPI) GetMaxConcReq() *MaxConcReq {
 	return maxConcReq
 }
 
+// get max concurrent requests parameter for http rpc requests
+func (api *privateAdminAPI) SetHTTPMaxConcReq(httpMaxConcReq uint64) *MaxConcReq {
+	api.node.http.httpConfig.maxConcReq = httpMaxConcReq
+
+	api.node.http.httpHandler.Load().(*rpcHandler).server.SetMaxConcReq(httpMaxConcReq)
+
+	return api.GetMaxConcReq()
+}
+
+// get max concurrent requests parameter for websocket rpc requests
+func (api *privateAdminAPI) SetWSMaxConcReq(wsMaxConcReq uint64) *MaxConcReq {
+	api.node.ws.wsConfig.maxConcReq = wsMaxConcReq
+
+	api.node.ws.wsHandler.Load().(*rpcHandler).server.SetMaxConcReq(wsMaxConcReq)
+
+	return api.GetMaxConcReq()
+}
+
 // RemovePeer disconnects from a remote node if the connection exists
 func (api *privateAdminAPI) RemovePeer(url string) (bool, error) {
 	// Make sure the server is running, fail otherwise

--- a/node/config.go
+++ b/node/config.go
@@ -139,6 +139,9 @@ type Config struct {
 	// HTTPPathPrefix specifies a path prefix on which http-rpc is to be served.
 	HTTPPathPrefix string `toml:",omitempty"`
 
+	// HTTPMaxConcurrentRequests is the maximum number of concurrent HTTP requests. 0 means no limit.
+	HTTPMaxConcurrentRequests uint64 `toml:",omitempty"`
+
 	// AuthAddr is the listening address on which authenticated APIs are provided.
 	AuthAddr string `toml:",omitempty"`
 
@@ -160,6 +163,9 @@ type Config struct {
 
 	// WSPathPrefix specifies a path prefix on which ws-rpc is to be served.
 	WSPathPrefix string `toml:",omitempty"`
+
+	// WSMaxConcurrentRequests is the maximum number of concurrent websocket requests. 0 means no limit.
+	WSMaxConcurrentRequests uint64 `toml:",omitempty"`
 
 	// WSOrigins is the list of domain to accept websocket requests from. Please be
 	// aware that the server can only act upon the HTTP request the client sends and

--- a/node/node.go
+++ b/node/node.go
@@ -105,7 +105,7 @@ func New(conf *Config) (*Node, error) {
 
 	node := &Node{
 		config:        conf,
-		inprocHandler: rpc.NewServer(),
+		inprocHandler: rpc.NewServer(0),
 		eventmux:      new(event.TypeMux),
 		log:           conf.Logger,
 		stop:          make(chan struct{}),
@@ -406,6 +406,7 @@ func (n *Node) startRPC() error {
 			Vhosts:             n.config.HTTPVirtualHosts,
 			Modules:            n.config.HTTPModules,
 			prefix:             n.config.HTTPPathPrefix,
+			maxConcReq:         n.config.HTTPMaxConcurrentRequests,
 		}); err != nil {
 			return err
 		}
@@ -419,9 +420,10 @@ func (n *Node) startRPC() error {
 			return err
 		}
 		if err := server.enableWS(n.rpcAPIs, wsConfig{
-			Modules: n.config.WSModules,
-			Origins: n.config.WSOrigins,
-			prefix:  n.config.WSPathPrefix,
+			Modules:    n.config.WSModules,
+			Origins:    n.config.WSOrigins,
+			prefix:     n.config.WSPathPrefix,
+			maxConcReq: n.config.WSMaxConcurrentRequests,
 		}); err != nil {
 			return err
 		}

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -42,14 +42,16 @@ type httpConfig struct {
 	Vhosts             []string
 	prefix             string // path prefix on which to mount http handler
 	jwtSecret          []byte // optional JWT secret
+	maxConcReq         uint64 // maximum number of concurrent requests
 }
 
 // wsConfig is the JSON-RPC/Websocket configuration
 type wsConfig struct {
-	Origins   []string
-	Modules   []string
-	prefix    string // path prefix on which to mount ws handler
-	jwtSecret []byte // optional JWT secret
+	Origins    []string
+	Modules    []string
+	prefix     string // path prefix on which to mount ws handler
+	jwtSecret  []byte // optional JWT secret
+	maxConcReq uint64 // maximum number of concurrent requests
 }
 
 type rpcHandler struct {
@@ -282,7 +284,7 @@ func (h *httpServer) enableRPC(apis []rpc.API, config httpConfig) error {
 	}
 
 	// Create RPC server and handler.
-	srv := rpc.NewServer()
+	srv := rpc.NewServer(config.maxConcReq)
 	if err := RegisterApis(apis, config.Modules, srv, false); err != nil {
 		return err
 	}
@@ -313,7 +315,7 @@ func (h *httpServer) enableWS(apis []rpc.API, config wsConfig) error {
 		return fmt.Errorf("JSON-RPC over WebSocket is already enabled")
 	}
 	// Create RPC server and handler.
-	srv := rpc.NewServer()
+	srv := rpc.NewServer(config.maxConcReq)
 	if err := RegisterApis(apis, config.Modules, srv, false); err != nil {
 		return err
 	}

--- a/packaging/templates/mainnet-v1/archive/config.toml
+++ b/packaging/templates/mainnet-v1/archive/config.toml
@@ -65,6 +65,7 @@ gcmode = "archive"
         vhosts = ["*"]
         corsdomain = ["*"]
         # prefix = ""
+        # maxconcreq = 0
     [jsonrpc.ws]
         enabled = true
         port = 8546
@@ -72,6 +73,7 @@ gcmode = "archive"
         # host = "localhost"
         # api = ["web3", "net"]
         origins = ["*"]
+        # maxconcreq = 0
     # [jsonrpc.graphql]
         # enabled = false
         # port = 0

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
@@ -65,6 +65,7 @@ syncmode = "full"
         vhosts = ["*"]
         corsdomain = ["*"]
         # prefix = ""
+        # maxconcreq = 0
     # [jsonrpc.ws]
         # enabled = false
         # port = 8546
@@ -72,6 +73,7 @@ syncmode = "full"
         # host = "localhost"
         # api = ["web3", "net"]
         # origins = ["*"]
+        # maxconcreq = 0
     # [jsonrpc.graphql]
         # enabled = false
         # port = 0

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
@@ -67,6 +67,7 @@ syncmode = "full"
         vhosts = ["*"]
         corsdomain = ["*"]
         # prefix = ""
+        # maxconcreq = 0
     # [jsonrpc.ws]
         # enabled = false
         # port = 8546
@@ -74,6 +75,7 @@ syncmode = "full"
         # host = "localhost"
         # api = ["web3", "net"]
         # origins = ["*"]
+        # maxconcreq = 0
     # [jsonrpc.graphql]
         # enabled = false
         # port = 0

--- a/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
@@ -67,6 +67,7 @@ syncmode = "full"
         vhosts = ["*"]
         corsdomain = ["*"]
         # prefix = ""
+        # maxconcreq = 0
     # [jsonrpc.ws]
         # enabled = false
         # port = 8546
@@ -74,6 +75,7 @@ syncmode = "full"
         # host = "localhost"
         # api = ["web3", "net"]
         # origins = ["*"]
+        # maxconcreq = 0
     # [jsonrpc.graphql]
         # enabled = false
         # port = 0

--- a/packaging/templates/testnet-v4/archive/config.toml
+++ b/packaging/templates/testnet-v4/archive/config.toml
@@ -65,6 +65,7 @@ gcmode = "archive"
         vhosts = ["*"]
         corsdomain = ["*"]
         # prefix = ""
+        # maxconcreq = 0
     [jsonrpc.ws]
         enabled = true
         port = 8546
@@ -72,6 +73,7 @@ gcmode = "archive"
         # host = "localhost"
         # api = ["web3", "net"]
         origins = ["*"]
+        # maxconcreq = 0
     # [jsonrpc.graphql]
         # enabled = false
         # port = 0

--- a/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
@@ -65,6 +65,7 @@ syncmode = "full"
         vhosts = ["*"]
         corsdomain = ["*"]
         # prefix = ""
+        # maxconcreq = 0
     # [jsonrpc.ws]
         # enabled = false
         # port = 8546
@@ -72,6 +73,7 @@ syncmode = "full"
         # host = "localhost"
         # api = ["web3", "net"]
         # origins = ["*"]
+        # maxconcreq = 0
     # [jsonrpc.graphql]
         # enabled = false
         # port = 0

--- a/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
@@ -67,6 +67,7 @@ syncmode = "full"
         vhosts = ["*"]
         corsdomain = ["*"]
         # prefix = ""
+        # maxconcreq = 0
     # [jsonrpc.ws]
         # enabled = false
         # port = 8546
@@ -74,6 +75,7 @@ syncmode = "full"
         # host = "localhost"
         # api = ["web3", "net"]
         # origins = ["*"]
+        # maxconcreq = 0
     # [jsonrpc.graphql]
         # enabled = false
         # port = 0

--- a/packaging/templates/testnet-v4/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/without-sentry/bor/config.toml
@@ -67,6 +67,7 @@ syncmode = "full"
         vhosts = ["*"]
         corsdomain = ["*"]
         # prefix = ""
+        # maxconcreq = 0
     # [jsonrpc.ws]
         # enabled = false
         # port = 8546
@@ -74,6 +75,7 @@ syncmode = "full"
         # host = "localhost"
         # api = ["web3", "net"]
         # origins = ["*"]
+        # maxconcreq = 0
     # [jsonrpc.graphql]
         # enabled = false
         # port = 0

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -407,7 +407,7 @@ func TestClientSubscriptionUnsubscribeServer(t *testing.T) {
 	t.Parallel()
 
 	// Create the server.
-	srv := NewServer()
+	srv := NewServer(0)
 	srv.RegisterName("nftest", new(notificationTestService))
 	p1, p2 := net.Pipe()
 	recorder := &unsubscribeRecorder{ServerCodec: NewCodec(p1)}
@@ -443,7 +443,7 @@ func TestClientSubscriptionChannelClose(t *testing.T) {
 	t.Parallel()
 
 	var (
-		srv     = NewServer()
+		srv     = NewServer(0)
 		httpsrv = httptest.NewServer(srv.WebsocketHandler(nil))
 		wsURL   = "ws:" + strings.TrimPrefix(httpsrv.URL, "http:")
 	)

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -27,7 +27,7 @@ import (
 func StartIPCEndpoint(ipcEndpoint string, apis []API) (net.Listener, *Server, error) {
 	// Register all the APIs exposed by the services.
 	var (
-		handler    = NewServer()
+		handler    = NewServer(0)
 		regMap     = make(map[string]struct{})
 		registered []string
 	)

--- a/rpc/http_test.go
+++ b/rpc/http_test.go
@@ -103,7 +103,7 @@ func TestHTTPResponseWithEmptyGet(t *testing.T) {
 func TestHTTPRespBodyUnlimited(t *testing.T) {
 	const respLength = maxRequestContentLength * 3
 
-	s := NewServer()
+	s := NewServer(0)
 	defer s.Stop()
 	s.RegisterName("test", largeRespService{respLength})
 	ts := httptest.NewServer(s)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -104,6 +104,7 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 	if s.maxConReq > 0 {
 		if s.reqCount > s.maxConReq { //if maxConReq is 0, then no limit
 			maxConcReqDiscardedTxs.Inc(1)
+			log.Warn("RPC server ratelimiting", "Concurrent Reqs", s.reqCount, "MaxConcurrentReqs", s.maxConReq)
 			// nolint: errcheck
 			codec.writeJSON(ctx, errorMessage(&invalidMessageError{"too many requests"}))
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -97,11 +97,8 @@ func (s *Server) ServeCodec(codec ServerCodec, options CodecOption) {
 // this mode.
 func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 
-	// TODO @0xsharma : remove debug logs.
-	log.Info("####", "serveSingleRequest : number", s.reqCount, "maxConReq", s.maxConReq)
 	if s.maxConReq > 0 {
 		if s.reqCount > s.maxConReq { //if maxConReq is 0, then no limit
-			log.Warn("####", "serveSingleRequest : too many", s.reqCount)
 			codec.writeJSON(ctx, errorMessage(&invalidMessageError{"too many requests"}))
 			return
 		} else {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -104,7 +104,9 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 	if s.maxConReq > 0 {
 		if s.reqCount > s.maxConReq { //if maxConReq is 0, then no limit
 			maxConcReqDiscardedTxs.Inc(1)
+			// nolint: errcheck
 			codec.writeJSON(ctx, errorMessage(&invalidMessageError{"too many requests"}))
+
 			return
 		} else {
 			atomic.AddInt64(&s.reqCount, 1)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -110,7 +110,9 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 	if s.maxConReq.Load() > 0 {
 		if s.reqCount.Load() > s.maxConReq.Load() { //if maxConReq is 0, then no limit
 			maxConcReqDiscardedTxs.Inc(1)
+
 			currentTime := time.Now()
+
 			if currentTime.Sub(s.lastRateLimitWarnTime) >= 10*time.Second {
 				s.lastRateLimitWarnTime = currentTime
 				log.Warn("RPC server ratelimiting", "Concurrent Reqs", s.reqCount.Load(), "MaxConcurrentReqs", s.maxConReq.Load())

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestServerRegisterName(t *testing.T) {
-	server := NewServer()
+	server := NewServer(0)
 	service := new(testService)
 
 	if err := server.RegisterName("test", service); err != nil {

--- a/rpc/subscription_test.go
+++ b/rpc/subscription_test.go
@@ -53,7 +53,7 @@ func TestSubscriptions(t *testing.T) {
 		subCount          = len(namespaces)
 		notificationCount = 3
 
-		server                 = NewServer()
+		server                 = NewServer(0)
 		clientConn, serverConn = net.Pipe()
 		out                    = json.NewEncoder(clientConn)
 		in                     = json.NewDecoder(clientConn)

--- a/rpc/testservice_test.go
+++ b/rpc/testservice_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newTestServer() *Server {
-	server := NewServer()
+	server := NewServer(0)
 	server.idgen = sequentialIDGenerator()
 	if err := server.RegisterName("test", new(testService)); err != nil {
 		panic(err)

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -203,7 +203,7 @@ func TestClientWebsocketPing(t *testing.T) {
 // This checks that the websocket transport can deal with large messages.
 func TestClientWebsocketLargeMessage(t *testing.T) {
 	var (
-		srv     = NewServer()
+		srv     = NewServer(0)
 		httpsrv = httptest.NewServer(srv.WebsocketHandler(nil))
 		wsURL   = "ws:" + strings.TrimPrefix(httpsrv.URL, "http:")
 	)


### PR DESCRIPTION
# Description

In this PR, we introduce to new flags `--http.maxconcreq` and `--ws.maxconcreq`. These flags can be used to ratelimit the number concurrent RPC requests on the client. `0` is the default value which `disables` the rate-limiting feature.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Nodes audience

This test is to facilitate the RPC providers to have more control on the RPC client in Bor.

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mainnet
- [ ] I have created new e2e tests into express-cli

