### PR TITLE
Tessellated/fastlane jj1980

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -175,6 +175,8 @@ type TxPoolConfig struct {
 	GlobalQueue  uint64 // Maximum number of non-executable transaction slots for all accounts
 
 	Lifetime time.Duration // Maximum amount of time non-executable transaction are queued
+
+	FastLanePeer string // Peer to prioritize with Fastlane.
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction
@@ -192,6 +194,8 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	GlobalQueue:  1024,
 
 	Lifetime: 3 * time.Hour,
+
+	FastLanePeer: "", // Default: No prioritized peer.
 }
 
 // sanitize checks the provided user configurations and changes anything that's

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -176,7 +176,7 @@ type TxPoolConfig struct {
 
 	Lifetime time.Duration // Maximum amount of time non-executable transaction are queued
 
-	FastLanePeer string // Peer to prioritize with Fastlane.
+	FastLanePeer string // Peer to prioritize with FastLane.
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -266,7 +266,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		EthAPI:             ethAPI,
 		PeerRequiredBlocks: config.PeerRequiredBlocks,
 		checker:            checker,
-		fastLanePeer: 		config.TxPool.FastLanePeer,
+		fastLanePeer:       config.TxPool.FastLanePeer,
 	}); err != nil {
 		return nil, err
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -266,6 +266,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		EthAPI:             ethAPI,
 		PeerRequiredBlocks: config.PeerRequiredBlocks,
 		checker:            checker,
+		fastLanePeer: 		config.TxPool.FastLanePeer,
 	}); err != nil {
 		return nil, err
 	}

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -179,14 +179,14 @@ type TxFetcher struct {
 	clock mclock.Clock  // Time wrapper to simulate in tests
 	rand  *mrand.Rand   // Randomizer to use in tests instead of map range loops (soft-random)
 
-	// The peer string of a fastlane node.
+	// The peer string of a FastLane node.
 	fastLanePeer string
 }
 
 // NewTxFetcher creates a transaction fetcher to retrieve transaction
 // based on hash announcements.
-func NewTxFetcher(hasTx func(common.Hash) bool, addTxs func([]*types.Transaction) []error, fetchTxs func(string, []common.Hash) error, fastlanePeer string) *TxFetcher {
-	return NewTxFetcherForTests(hasTx, addTxs, fetchTxs, mclock.System{}, nil, fastlanePeer)
+func NewTxFetcher(hasTx func(common.Hash) bool, addTxs func([]*types.Transaction) []error, fetchTxs func(string, []common.Hash) error, fastLanePeer string) *TxFetcher {
+	return NewTxFetcherForTests(hasTx, addTxs, fetchTxs, mclock.System{}, nil, fastLanePeer)
 }
 
 // NewTxFetcherForTests is a testing method to mock out the realtime clock with
@@ -196,7 +196,7 @@ func NewTxFetcherForTests(
 	clock mclock.Clock, rand *mrand.Rand, fastLanePeer string) *TxFetcher {
 
 	if fastLanePeer == "" {
-		log.Warn("Warning: FastLane peer is not set. ")
+		log.Warn("[FastLane] FastLane peer is not set.")
 	}
 
 	return &TxFetcher{
@@ -282,12 +282,12 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 
 	// Only execute FastLane logic if there is a FastLane Peer set.
 	if f.fastLanePeer != "" {
-		// Delay non-FastLane peer txs for up to 500ms.
+		// Delay non-FastLane peer txs by nonFastLaneTxDelay
 		isFastLanePeer := peer == f.fastLanePeer
 		log.Debug("[FastLane] Received transactions from peer %s (isFastLanePeer = %t)", peer, isFastLanePeer)
 		if isFastLanePeer {
 			log.Debug("[FastLane] Delaying tx addition to mempool for peer %s", peer)
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(nonFastLaneTxDelay)
 			log.Debug("[FastLane] Delaying complete for peer %s", peer)
 		} else {
 			log.Debug("[FastLane] Will not delay addition of txs to mempool.")

--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -81,6 +81,7 @@ func TestTransactionFetcherWaiting(t *testing.T) {
 				func(common.Hash) bool { return false },
 				nil,
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -171,6 +172,7 @@ func TestTransactionFetcherSkipWaiting(t *testing.T) {
 				func(common.Hash) bool { return false },
 				nil,
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -234,6 +236,7 @@ func TestTransactionFetcherSingletonRequesting(t *testing.T) {
 				func(common.Hash) bool { return false },
 				nil,
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -314,6 +317,7 @@ func TestTransactionFetcherFailedRescheduling(t *testing.T) {
 					<-proceed
 					return errors.New("peer disconnected")
 				},
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -383,6 +387,7 @@ func TestTransactionFetcherCleanup(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -422,6 +427,7 @@ func TestTransactionFetcherCleanupEmpty(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -460,6 +466,7 @@ func TestTransactionFetcherMissingRescheduling(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -506,6 +513,7 @@ func TestTransactionFetcherMissingCleanup(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -544,6 +552,7 @@ func TestTransactionFetcherBroadcasts(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -592,6 +601,7 @@ func TestTransactionFetcherWaitTimerResets(t *testing.T) {
 				func(common.Hash) bool { return false },
 				nil,
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -649,6 +659,7 @@ func TestTransactionFetcherTimeoutRescheduling(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -714,6 +725,7 @@ func TestTransactionFetcherTimeoutTimerResets(t *testing.T) {
 				func(common.Hash) bool { return false },
 				nil,
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -773,6 +785,7 @@ func TestTransactionFetcherRateLimiting(t *testing.T) {
 				func(common.Hash) bool { return false },
 				nil,
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -811,6 +824,7 @@ func TestTransactionFetcherDoSProtection(t *testing.T) {
 				func(common.Hash) bool { return false },
 				nil,
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -878,6 +892,7 @@ func TestTransactionFetcherUnderpricedDedup(t *testing.T) {
 					return errs
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -947,6 +962,7 @@ func TestTransactionFetcherUnderpricedDoSProtection(t *testing.T) {
 					return errs
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: append(steps, []interface{}{
@@ -969,6 +985,7 @@ func TestTransactionFetcherOutOfBoundDeliveries(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -1022,6 +1039,7 @@ func TestTransactionFetcherDrop(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -1088,6 +1106,7 @@ func TestTransactionFetcherDropRescheduling(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -1133,6 +1152,7 @@ func TestTransactionFetcherFuzzCrash01(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -1160,6 +1180,7 @@ func TestTransactionFetcherFuzzCrash02(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -1189,6 +1210,7 @@ func TestTransactionFetcherFuzzCrash03(t *testing.T) {
 					return make([]error, len(txs))
 				},
 				func(string, []common.Hash) error { return nil },
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -1225,6 +1247,7 @@ func TestTransactionFetcherFuzzCrash04(t *testing.T) {
 					<-proceed
 					return errors.New("peer disconnected")
 				},
+				"",
 			)
 		},
 		steps: []interface{}{
@@ -1241,6 +1264,86 @@ func TestTransactionFetcherFuzzCrash04(t *testing.T) {
 			}),
 			doWait{time: 0, step: true},
 			doWait{time: txFetchTimeout, step: true},
+		},
+	})
+}
+
+func TestTransactionFetcherFastlaneValidatorOnlyPatch(t *testing.T) {
+	testTxpool := make(map[common.Hash]*types.Transaction)
+	txFetcher := NewTxFetcher(
+		func(hash common.Hash) bool {
+			if _, has := testTxpool[hash]; has {
+				return true
+			}
+			return false
+		},
+		func(txs []*types.Transaction) []error {
+			for _, tx := range txs {
+				testTxpool[tx.Hash()] = tx
+			}
+			return make([]error, len(txs))
+		},
+		func(string, []common.Hash) error { return nil },
+		"FASTLANEPEER",
+	)
+
+	testTransactionFetcherParallel(t, txFetcherTest{
+		init: func() *TxFetcher { return txFetcher },
+		steps: []interface{}{
+			// 1. Broadcast from Fastlane peer.
+			doTxEnqueue{peer: "FASTLANEPEER", txs: []*types.Transaction{testTxs[0]}, direct: false},
+			// Tx should be added to txpool without delay.
+			doFunc(func() {
+				hash := testTxs[0].Hash()
+				if !txFetcher.hasTx(hash) {
+					t.Errorf("step 1, peer FASTLANEPEER: hash %x missing from testTxpool", hash)
+				}
+			}),
+
+			// 2. Broadcast from non-Fastlane peer.
+			// doTxEnqueue wait for the fetcher to process something, which defeat our async
+			// method of delaying the tx. Doing our own Enqueue instead.
+			doFunc(func() {
+				if err := txFetcher.Enqueue("A", []*types.Transaction{testTxs[1]}, false); err != nil {
+					t.Errorf("step 2: %v", err)
+				}
+			}),
+			// Tx should be added to txpool after a delay.
+			doFunc(func() {
+				hash := testTxs[1].Hash()
+				if txFetcher.hasTx(hash) {
+					t.Errorf("step 3, peer A: hash %x added to testTxpool too early", hash)
+				}
+				// Add minor delay to nonFastLaneTxDelay to ensure Enqueue as time to process
+				time.Sleep(nonFastLaneTxDelay + 10*time.Millisecond)
+				if !txFetcher.hasTx(hash) {
+					t.Errorf("step 3, peer A: hash %x missing from testTxpool", hash)
+				}
+			}),
+			// Reset for next step
+			doWait{time: 0, step: true},
+
+			// 3. Announcements from Fastlane and non-Fastlane peers
+			doTxNotify{peer: "FASTLANEPEER", hashes: []common.Hash{testTxsHashes[2]}},
+			doWait{time: txArriveTimeout, step: true},
+			doTxEnqueue{peer: "FASTLANEPEER", txs: []*types.Transaction{testTxs[2]}, direct: true},
+			// Tx should be added to txpool without delay.
+			doFunc(func() {
+				hash := testTxs[2].Hash()
+				if !txFetcher.hasTx(hash) {
+					t.Errorf("step 8, peer FASTLANEPEER: hash %x missing from testTxpool", hash)
+				}
+			}),
+			doTxNotify{peer: "A", hashes: []common.Hash{testTxsHashes[3]}},
+			doWait{time: txArriveTimeout, step: true},
+			doTxEnqueue{peer: "A", txs: []*types.Transaction{testTxs[3]}, direct: true},
+			// Tx should be added to txpool without delay.
+			doFunc(func() {
+				hash := testTxs[3].Hash()
+				if !txFetcher.hasTx(hash) {
+					t.Errorf("step 12, peer A: hash %x missing from testTxpool", hash)
+				}
+			}),
 		},
 	})
 }

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -93,6 +93,8 @@ type handlerConfig struct {
 
 	PeerRequiredBlocks map[uint64]common.Hash // Hard coded map of required block hashes for sync challenges
 	checker            ethereum.ChainValidator
+
+	fastLanePeer string
 }
 
 type handler struct {
@@ -307,7 +309,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		}
 		return p.RequestTxs(hashes)
 	}
-	h.txFetcher = fetcher.NewTxFetcher(h.txpool.Has, h.txpool.AddRemotes, fetchTx)
+	h.txFetcher = fetcher.NewTxFetcher(h.txpool.Has, h.txpool.AddRemotes, fetchTx, config.fastLanePeer)
 	h.chainSync = newChainSyncer(h)
 	return h, nil
 }


### PR DESCRIPTION
Delay all non-Fastlane tx broadcasts by 500ms.
Added `TestTransactionFetcherFastlaneValidatorOnlyPatch` to unit tests, it simulates a few scenarios.