### PR TITLE
internal/cli/server, rpc: lower down http readtimeout to 10s

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -94,7 +94,7 @@ syncmode = "full"
 #     vhosts = ["*"]
 #     corsdomain = ["*"]
 #   [jsonrpc.timeouts]
-#     read = "30s"
+#     read = "10s"
 #     write = "30s"
 #     idle = "2m0s"
 

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -93,7 +93,7 @@ ethstats = ""                # Reporting URL of a ethstats service (nodename:sec
     vhosts = ["localhost"]      # Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard.
     corsdomain = ["localhost"]  # Comma separated list of domains from which to accept cross origin requests (browser enforced)
   [jsonrpc.timeouts]
-    read = "30s"
+    read = "10s"
     write = "30s"
     idle = "2m0s"
 

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -540,7 +540,7 @@ func DefaultConfig() *Config {
 				VHost:   []string{"localhost"},
 			},
 			HttpTimeout: &HttpTimeouts{
-				ReadTimeout:  30 * time.Second,
+				ReadTimeout:  10 * time.Second,
 				WriteTimeout: 30 * time.Second,
 				IdleTimeout:  120 * time.Second,
 			},

--- a/packaging/templates/mainnet-v1/archive/config.toml
+++ b/packaging/templates/mainnet-v1/archive/config.toml
@@ -86,7 +86,7 @@ gcmode = "archive"
         # vhosts = ["*"]
         # corsdomain = ["*"]
     # [jsonrpc.timeouts]
-        # read = "30s"
+        # read = "10s"
         # write = "30s"
         # idle = "2m0s"
 

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
@@ -86,7 +86,7 @@ syncmode = "full"
         # vhosts = ["*"]
         # corsdomain = ["*"]
     # [jsonrpc.timeouts]
-        # read = "30s"
+        # read = "10s"
         # write = "30s"
         # idle = "2m0s"
 

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
@@ -88,7 +88,7 @@ syncmode = "full"
         # vhosts = ["*"]
         # corsdomain = ["*"]
     # [jsonrpc.timeouts]
-        # read = "30s"
+        # read = "10s"
         # write = "30s"
         # idle = "2m0s"
 

--- a/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
@@ -88,7 +88,7 @@ syncmode = "full"
         # vhosts = ["*"]
         # corsdomain = ["*"]
     # [jsonrpc.timeouts]
-        # read = "30s"
+        # read = "10s"
         # write = "30s"
         # idle = "2m0s"
 

--- a/packaging/templates/testnet-v4/archive/config.toml
+++ b/packaging/templates/testnet-v4/archive/config.toml
@@ -86,7 +86,7 @@ gcmode = "archive"
         # vhosts = ["*"]
         # corsdomain = ["*"]
     # [jsonrpc.timeouts]
-        # read = "30s"
+        # read = "10s"
         # write = "30s"
         # idle = "2m0s"
 

--- a/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
@@ -86,7 +86,7 @@ syncmode = "full"
         # vhosts = ["*"]
         # corsdomain = ["*"]
     # [jsonrpc.timeouts]
-        # read = "30s"
+        # read = "10s"
         # write = "30s"
         # idle = "2m0s"
 

--- a/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
@@ -88,7 +88,7 @@ syncmode = "full"
         # vhosts = ["*"]
         # corsdomain = ["*"]
     # [jsonrpc.timeouts]
-        # read = "30s"
+        # read = "10s"
         # write = "30s"
         # idle = "2m0s"
 

--- a/packaging/templates/testnet-v4/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/without-sentry/bor/config.toml
@@ -88,7 +88,7 @@ syncmode = "full"
         # vhosts = ["*"]
         # corsdomain = ["*"]
     # [jsonrpc.timeouts]
-        # read = "30s"
+        # read = "10s"
         # write = "30s"
         # idle = "2m0s"
 

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -104,7 +104,7 @@ type HTTPTimeouts struct {
 // DefaultHTTPTimeouts represents the default timeout values used if further
 // configuration is not provided.
 var DefaultHTTPTimeouts = HTTPTimeouts{
-	ReadTimeout:  30 * time.Second,
+	ReadTimeout:  10 * time.Second,
 	WriteTimeout: 30 * time.Second,
 	IdleTimeout:  120 * time.Second,
 }


### PR DESCRIPTION
# Description

Bring down default read time out to 10 sec from 30 sec

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

