### PR TITLE
rm : remove interruptctx from txsCh select case

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -674,30 +674,13 @@ func (w *worker) mainLoop(ctx context.Context) {
 				txset := types.NewTransactionsByPriceAndNonce(w.current.signer, txs, cmath.FromBig(w.current.header.BaseFee))
 				tcount := w.current.tcount
 
-				// nolint : contextcheck
-				var interruptCtx = context.Background()
-
-				stopFn := func() {}
-
-				defer func() {
-					stopFn()
-				}()
-
-				if w.interruptCommitFlag {
-					interruptCtx, stopFn = getInterruptTimer(ctx, w.current, w.chain.CurrentBlock())
-					// nolint : staticcheck
-					interruptCtx = vm.PutCache(interruptCtx, w.interruptedTxCache)
-				}
-
-				w.commitTransactions(w.current, txset, nil, interruptCtx)
+				w.commitTransactions(w.current, txset, nil, context.Background())
 
 				// Only update the snapshot if any new transactions were added
 				// to the pending block
 				if tcount != w.current.tcount {
 					w.updateSnapshot(w.current)
 				}
-
-				stopFn()
 			} else {
 				// Special case, if the consensus engine is 0 period clique(dev mode),
 				// submit sealing work here since all empty submission will be rejected

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -674,6 +674,7 @@ func (w *worker) mainLoop(ctx context.Context) {
 				txset := types.NewTransactionsByPriceAndNonce(w.current.signer, txs, cmath.FromBig(w.current.header.BaseFee))
 				tcount := w.current.tcount
 
+				//nolint:contextcheck
 				w.commitTransactions(w.current, txset, nil, context.Background())
 
 				// Only update the snapshot if any new transactions were added


### PR DESCRIPTION
# Description

In this PR, we remove interrupt commit flow from select case of txsCh. Earlier, due to this "interrupt commit logs" were spamming the bor logs. 