### PR TITLE
miner :: add : check to run worker commitWork

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -580,7 +580,9 @@ func (w *worker) mainLoop(ctx context.Context) {
 		select {
 		case req := <-w.newWorkCh:
 			//nolint:contextcheck
-			w.commitWork(req.ctx, req.interrupt, req.noempty, req.timestamp)
+			if w.isRunning() {
+				w.commitWork(req.ctx, req.interrupt, req.noempty, req.timestamp)
+			}
 
 		case req := <-w.getWorkCh:
 			//nolint:contextcheck


### PR DESCRIPTION
# Description

In this PR, we check if the node is running with `--mine` /(miner node) , then only we do the resource extensive operations of executing transactions and committing work. On full nodes, these operations shall not take place and hence result in better efficiency of the nodes. 