### PR TITLE
Verify validator set against local contract on receiving an end-of-sprint block

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -464,8 +464,15 @@ func (c *Bor) verifyCascadingFields(chain consensus.ChainHeaderReader, header *t
 
 	// Verify the validator list match the local contract
 	if IsSprintStart(number+1, c.config.CalculateSprint(number)) {
-		parentHeader := chain.GetHeaderByNumber(number - 1)
-		newValidators, err := c.spanner.GetCurrentValidators(context.Background(), parentHeader.Hash(), number+1)
+		parentBlockNumber := number - 1
+
+		var newValidators []*valset.Validator
+
+		var err error
+
+		for newValidators, err = c.spanner.GetCurrentValidators(context.Background(), chain.GetHeaderByNumber(parentBlockNumber).Hash(), number+1); err != nil && parentBlockNumber > 0; {
+			parentBlockNumber--
+		}
 
 		if err != nil {
 			return errUnknownValidators

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -473,7 +473,11 @@ func (c *Bor) verifyCascadingFields(chain consensus.ChainHeaderReader, header *t
 
 		sort.Sort(valset.ValidatorsByAddress(newValidators))
 
-		headerVals, _ := valset.ParseValidators(header.Extra[extraVanity : len(header.Extra)-extraSeal])
+		headerVals, err := valset.ParseValidators(header.Extra[extraVanity : len(header.Extra)-extraSeal])
+
+		if err != nil {
+			return err
+		}
 
 		sort.Sort(valset.ValidatorsByAddress(headerVals))
 

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -298,6 +298,14 @@ func (c *Bor) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Head
 	return c.verifyHeader(chain, header, nil)
 }
 
+func (c *Bor) GetSpanner() Spanner {
+	return c.spanner
+}
+
+func (c *Bor) SetSpanner(spanner Spanner) {
+	c.spanner = spanner
+}
+
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers. The
 // method returns a quit channel to abort the operations and a results channel to
 // retrieve the async verifications (the order is that of the input slice).
@@ -456,7 +464,9 @@ func (c *Bor) verifyCascadingFields(chain consensus.ChainHeaderReader, header *t
 
 	// Verify the validator list match the local contract
 	if IsSprintStart(number+1, c.config.CalculateSprint(number)) {
-		newValidators, err := c.spanner.GetCurrentValidators(context.Background(), header.ParentHash, number+1)
+		parentHeader := chain.GetHeaderByNumber(number - 1)
+		newValidators, err := c.spanner.GetCurrentValidators(context.Background(), parentHeader.Hash(), number+1)
+
 		if err != nil {
 			return errUnknownValidators
 		}

--- a/consensus/bor/heimdall/span/spanner.go
+++ b/consensus/bor/heimdall/span/spanner.go
@@ -116,7 +116,7 @@ func (c *ChainSpanner) GetCurrentValidators(ctx context.Context, headerHash comm
 		Data: &msgData,
 	}, blockNr, nil)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	var (

--- a/tests/bor/bor_test.go
+++ b/tests/bor/bor_test.go
@@ -392,11 +392,17 @@ func TestInsertingSpanSizeBlocks(t *testing.T) {
 
 	currentValidators := []*valset.Validator{valset.NewValidator(addr, 10)}
 
+	spanner := getMockedSpanner(t, currentValidators)
+	_bor.SetSpanner(spanner)
+
 	// Insert sprintSize # of blocks so that span is fetched at the start of a new sprint
 	for i := uint64(1); i <= spanSize; i++ {
 		block = buildNextBlock(t, _bor, chain, block, nil, init.genesis.Config.Bor, nil, currentValidators)
 		insertNewBlock(t, chain, block)
 	}
+
+	spanner = getMockedSpanner(t, currentSpan.ValidatorSet.Validators)
+	_bor.SetSpanner(spanner)
 
 	validators, err := _bor.GetCurrentValidators(context.Background(), block.Hash(), spanSize) // check validator set at the first block of new span
 	if err != nil {
@@ -426,6 +432,9 @@ func TestFetchStateSyncEvents(t *testing.T) {
 	res, _ := loadSpanFromFile(t)
 
 	currentValidators := []*valset.Validator{valset.NewValidator(addr, 10)}
+
+	spanner := getMockedSpanner(t, currentValidators)
+	_bor.SetSpanner(spanner)
 
 	// Insert sprintSize # of blocks so that span is fetched at the start of a new sprint
 	for i := uint64(1); i < sprintSize; i++ {
@@ -528,6 +537,9 @@ func TestFetchStateSyncEvents_2(t *testing.T) {
 			currentValidators = []*valset.Validator{valset.NewValidator(addr, 10)}
 		}
 
+		spanner := getMockedSpanner(t, currentValidators)
+		_bor.SetSpanner(spanner)
+
 		block = buildNextBlock(t, _bor, chain, block, nil, init.genesis.Config.Bor, nil, currentValidators)
 		insertNewBlock(t, chain, block)
 	}
@@ -553,6 +565,9 @@ func TestFetchStateSyncEvents_2(t *testing.T) {
 		} else {
 			currentValidators = []*valset.Validator{valset.NewValidator(addr, 10)}
 		}
+
+		spanner := getMockedSpanner(t, currentValidators)
+		_bor.SetSpanner(spanner)
 
 		block = buildNextBlock(t, _bor, chain, block, nil, init.genesis.Config.Bor, nil, res.Result.ValidatorSet.Validators)
 		insertNewBlock(t, chain, block)
@@ -580,6 +595,8 @@ func TestOutOfTurnSigning(t *testing.T) {
 
 	h.EXPECT().Close().AnyTimes()
 
+	spanner := getMockedSpanner(t, heimdallSpan.ValidatorSet.Validators)
+	_bor.SetSpanner(spanner)
 	_bor.SetHeimdallClient(h)
 
 	db := init.ethereum.ChainDb()
@@ -1081,6 +1098,9 @@ func TestJaipurFork(t *testing.T) {
 	block := init.genesis.ToBlock(db)
 
 	res, _ := loadSpanFromFile(t)
+
+	spanner := getMockedSpanner(t, res.Result.ValidatorSet.Validators)
+	_bor.SetSpanner(spanner)
 
 	for i := uint64(1); i < sprintSize; i++ {
 		block = buildNextBlock(t, _bor, chain, block, nil, init.genesis.Config.Bor, nil, res.Result.ValidatorSet.Validators)

--- a/tests/bor/helper.go
+++ b/tests/bor/helper.go
@@ -352,6 +352,16 @@ func getMockedHeimdallClient(t *testing.T, heimdallSpan *span.HeimdallSpan) (*mo
 	return h, ctrl
 }
 
+func getMockedSpanner(t *testing.T, validators []*valset.Validator) *bor.MockSpanner {
+	t.Helper()
+
+	spanner := bor.NewMockSpanner(gomock.NewController(t))
+	spanner.EXPECT().GetCurrentValidators(gomock.Any(), gomock.Any(), gomock.Any()).Return(validators, nil).AnyTimes()
+	spanner.EXPECT().GetCurrentSpan(gomock.Any(), gomock.Any()).Return(&span.Span{0, 0, 0}, nil).AnyTimes()
+	spanner.EXPECT().CommitSpan(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	return spanner
+}
+
 func generateFakeStateSyncEvents(sample *clerk.EventRecordWithTime, count int) []*clerk.EventRecordWithTime {
 	events := make([]*clerk.EventRecordWithTime, count)
 	event := *sample


### PR DESCRIPTION
# Description

Verify validator set against local contract on receiving an end-of-sprint block. Tested locally in a devnet.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
