### PR TITLE
core/txpool: implement additional DoS defenses from geth

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"container/heap"
 	"errors"
 	"fmt"
 	"math"
@@ -86,6 +87,14 @@ var (
 	// than some meaningful limit a user might use. This is not a consensus error
 	// making the transaction invalid, rather a DOS protection.
 	ErrOversizedData = errors.New("oversized data")
+
+	// ErrFutureReplacePending is returned if a future transaction replaces a pending
+	// transaction. Future transactions should only be able to replace other future transactions.
+	ErrFutureReplacePending = errors.New("future transaction tries to replace pending")
+
+	// ErrOverdraft is returned if a transaction would cause the senders balance to go negative
+	// thus invalidating a potential large number of transactions.
+	ErrOverdraft = errors.New("transaction would cause overdraft")
 )
 
 var (
@@ -645,8 +654,23 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	// Transactor should have enough funds to cover the costs
 	// cost == V + GP * GL
-	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
+	balance := pool.currentState.GetBalance(from)
+	if balance.Cmp(tx.Cost()) < 0 {
 		return ErrInsufficientFunds
+	}
+	// Verify that replacing transactions will not result in overdraft
+	list := pool.pending[from]
+	if list != nil { // Sender already has pending txs
+		sum := new(big.Int).Add(tx.Cost(), list.totalcost)
+		if repl := list.txs.Get(tx.Nonce()); repl != nil {
+			// Deduct the cost of a transaction replaced by this
+			sum.Sub(sum, repl.Cost())
+		}
+
+		if balance.Cmp(sum) < 0 {
+			log.Trace("Replacing transactions would overdraft", "sender", from, "balance", pool.currentState.GetBalance(from), "required", sum)
+			return ErrOverdraft
+		}
 	}
 	// Ensure the transaction has more gas than the basic tx fee.
 	intrGas, err := IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, pool.istanbul)
@@ -684,6 +708,10 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 		invalidTxMeter.Mark(1)
 		return false, err
 	}
+
+	// already validated by this point
+	from, _ := types.Sender(pool.signer, tx)
+
 	// If the transaction pool is full, discard underpriced transactions
 	if uint64(pool.all.Slots()+numSlots(tx)) > pool.config.GlobalSlots+pool.config.GlobalQueue {
 		// If the new transaction is underpriced, don't accept it
@@ -692,6 +720,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 			underpricedTxMeter.Mark(1)
 			return false, ErrUnderpriced
 		}
+
 		// We're about to replace a transaction. The reorg does a more thorough
 		// analysis of what to remove and how, but it runs async. We don't want to
 		// do too many replacements between reorg-runs, so we cap the number of
@@ -712,17 +741,39 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 			overflowedTxMeter.Mark(1)
 			return false, ErrTxPoolOverflow
 		}
-		// Bump the counter of rejections-since-reorg
-		pool.changesSinceReorg += len(drop)
+		// If the new transaction is a future transaction it should never churn pending transactions
+		if pool.isFuture(from, tx) {
+			var replacesPending bool
+
+			for _, dropTx := range drop {
+				dropSender, _ := types.Sender(pool.signer, dropTx)
+				if list := pool.pending[dropSender]; list != nil && list.Overlaps(dropTx) {
+					replacesPending = true
+					break
+				}
+			}
+			// Add all transactions back to the priced queue
+			if replacesPending {
+				for _, dropTx := range drop {
+					heap.Push(&pool.priced.urgent, dropTx)
+				}
+
+				log.Trace("Discarding future transaction replacing pending tx", "hash", hash)
+
+				return false, ErrFutureReplacePending
+			}
+		}
 		// Kick out the underpriced remote transactions.
 		for _, tx := range drop {
 			log.Trace("Discarding freshly underpriced transaction", "hash", tx.Hash(), "gasTipCap", tx.GasTipCap(), "gasFeeCap", tx.GasFeeCap())
 			underpricedTxMeter.Mark(1)
-			pool.removeTx(tx.Hash(), false)
+
+			dropped := pool.removeTx(tx.Hash(), false)
+			pool.changesSinceReorg += dropped
 		}
 	}
+
 	// Try to replace an existing transaction in the pending pool
-	from, _ := types.Sender(pool.signer, tx) // already validated
 	if list := pool.pending[from]; list != nil && list.Overlaps(tx) {
 		// Nonce already pending, check if required price bump is met
 		inserted, old := list.Add(tx, pool.config.PriceBump)
@@ -764,6 +815,20 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 
 	log.Trace("Pooled new future transaction", "hash", hash, "from", from, "to", tx.To())
 	return replaced, nil
+}
+
+// isFuture reports whether the given transaction is immediately executable.
+func (pool *TxPool) isFuture(from common.Address, tx *types.Transaction) bool {
+	list := pool.pending[from]
+	if list == nil {
+		return pool.pendingNonces.get(from) != tx.Nonce()
+	}
+	// Sender has pending transactions.
+	if old := list.txs.Get(tx.Nonce()); old != nil {
+		return false // It replaces a pending transaction.
+	}
+	// Not replacing, check if parent nonce exists in pending.
+	return list.txs.Get(tx.Nonce()-1) == nil
 }
 
 // enqueueTx inserts a new transaction into the non-executable transaction queue.
@@ -1013,11 +1078,12 @@ func (pool *TxPool) Has(hash common.Hash) bool {
 
 // removeTx removes a single transaction from the queue, moving all subsequent
 // transactions back to the future queue.
-func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
+// Returns the number of transactions removed from the pending queue.
+func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) int {
 	// Fetch the transaction we wish to delete
 	tx := pool.all.Get(hash)
 	if tx == nil {
-		return
+		return 0
 	}
 	addr, _ := types.Sender(pool.signer, tx) // already validated during insertion
 
@@ -1045,7 +1111,8 @@ func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
 			pool.pendingNonces.setIfLower(addr, tx.Nonce())
 			// Reduce the pending counter
 			pendingGauge.Dec(int64(1 + len(invalids)))
-			return
+
+			return 1 + len(invalids)
 		}
 	}
 	// Transaction is in the future queue
@@ -1059,6 +1126,8 @@ func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
 			delete(pool.beats, addr)
 		}
 	}
+
+	return 0
 }
 
 // requestReset requests a pool reset to the new head block.

--- a/core/txpool2_test.go
+++ b/core/txpool2_test.go
@@ -1,0 +1,229 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+package core
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+func pricedValuedTransaction(nonce uint64, value int64, gaslimit uint64, gasprice *big.Int, key *ecdsa.PrivateKey) *types.Transaction {
+	tx, _ := types.SignTx(types.NewTransaction(nonce, common.Address{}, big.NewInt(value), gaslimit, gasprice, nil), types.HomesteadSigner{}, key)
+	return tx
+}
+
+func count(t *testing.T, pool *TxPool) (pending int, queued int) {
+	t.Helper()
+
+	pending, queued = pool.stats()
+
+	if err := validateTxPoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+
+	return pending, queued
+}
+
+func fillPool(t *testing.T, pool *TxPool) {
+	t.Helper()
+	// Create a number of test accounts, fund them and make transactions
+	executableTxs := types.Transactions{}
+	nonExecutableTxs := types.Transactions{}
+
+	for i := 0; i < 384; i++ {
+		key, _ := crypto.GenerateKey()
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(key.PublicKey), big.NewInt(10000000000))
+		// Add executable ones
+		for j := 0; j < int(pool.config.AccountSlots); j++ {
+			executableTxs = append(executableTxs, pricedTransaction(uint64(j), 100000, big.NewInt(300), key))
+		}
+	}
+	// Import the batch and verify that limits have been enforced
+	pool.AddRemotesSync(executableTxs)
+	pool.AddRemotesSync(nonExecutableTxs)
+	pending, queued := pool.Stats()
+	slots := pool.all.Slots()
+	// sanity-check that the test prerequisites are ok (pending full)
+	if have, want := pending, slots; have != want {
+		t.Fatalf("have %d, want %d", have, want)
+	}
+
+	if have, want := queued, 0; have != want {
+		t.Fatalf("have %d, want %d", have, want)
+	}
+
+	t.Logf("pool.config: GlobalSlots=%d, GlobalQueue=%d\n", pool.config.GlobalSlots, pool.config.GlobalQueue)
+	t.Logf("pending: %d queued: %d, all: %d\n", pending, queued, slots)
+}
+
+// Tests that if a batch high-priced of non-executables arrive, they do not kick out
+// executable transactions
+func TestTransactionFutureAttack(t *testing.T) {
+	t.Parallel()
+
+	// Create the pool to test the limit enforcement with
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	blockchain := &testBlockChain{1000000, statedb, new(event.Feed)}
+	config := testTxPoolConfig
+	config.GlobalQueue = 100
+	config.GlobalSlots = 100
+	pool := NewTxPool(config, eip1559Config, blockchain)
+
+	defer pool.Stop()
+	fillPool(t, pool)
+	pending, _ := pool.Stats()
+	// Now, future transaction attack starts, let's add a bunch of expensive non-executables, and see if the pending-count drops
+	{
+		key, _ := crypto.GenerateKey()
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(key.PublicKey), big.NewInt(100000000000))
+		futureTxs := types.Transactions{}
+		for j := 0; j < int(pool.config.GlobalSlots+pool.config.GlobalQueue); j++ {
+			futureTxs = append(futureTxs, pricedTransaction(1000+uint64(j), 100000, big.NewInt(500), key))
+		}
+		for i := 0; i < 5; i++ {
+			pool.AddRemotesSync(futureTxs)
+			newPending, newQueued := count(t, pool)
+			t.Logf("pending: %d queued: %d, all: %d\n", newPending, newQueued, pool.all.Slots())
+		}
+	}
+
+	newPending, _ := pool.Stats()
+	// Pending should not have been touched
+	if have, want := newPending, pending; have < want {
+		t.Errorf("wrong pending-count, have %d, want %d (GlobalSlots: %d)",
+			have, want, pool.config.GlobalSlots)
+	}
+}
+
+// Tests that if a batch high-priced of non-executables arrive, they do not kick out
+// executable transactions
+func TestTransactionFuture1559(t *testing.T) {
+	t.Parallel()
+	// Create the pool to test the pricing enforcement with
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	blockchain := &testBlockChain{1000000, statedb, new(event.Feed)}
+	pool := NewTxPool(testTxPoolConfig, eip1559Config, blockchain)
+
+	defer pool.Stop()
+
+	// Create a number of test accounts, fund them and make transactions
+	fillPool(t, pool)
+	pending, _ := pool.Stats()
+
+	// Now, future transaction attack starts, let's add a bunch of expensive non-executables, and see if the pending-count drops
+	{
+		key, _ := crypto.GenerateKey()
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(key.PublicKey), big.NewInt(100000000000))
+		futureTxs := types.Transactions{}
+		for j := 0; j < int(pool.config.GlobalSlots+pool.config.GlobalQueue); j++ {
+			futureTxs = append(futureTxs, dynamicFeeTx(1000+uint64(j), 100000, big.NewInt(200), big.NewInt(101), key))
+		}
+		pool.AddRemotesSync(futureTxs)
+	}
+
+	newPending, _ := pool.Stats()
+	// Pending should not have been touched
+	if have, want := newPending, pending; have != want {
+		t.Errorf("Wrong pending-count, have %d, want %d (GlobalSlots: %d)",
+			have, want, pool.config.GlobalSlots)
+	}
+}
+
+// Tests that if a batch of balance-overdraft txs arrive, they do not kick out
+// executable transactions
+func TestTransactionZAttack(t *testing.T) {
+	t.Parallel()
+	// Create the pool to test the pricing enforcement with
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	blockchain := &testBlockChain{1000000, statedb, new(event.Feed)}
+	pool := NewTxPool(testTxPoolConfig, eip1559Config, blockchain)
+
+	defer pool.Stop()
+
+	// Create a number of test accounts, fund them and make transactions
+	fillPool(t, pool)
+
+	countInvalidPending := func() int {
+		t.Helper()
+
+		var ivpendingNum int
+
+		pendingtxs, _ := pool.Content()
+
+		for account, txs := range pendingtxs {
+			cur_balance := new(big.Int).Set(pool.currentState.GetBalance(account))
+			for _, tx := range txs {
+				if cur_balance.Cmp(tx.Value()) <= 0 {
+					ivpendingNum++
+				} else {
+					cur_balance.Sub(cur_balance, tx.Value())
+				}
+			}
+		}
+
+		if err := validateTxPoolInternals(pool); err != nil {
+			t.Fatalf("pool internal state corrupted: %v", err)
+		}
+
+		return ivpendingNum
+	}
+	ivPending := countInvalidPending()
+	t.Logf("invalid pending: %d\n", ivPending)
+
+	// Now, DETER-Z attack starts, let's add a bunch of expensive non-executables (from N accounts) along with balance-overdraft txs (from one account), and see if the pending-count drops
+	for j := 0; j < int(pool.config.GlobalQueue); j++ {
+		futureTxs := types.Transactions{}
+		key, _ := crypto.GenerateKey()
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(key.PublicKey), big.NewInt(100000000000))
+		futureTxs = append(futureTxs, pricedTransaction(1000+uint64(j), 21000, big.NewInt(500), key))
+		pool.AddRemotesSync(futureTxs)
+	}
+
+	overDraftTxs := types.Transactions{}
+	{
+		key, _ := crypto.GenerateKey()
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(key.PublicKey), big.NewInt(100000000000))
+		for j := 0; j < int(pool.config.GlobalSlots); j++ {
+			overDraftTxs = append(overDraftTxs, pricedValuedTransaction(uint64(j), 60000000000, 21000, big.NewInt(500), key))
+		}
+	}
+	pool.AddRemotesSync(overDraftTxs)
+	pool.AddRemotesSync(overDraftTxs)
+	pool.AddRemotesSync(overDraftTxs)
+	pool.AddRemotesSync(overDraftTxs)
+	pool.AddRemotesSync(overDraftTxs)
+
+	newPending, newQueued := count(t, pool)
+	newIvPending := countInvalidPending()
+
+	t.Logf("pool.all.Slots(): %d\n", pool.all.Slots())
+	t.Logf("pending: %d queued: %d, all: %d\n", newPending, newQueued, pool.all.Slots())
+	t.Logf("invalid pending: %d\n", newIvPending)
+
+	// Pending should not have been touched
+	if newIvPending != ivPending {
+		t.Errorf("Wrong invalid pending-count, have %d, want %d (GlobalSlots: %d, queued: %d)",
+			newIvPending, ivPending, pool.config.GlobalSlots, newQueued)
+	}
+}


### PR DESCRIPTION
# Description

This PR adds few additional checks in the transaction pool which are derived from a fix in geth and helps in prevention of DoS attacks. 

Referencing details from geth's [PR](https://github.com/ethereum/go-ethereum/pull/26648). 
> This PR adds two new rules to the transaction pool:
>     - A future transaction can not evict a pending transaction
>     - A transaction can not overspend funds of a sender

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
