### PR TITLE
core: use internal context for sending traces

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1388,7 +1388,7 @@ func (bc *BlockChain) writeBlockAndSetHead(ctx context.Context, block *types.Blo
 
 	var reorg bool
 
-	tracing.Exec(ctx, "blockchain.ReorgNeeded", func(_ context.Context, span trace.Span) {
+	tracing.Exec(writeBlockAndSetHeadCtx, "blockchain.ReorgNeeded", func(_ context.Context, span trace.Span) {
 		reorg, err = bc.forker.ReorgNeeded(currentBlock.Header(), block.Header())
 		tracing.SetAttributes(
 			span,
@@ -1402,7 +1402,7 @@ func (bc *BlockChain) writeBlockAndSetHead(ctx context.Context, block *types.Blo
 		return NonStatTy, err
 	}
 
-	tracing.Exec(ctx, "blockchain.reorg", func(_ context.Context, span trace.Span) {
+	tracing.Exec(writeBlockAndSetHeadCtx, "blockchain.reorg", func(_ context.Context, span trace.Span) {
 		if reorg {
 			// Reorganise the chain if the parent is not the head block
 			if block.ParentHash() != currentBlock.Hash() {
@@ -1431,7 +1431,7 @@ func (bc *BlockChain) writeBlockAndSetHead(ctx context.Context, block *types.Blo
 
 	// Set new head.
 	if status == CanonStatTy {
-		tracing.Exec(ctx, "blockchain.writeHeadBlock", func(_ context.Context, _ trace.Span) {
+		tracing.Exec(writeBlockAndSetHeadCtx, "blockchain.writeHeadBlock", func(_ context.Context, _ trace.Span) {
 			bc.writeHeadBlock(block)
 		})
 	}


### PR DESCRIPTION
# Description

This PR is a fix on top of https://github.com/maticnetwork/bor/pull/753 where a common trace context was used instead of internal made context. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
