### PR TITLE
internal/cli: add `skiptrace` flag for profiling

### DIFF
--- a/docs/cli/debug_pprof.md
+++ b/docs/cli/debug_pprof.md
@@ -6,6 +6,8 @@ The ```debug pprof <enode>``` command will create an archive containing bor ppro
 
 - ```address```: Address of the grpc endpoint (default: 127.0.0.1:3131)
 
-- ```seconds```: seconds to trace (default: 2)
+- ```seconds```: seconds to profile (default: 2)
 
 - ```output```: Output directory
+
+- ```skiptrace```: Skip running the trace (default: false)


### PR DESCRIPTION
# Description

This PR adds a new flag called `skiptrace` in the `bor debug pprof` subcommand. In the 3 profiles which gets generated by default, the `trace` profile is expensive and consumes too much size (for grpc) as compared to the `cpu` and `heap` profiles. Even though we have increased the GRPC limit, the process can become fast if we can skip it using a flag itself. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
