### PR TITLE
Added support for miner.recommit flag

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -58,6 +58,7 @@ syncmode = "full"
   # mine = true
   # etherbase = "VALIDATOR ADDRESS"
   # extradata = ""
+  # recommit = "2m5s"
 
 
 # [jsonrpc]

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -58,6 +58,7 @@ ethstats = ""                # Reporting URL of a ethstats service (nodename:sec
   extradata = ""           # Block extra data set by the miner (default = client version)
   gaslimit = 30000000      # Target gas ceiling for mined blocks
   gasprice = "1000000000"  # Minimum gas price for mining a transaction (recommended for mainnet = 30000000000, default suitable for mumbai/devnet)
+  recommit = "2m5s"        # The time interval for miner to re-create mining work
 
 [jsonrpc]
   ipcdisable = false                               # Disable the IPC-RPC server

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -164,6 +164,8 @@ The ```bor server``` command runs the Bor client.
 
 - ```miner.gasprice```: Minimum gas price for mining a transaction (default: 1000000000)
 
+- ```miner.recommit```: The time interval for miner to re-create mining work (default: 2m5s)
+
 ### Telemetry Options
 
 - ```metrics```: Enable metrics collection and reporting (default: false)

--- a/internal/cli/dumpconfig.go
+++ b/internal/cli/dumpconfig.go
@@ -58,6 +58,7 @@ func (c *DumpconfigCommand) Run(args []string) int {
 	userConfig.TxPool.RejournalRaw = userConfig.TxPool.Rejournal.String()
 	userConfig.TxPool.LifeTimeRaw = userConfig.TxPool.LifeTime.String()
 	userConfig.Sealer.GasPriceRaw = userConfig.Sealer.GasPrice.String()
+	userConfig.Sealer.RecommitRaw = userConfig.Sealer.Recommit.String()
 	userConfig.Gpo.MaxPriceRaw = userConfig.Gpo.MaxPrice.String()
 	userConfig.Gpo.IgnorePriceRaw = userConfig.Gpo.IgnorePrice.String()
 	userConfig.Cache.RejournalRaw = userConfig.Cache.Rejournal.String()

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -232,6 +232,10 @@ type SealerConfig struct {
 	// GasPrice is the minimum gas price for mining a transaction
 	GasPrice    *big.Int `hcl:"-,optional" toml:"-"`
 	GasPriceRaw string   `hcl:"gasprice,optional" toml:"gasprice,optional"`
+
+	// The time interval for miner to re-create mining work.
+	Recommit    time.Duration `hcl:"-,optional" toml:"-"`
+	RecommitRaw string        `hcl:"recommit,optional" toml:"recommit,optional"`
 }
 
 type JsonRPCConfig struct {
@@ -500,6 +504,7 @@ func DefaultConfig() *Config {
 			GasCeil:   30_000_000,                  // geth's default
 			GasPrice:  big.NewInt(1 * params.GWei), // geth's default
 			ExtraData: "",
+			Recommit:  125 * time.Second,
 		},
 		Gpo: &GpoConfig{
 			Blocks:      20,
@@ -632,6 +637,7 @@ func (c *Config) fillTimeDurations() error {
 		td   *time.Duration
 		str  *string
 	}{
+		{"miner.recommit", &c.Sealer.Recommit, &c.Sealer.RecommitRaw},
 		{"jsonrpc.timeouts.read", &c.JsonRPC.HttpTimeout.ReadTimeout, &c.JsonRPC.HttpTimeout.ReadTimeoutRaw},
 		{"jsonrpc.timeouts.write", &c.JsonRPC.HttpTimeout.WriteTimeout, &c.JsonRPC.HttpTimeout.WriteTimeoutRaw},
 		{"jsonrpc.timeouts.idle", &c.JsonRPC.HttpTimeout.IdleTimeout, &c.JsonRPC.HttpTimeout.IdleTimeoutRaw},
@@ -748,6 +754,7 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 
 	// miner options
 	{
+		n.Miner.Recommit = c.Sealer.Recommit
 		n.Miner.GasPrice = c.Sealer.GasPrice
 		n.Miner.GasCeil = c.Sealer.GasCeil
 		n.Miner.ExtraData = []byte(c.Sealer.ExtraData)

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -241,6 +241,13 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "Sealer",
 		Default: c.cliConfig.Sealer.GasPrice,
 	})
+	f.DurationFlag(&flagset.DurationFlag{
+		Name:    "miner.recommit",
+		Usage:   "The time interval for miner to re-create mining work",
+		Value:   &c.cliConfig.Sealer.Recommit,
+		Default: c.cliConfig.Sealer.Recommit,
+		Group:   "Sealer",
+	})
 
 	// ethstats
 	f.StringFlag(&flagset.StringFlag{

--- a/packaging/templates/mainnet-v1/archive/config.toml
+++ b/packaging/templates/mainnet-v1/archive/config.toml
@@ -51,6 +51,7 @@ gcmode = "archive"
     # mine = false
     # etherbase = ""
     # extradata = ""
+    # recommit = "2m5s"
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
@@ -51,6 +51,7 @@ syncmode = "full"
     # mine = false
     # etherbase = ""
     # extradata = ""
+    # recommit = "2m5s"
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
@@ -53,6 +53,7 @@ syncmode = "full"
     gasprice = "30000000000"
     # etherbase = ""
     # extradata = ""
+    # recommit = "2m5s"
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
@@ -53,6 +53,7 @@ syncmode = "full"
     gasprice = "30000000000"
     # etherbase = ""
     # extradata = ""
+    # recommit = "2m5s"
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/testnet-v4/archive/config.toml
+++ b/packaging/templates/testnet-v4/archive/config.toml
@@ -51,6 +51,7 @@ gcmode = "archive"
     # mine = false
     # etherbase = ""
     # extradata = ""
+    # recommit = "2m5s"
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
@@ -51,6 +51,7 @@ syncmode = "full"
     # mine = false
     # etherbase = ""
     # extradata = ""
+    # recommit = "2m5s"
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
@@ -53,6 +53,7 @@ syncmode = "full"
     # gasprice = "1000000000"
     # etherbase = ""
     # extradata = ""
+    # recommit = "2m5s"
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/testnet-v4/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/without-sentry/bor/config.toml
@@ -53,6 +53,7 @@ syncmode = "full"
     # gasprice = "1000000000"
     # etherbase = ""
     # extradata = ""
+    # recommit = "2m5s"
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"


### PR DESCRIPTION
We will take this up when working on all the PRs with `MEV` labels.

Linking these two points ([first](https://github.com/maticnetwork/bor/commit/fcb722e4bf5bdda23d4c91da40ab95c9023a80c3#commitcomment-100665900), and [second](https://github.com/maticnetwork/bor/commit/fcb722e4bf5bdda23d4c91da40ab95c9023a80c3#commitcomment-100675141)) mentioned by @thogard785 in this [commit](https://github.com/maticnetwork/bor/commit/fcb722e4bf5bdda23d4c91da40ab95c9023a80c3).