### PR TITLE
prolong locks for txpool

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -322,10 +322,9 @@ func (m *txSortedMap) flatten() types.Transactions {
 			cache = append(cache, tx)
 		}
 
-		m.m.RUnlock()
-
-		// exclude sorting from locks
 		sort.Sort(types.TxByNonce(cache))
+
+		m.m.RUnlock()
 
 		m.cacheMu.Lock()
 		m.cache = cache


### PR DESCRIPTION
The panic log was not very informative. The only thing I can figure out is that it is connected with tx.items so prolonged locks a bit for them