### PR TITLE
core: improve locks in txpool

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -173,9 +173,13 @@ func (m *txSortedMap) reheap(withRlock bool) {
 	heap.Init(&index)
 
 	if withRlock {
-		m.m.RLock()
-		m.index = &index
-		m.m.RUnlock()
+		m.m.Lock()
+	}
+
+	m.index = &index
+
+	if withRlock {
+		m.m.Unlock()
 	}
 
 	m.cacheMu.Lock()

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -150,19 +150,25 @@ func (m *txSortedMap) Filter(filter func(*types.Transaction) bool) types.Transac
 	removed := m.filter(filter)
 	// If transactions were removed, the heap and cache are ruined
 	if len(removed) > 0 {
-		m.reheap()
+		m.reheap(false)
 	}
 	return removed
 }
 
-func (m *txSortedMap) reheap() {
-	*m.index = make([]uint64, 0, len(m.items))
+func (m *txSortedMap) reheap(withRlock bool) {
+	index := make(nonceHeap, 0, len(m.items))
 
 	for nonce := range m.items {
-		*m.index = append(*m.index, nonce)
+		index = append(index, nonce)
 	}
 
-	heap.Init(m.index)
+	heap.Init(&index)
+
+	if withRlock {
+		m.m.RLock()
+		m.index = &index
+		m.m.RUnlock()
+	}
 
 	m.cacheMu.Lock()
 	m.cache = nil
@@ -521,6 +527,7 @@ func (l *txList) Filter(costLimit *uint256.Int, gasLimit uint64) (types.Transact
 				lowest = nonce
 			}
 		}
+
 		l.txs.m.Lock()
 		invalids = l.txs.filter(func(tx *types.Transaction) bool { return tx.Nonce() > lowest })
 		l.txs.m.Unlock()
@@ -529,11 +536,7 @@ func (l *txList) Filter(costLimit *uint256.Int, gasLimit uint64) (types.Transact
 	l.subTotalCost(removed)
 	l.subTotalCost(invalids)
 
-	l.txs.m.RLock()
-	defer l.txs.m.RUnlock()
-
-	l.txs.reheap()
-
+	l.txs.reheap(true)
 	return removed, invalids
 }
 

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -521,12 +521,19 @@ func (l *txList) Filter(costLimit *uint256.Int, gasLimit uint64) (types.Transact
 				lowest = nonce
 			}
 		}
+		l.txs.m.Lock()
 		invalids = l.txs.filter(func(tx *types.Transaction) bool { return tx.Nonce() > lowest })
+		l.txs.m.Unlock()
 	}
 	// Reset total cost
 	l.subTotalCost(removed)
 	l.subTotalCost(invalids)
+
+	l.txs.m.RLock()
+	defer l.txs.m.RUnlock()
+
 	l.txs.reheap()
+
 	return removed, invalids
 }
 

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // nonceHeap is a heap.Interface implementation over 64bit unsigned integers for
@@ -160,6 +161,7 @@ func (m *txSortedMap) reheap(withRlock bool) {
 
 	if withRlock {
 		m.m.RLock()
+		log.Info("[DEBUG] Acquired lock over txpool map while performing reheap")
 	}
 
 	for nonce := range m.items {

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -158,8 +158,16 @@ func (m *txSortedMap) Filter(filter func(*types.Transaction) bool) types.Transac
 func (m *txSortedMap) reheap(withRlock bool) {
 	index := make(nonceHeap, 0, len(m.items))
 
+	if withRlock {
+		m.m.RLock()
+	}
+
 	for nonce := range m.items {
 		index = append(index, nonce)
+	}
+
+	if withRlock {
+		m.m.RUnlock()
 	}
 
 	heap.Init(&index)

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -549,6 +549,7 @@ func (l *txList) Filter(costLimit *uint256.Int, gasLimit uint64) (types.Transact
 	l.subTotalCost(invalids)
 
 	l.txs.reheap(true)
+
 	return removed, invalids
 }
 

--- a/packaging/templates/package_scripts/control
+++ b/packaging/templates/package_scripts/control
@@ -1,5 +1,5 @@
 Source: bor
-Version: 0.3.7
+Version: 0.3.8-beta
 Section: develop
 Priority: standard
 Maintainer: Polygon <release-team@polygon.technology>

--- a/packaging/templates/package_scripts/control.arm64
+++ b/packaging/templates/package_scripts/control.arm64
@@ -1,5 +1,5 @@
 Source: bor
-Version: 0.3.7
+Version: 0.3.8-beta
 Section: develop
 Priority: standard
 Maintainer: Polygon <release-team@polygon.technology>

--- a/packaging/templates/package_scripts/control.profile.amd64
+++ b/packaging/templates/package_scripts/control.profile.amd64
@@ -1,5 +1,5 @@
 Source: bor-profile
-Version: 0.3.7
+Version: 0.3.8-beta
 Section: develop
 Priority: standard
 Maintainer: Polygon <release-team@polygon.technology>

--- a/packaging/templates/package_scripts/control.profile.arm64
+++ b/packaging/templates/package_scripts/control.profile.arm64
@@ -1,5 +1,5 @@
 Source: bor-profile
-Version: 0.3.7
+Version: 0.3.8-beta
 Section: develop
 Priority: standard
 Maintainer: Polygon <release-team@polygon.technology>

--- a/packaging/templates/package_scripts/control.validator
+++ b/packaging/templates/package_scripts/control.validator
@@ -1,5 +1,5 @@
 Source: bor-profile
-Version: 0.3.7
+Version: 0.3.8-beta
 Section: develop
 Priority: standard
 Maintainer: Polygon <release-team@polygon.technology>

--- a/packaging/templates/package_scripts/control.validator.arm64
+++ b/packaging/templates/package_scripts/control.validator.arm64
@@ -1,5 +1,5 @@
 Source: bor-profile
-Version: 0.3.7
+Version: 0.3.8-beta
 Section: develop
 Priority: standard
 Maintainer: Polygon <release-team@polygon.technology>

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 0        // Major version component of the current release
-	VersionMinor = 3        // Minor version component of the current release
-	VersionPatch = 7        // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 0      // Major version component of the current release
+	VersionMinor = 3      // Minor version component of the current release
+	VersionPatch = 8      // Patch version component of the current release
+	VersionMeta  = "beta" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
# Description

This PR cherry-picks https://github.com/maticnetwork/bor/pull/805 and https://github.com/maticnetwork/bor/pull/806 which improves locks on a map used by transaction pool. 

Thanks and shout out to @thogard785 for helping in identifying and fixing this issue. 

Quoting the description from #805 by @thogard785
> The filter method of txSortedMap is typically called by caller that holds the "m" RWLock object.
> 
> During reorgs, however, a Filter method of txList calls the filter method of txSortedMap but does not engage the lock.
> 
> This Filter method is called only by the txPool methods demoteUnexecutables and promoteExecutables, which are only called during reorgs (which explains the low frequency with which this crash occurs).

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
