### PR TITLE
added a write lock to the txs.filter method and a read lock to the tx…

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -506,8 +506,12 @@ func (l *txList) Filter(costLimit *uint256.Int, gasLimit uint64) (types.Transact
 				lowest = nonce
 			}
 		}
+		l.txs.m.Lock()
 		invalids = l.txs.filter(func(tx *types.Transaction) bool { return tx.Nonce() > lowest })
+		l.txs.m.Unlock()
 	}
+	l.txs.m.RLock()
+	defer l.txs.m.RUnlock()
 	l.txs.reheap()
 	return removed, invalids
 }


### PR DESCRIPTION
The filter method of txSortedMap is typically called by caller that holds the "m" RWLock object.

During reorgs, however, a Filter method of txList calls the filter method of txSortedMap but does not engage the lock. 

This Filter method is called only by the txPool methods demoteUnexecutables and promoteExecutables, which are only called during reorgs (which explains the low frequency with which this crash occurs). 

# Description

Added in a read lock and a write lock

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Nodes audience

This PR is in response to a validator crash

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Additional comments

Have not had time to test this yet but it seemed urgent. 
