### PR TITLE
Feat : SetMaxPeers

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -192,6 +192,15 @@ web3._extend({
 			name: 'stopWS',
 			call: 'admin_stopWS'
 		}),
+		new web3._extend.Method({
+			name: 'getMaxPeers',
+			call: 'admin_getMaxPeers'
+		}),
+		new web3._extend.Method({
+			name: 'setMaxPeers',
+			call: 'admin_setMaxPeers',
+			params: 1
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/node/api.go
+++ b/node/api.go
@@ -68,7 +68,9 @@ func (api *privateAdminAPI) SetMaxPeers(maxPeers int) (bool, error) {
 	if server == nil {
 		return false, ErrNodeStopped
 	}
+
 	server.SetMaxPeers(maxPeers)
+
 	return true, nil
 }
 
@@ -79,6 +81,7 @@ func (api *privateAdminAPI) GetMaxPeers() (int, error) {
 	if server == nil {
 		return 0, ErrNodeStopped
 	}
+
 	return server.MaxPeers, nil
 }
 

--- a/node/api.go
+++ b/node/api.go
@@ -61,6 +61,27 @@ type privateAdminAPI struct {
 	node *Node // Node interfaced by this API
 }
 
+// This function sets the param maxPeers for the node. If there are excess peers attached to the node, it will remove the difference.
+func (api *privateAdminAPI) SetMaxPeers(maxPeers int) (bool, error) {
+	// Make sure the server is running, fail otherwise
+	server := api.node.Server()
+	if server == nil {
+		return false, ErrNodeStopped
+	}
+	server.SetMaxPeers(maxPeers)
+	return true, nil
+}
+
+// This function gets the maxPeers param for the node.
+func (api *privateAdminAPI) GetMaxPeers() (int, error) {
+	// Make sure the server is running, fail otherwise
+	server := api.node.Server()
+	if server == nil {
+		return 0, ErrNodeStopped
+	}
+	return server.MaxPeers, nil
+}
+
 // AddPeer requests connecting to a remote node, and also maintaining the new
 // connection at all times, even reconnecting if it is lost.
 func (api *privateAdminAPI) AddPeer(url string) (bool, error) {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -307,6 +307,7 @@ func (srv *Server) Peers() []*Peer {
 	return ps
 }
 
+// This function retrieves the peers that are not trusted-peers
 func (srv *Server) getNonTrustedPeers() []*Peer {
 	allPeers := srv.Peers()
 
@@ -321,7 +322,7 @@ func (srv *Server) getNonTrustedPeers() []*Peer {
 	return nontrustedPeers
 }
 
-// Peers returns all connected peers.
+// SetMaxPeers sets the maximum number of peers that can be connected
 func (srv *Server) SetMaxPeers(maxPeers int) {
 	currentPeers := srv.getNonTrustedPeers()
 	if len(currentPeers) > maxPeers {
@@ -396,6 +397,7 @@ func (srv *Server) RemoveTrustedPeer(node *enode.Node) {
 	case srv.removetrusted <- node:
 	case <-srv.quit:
 	}
+	// Disconnect the peer if maxPeers is breached.
 	srv.SetMaxPeers(srv.MaxPeers)
 }
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -308,15 +308,12 @@ func (srv *Server) Peers() []*Peer {
 }
 
 func (srv *Server) getNonTrustedPeers() []*Peer {
-
 	allPeers := srv.Peers()
 
 	nontrustedPeers := []*Peer{}
 
 	for _, peer := range allPeers {
-
 		if !peer.Info().Network.Trusted {
-
 			nontrustedPeers = append(nontrustedPeers, peer)
 		}
 	}
@@ -334,6 +331,7 @@ func (srv *Server) SetMaxPeers(maxPeers int) {
 			srv.RemovePeer(peer.Node())
 		}
 	}
+
 	srv.MaxPeers = maxPeers
 }
 


### PR DESCRIPTION
# Description

In this PR, we are adding two new RPC methods to setMaxPeers and getMaxPeers of a node respectively.
With this change, maxPeers can be adjusted in runtime. This can be used to perform several chaotic tests.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli
