### PR TITLE
Restore log level enumerated constants

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -18,13 +18,13 @@ const skipLevel = 2
 type Lvl int
 
 const (
-	LvlDiscard Lvl = -1
-	LvlCrit    Lvl = iota
+	LvlCrit Lvl = iota
 	LvlError
 	LvlWarn
 	LvlInfo
 	LvlDebug
 	LvlTrace
+	LvlDiscard Lvl = -1
 )
 
 // AlignedString returns a 5-character string containing the name of a Lvl.


### PR DESCRIPTION
# Description

The addition of 'LvlDiscard Lvl = -1' at beginning of const block in commit e699254142 caused the iota assigned values of LvlCrit through LvlTrace to change from 0 to 5 to 1 to 6.

As these enumerated values were used in command line argument parsing in cmd/geth/ (and possibly other commands), commit e699254142 caused `--verbosity 3` to be interpreted as WARN instead of INFO (and likewise for the other numeric verbosity values.)

This restores the original enumerated const values to LvlCrit through LvlTrace by moving LvlDiscard after all the iota assigned constants. Usage of auto-increment enumerations does not work the same way in golang as it does in C/C++ and its behaviour is detailed in the link below.

https://go.dev/ref/spec#Iota

# Changes

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli