### PR TITLE
internal/ethapi :: Fix : newRPCTransactionFromBlockIndex

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1448,6 +1448,7 @@ func newRPCPendingTransaction(tx *types.Transaction, current *types.Header, conf
 // newRPCTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.
 func newRPCTransactionFromBlockIndex(b *types.Block, index uint64, config *params.ChainConfig, db ethdb.Database) *RPCTransaction {
 	txs := b.Transactions()
+
 	var txHash common.Hash
 
 	borReceipt := rawdb.ReadBorReceipt(db, b.Hash(), b.NumberU64())

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1449,13 +1449,10 @@ func newRPCPendingTransaction(tx *types.Transaction, current *types.Header, conf
 func newRPCTransactionFromBlockIndex(b *types.Block, index uint64, config *params.ChainConfig, db ethdb.Database) *RPCTransaction {
 	txs := b.Transactions()
 
-	var txHash common.Hash
-
 	borReceipt := rawdb.ReadBorReceipt(db, b.Hash(), b.NumberU64())
 	if borReceipt != nil {
-		txHash = types.GetDerivedBorTxHash(types.BorReceiptKey(b.Number().Uint64(), b.Hash()))
-		if txHash != (common.Hash{}) {
-			borTx, _, _, _ := rawdb.ReadBorTransactionWithBlockHash(db, txHash, b.Hash())
+		if borReceipt.TxHash != (common.Hash{}) {
+			borTx, _, _, _ := rawdb.ReadBorTransactionWithBlockHash(db, borReceipt.TxHash, b.Hash())
 			txs = append(txs, borTx)
 		}
 	}
@@ -1468,7 +1465,7 @@ func newRPCTransactionFromBlockIndex(b *types.Block, index uint64, config *param
 
 	// If the transaction is a bor transaction, we need to set the hash to the derived bor tx hash. BorTx is always the last index.
 	if borReceipt != nil && int(index) == len(txs)-1 {
-		rpcTx.Hash = txHash
+		rpcTx.Hash = borReceipt.TxHash
 	}
 
 	return rpcTx


### PR DESCRIPTION
# Description

The output of newRPCTransactionFromBlockIndex was incorrect and hence many of the dependant RPC calls were giving wrong results. It has been fixed in this PR. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mainnet
- [ ] I have created new e2e tests into express-cli

