### PR TITLE
core: add : impossible reorg block dump

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -18,6 +18,7 @@
 package core
 
 import (
+	"compress/gzip"
 	"errors"
 	"fmt"
 	"io"
@@ -25,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -2207,19 +2209,19 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 			}
 		}
 
-		err = os.WriteFile(filepath.Join(outPath, "oldchain.txt"), []byte(fmt.Sprintf("%+v", oldChain)), 0600)
+		err = ExportBlocks(oldChain, filepath.Join(outPath, "oldChain.gz"))
 		if err != nil {
-			log.Error("Impossible reorg : Unable to write to oldchain.txt", "Error", err)
+			log.Error("Impossible reorg : Unable to export oldChain", "Error", err)
 		}
 
-		err = os.WriteFile(filepath.Join(outPath, "oldBlock.txt"), []byte(fmt.Sprintf("%+v", oldBlock)), 0600)
+		err = ExportBlocks([]*types.Block{oldBlock}, filepath.Join(outPath, "oldBlock.gz"))
 		if err != nil {
-			log.Error("Impossible reorg : Unable to write to oldblock.txt", "Error", err)
+			log.Error("Impossible reorg : Unable to export oldBlock", "Error", err)
 		}
 
-		err = os.WriteFile(filepath.Join(outPath, "newBlock.txt"), []byte(fmt.Sprintf("%+v", newBlock)), 0600)
+		err = ExportBlocks([]*types.Block{newBlock}, filepath.Join(outPath, "newBlock.gz"))
 		if err != nil {
-			log.Error("Impossible reorg : Unable to write to newBlock.txt", "Error", err)
+			log.Error("Impossible reorg : Unable to export newBlock", "Error", err)
 		}
 
 		log.Error("Impossible reorg, please file an issue", "oldnum", oldBlock.Number(), "oldhash", oldBlock.Hash(), "oldblocks", len(oldChain), "newnum", newBlock.Number(), "newhash", newBlock.Hash(), "newblocks", len(newChain))
@@ -2271,6 +2273,44 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 			bc.chainSideFeed.Send(ChainSideEvent{Block: oldChain[i]})
 		}
 	}
+	return nil
+}
+
+// ExportBlocks exports blocks into the specified file, truncating any data
+// already present in the file.
+func ExportBlocks(blocks []*types.Block, fn string) error {
+	log.Info("Exporting blockchain", "file", fn)
+
+	// Open the file handle and potentially wrap with a gzip stream
+	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	var writer io.Writer = fh
+	if strings.HasSuffix(fn, ".gz") {
+		writer = gzip.NewWriter(writer)
+		defer writer.(*gzip.Writer).Close()
+	}
+	// Iterate over the blocks and export them
+	if err := ExportN(writer, blocks); err != nil {
+		return err
+	}
+
+	log.Info("Exported blocks", "file", fn)
+
+	return nil
+}
+
+// ExportBlock writes a block to the given writer.
+func ExportN(w io.Writer, blocks []*types.Block) error {
+	for _, block := range blocks {
+		if err := block.EncodeRLP(w); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -2191,6 +2193,20 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	} else {
 		// len(newChain) == 0 && len(oldChain) > 0
 		// rewind the canonical chain to a lower point.
+		out := fmt.Sprintf("oldChain: %+v,\n\noldBlock : %+v,\n\nnewBlock : %+v", oldChain, oldBlock, newBlock)
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			log.Error("Impossible reorg : Unable to get user home dir", "Error", err)
+		}
+
+		outPath := filepath.Join(home, fmt.Sprintf("impossibleReorg-%v.txt", time.Now().Format(time.RFC3339)))
+
+		err = os.WriteFile(outPath, []byte(out), 0600)
+		if err != nil {
+			log.Error("Impossible reorg : Unable to write to file", "Error", err)
+		}
+
 		log.Error("Impossible reorg, please file an issue", "oldnum", oldBlock.Number(), "oldhash", oldBlock.Hash(), "oldblocks", len(oldChain), "newnum", newBlock.Number(), "newhash", newBlock.Hash(), "newblocks", len(newChain))
 	}
 	// Insert the new chain(except the head block(reverse order)),

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2207,21 +2207,21 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 			if err != nil {
 				log.Error("Impossible reorg : Unable to create Dir", "Error", err)
 			}
-		}
+		} else {
+			err = ExportBlocks(oldChain, filepath.Join(outPath, "oldChain.gz"))
+			if err != nil {
+				log.Error("Impossible reorg : Unable to export oldChain", "Error", err)
+			}
 
-		err = ExportBlocks(oldChain, filepath.Join(outPath, "oldChain.gz"))
-		if err != nil {
-			log.Error("Impossible reorg : Unable to export oldChain", "Error", err)
-		}
+			err = ExportBlocks([]*types.Block{oldBlock}, filepath.Join(outPath, "oldBlock.gz"))
+			if err != nil {
+				log.Error("Impossible reorg : Unable to export oldBlock", "Error", err)
+			}
 
-		err = ExportBlocks([]*types.Block{oldBlock}, filepath.Join(outPath, "oldBlock.gz"))
-		if err != nil {
-			log.Error("Impossible reorg : Unable to export oldBlock", "Error", err)
-		}
-
-		err = ExportBlocks([]*types.Block{newBlock}, filepath.Join(outPath, "newBlock.gz"))
-		if err != nil {
-			log.Error("Impossible reorg : Unable to export newBlock", "Error", err)
+			err = ExportBlocks([]*types.Block{newBlock}, filepath.Join(outPath, "newBlock.gz"))
+			if err != nil {
+				log.Error("Impossible reorg : Unable to export newBlock", "Error", err)
+			}
 		}
 
 		log.Error("Impossible reorg, please file an issue", "oldnum", oldBlock.Number(), "oldhash", oldBlock.Hash(), "oldblocks", len(oldChain), "newnum", newBlock.Number(), "newhash", newBlock.Hash(), "newblocks", len(newChain))


### PR DESCRIPTION
# Description

In this PR, we add the functionality to dump the blocks data in `~/impossibleReorg-<TIME>.txt`. This will allow better observability to resolve impossible reorg issues in the future. 