### PR TITLE
Check if block is nil to prevent panic

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -628,6 +628,10 @@ func (s *PublicBlockChainAPI) GetTransactionReceiptsByBlock(ctx context.Context,
 		return nil, err
 	}
 
+	if block == nil {
+		return nil, errors.New("block not found")
+	}
+
 	receipts, err := s.b.GetReceipts(ctx, block.Hash())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Block from `BlockByNumberOrHash` function can be nil, so we need to check.

Code is the same as here: https://github.com/maticnetwork/bor/blob/c46aae23daf0a1a172e08f97dcf2d7159e33eae5/internal/ethapi/api.go

# Changes
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have tested this code on production mainnet node

# Additional comments

Issue: https://github.com/maticnetwork/bor/issues/725
