### PR TITLE
Makefile, params: fix git commit usage in bor version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GIT_COMMIT ?= $(shell git rev-list -1 HEAD)
 
 PACKAGE = github.com/ethereum/go-ethereum
 GO_FLAGS += -buildvcs=false
-GO_LDFLAGS += -ldflags "-X ${PACKAGE}/params.GitCommit=${GIT_COMMIT} "
+GO_LDFLAGS += -ldflags "-X ${PACKAGE}/params.GitCommit=${GIT_COMMIT}"
 
 TESTALL = $$(go list ./... | grep -v go-ethereum/cmd/)
 TESTE2E = ./tests/...

--- a/params/version.go
+++ b/params/version.go
@@ -21,12 +21,13 @@ import (
 )
 
 const (
-	GitCommit    = ""
 	VersionMajor = 0      // Major version component of the current release
 	VersionMinor = 3      // Minor version component of the current release
 	VersionPatch = 9      // Patch version component of the current release
 	VersionMeta  = "beta" // Version metadata to append to the version string
 )
+
+var GitCommit string
 
 // Version holds the textual version string.
 var Version = func() string {
@@ -48,7 +49,7 @@ var VersionWithMetaCommitDetails = func() string {
 	if VersionMeta != "" {
 		v += "-" + VersionMeta
 	}
-	v_git := fmt.Sprintf("Version : %s\nGitCommit : %s\n", v, GitCommit)
+	v_git := fmt.Sprintf("Version: %s\nGitCommit: %s", v, GitCommit)
 	return v_git
 }()
 


### PR DESCRIPTION
# Description

An empty git commit was displayed on `bor version` usage. The error mostly was because the variable was kept constant in the params/version.go file. This PR fixes it. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
