### PR TITLE
consensus/bor: revert "handle unauthorized signer in consensus.Prepare"

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -694,10 +694,10 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header) e
 
 	// Bail out early if we're unauthorized to sign a block. This check also takes
 	// place before block is signed in `Seal`.
-	if !snap.ValidatorSet.HasAddress(currentSigner.signer) {
-		// Check the UnauthorizedSignerError.Error() msg to see why we pass number-1
-		return &UnauthorizedSignerError{number - 1, currentSigner.signer.Bytes()}
-	}
+	// if !snap.ValidatorSet.HasAddress(currentSigner.signer) {
+	// 	// Check the UnauthorizedSignerError.Error() msg to see why we pass number-1
+	// 	return &UnauthorizedSignerError{number - 1, currentSigner.signer.Bytes()}
+	// }
 
 	// Set the correct difficulty
 	header.Difficulty = new(big.Int).SetUint64(Difficulty(snap.ValidatorSet, currentSigner.signer))

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -692,13 +692,6 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header) e
 
 	currentSigner := *c.authorizedSigner.Load()
 
-	// Bail out early if we're unauthorized to sign a block. This check also takes
-	// place before block is signed in `Seal`.
-	// if !snap.ValidatorSet.HasAddress(currentSigner.signer) {
-	// 	// Check the UnauthorizedSignerError.Error() msg to see why we pass number-1
-	// 	return &UnauthorizedSignerError{number - 1, currentSigner.signer.Bytes()}
-	// }
-
 	// Set the correct difficulty
 	header.Difficulty = new(big.Int).SetUint64(Difficulty(snap.ValidatorSet, currentSigner.signer))
 


### PR DESCRIPTION
# Description

This PR reverts changes made in #651 which made the node bail out early when it realised it's not part of the validator set in `consensus.Prepare`. As a result of this, the pending blocks were not getting updated since the flow broke off before the `worker.commit` phase . 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli
