### PR TITLE
internal/cli/server :: chg : default OpenCollectorEndpoint to empty string

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -128,7 +128,7 @@ syncmode = "full"
   metrics = true
   # expensive = false
   # prometheus-addr = "127.0.0.1:7071"
-  # opencollector-endpoint = "127.0.0.1:4317"
+  # opencollector-endpoint = ""
   # [telemetry.influx]
     # influxdb = false
     # endpoint = ""

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -129,7 +129,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   metrics = false                            # Enable metrics collection and reporting
   expensive = false                          # Enable expensive metrics collection and reporting
   prometheus-addr = "127.0.0.1:7071"         # Address for Prometheus Server
-  opencollector-endpoint = "127.0.0.1:4317"  # OpenCollector Endpoint (host:port)
+  opencollector-endpoint = ""  # OpenCollector Endpoint (host:port)
   [telemetry.influx]
     influxdb = false    # Enable metrics export/push to an external InfluxDB database (v1)
     endpoint = ""       # InfluxDB API endpoint to report metrics to

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -258,7 +258,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```metrics.prometheus-addr```: Address for Prometheus Server (default: 127.0.0.1:7071)
 
-- ```metrics.opencollector-endpoint```: OpenCollector Endpoint (host:port) (default: 127.0.0.1:4317)
+- ```metrics.opencollector-endpoint```: OpenCollector Endpoint (host:port)
 
 - ```metrics.influxdbv2```: Enable metrics export/push to an external InfluxDB v2 database (default: false)
 

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -703,7 +703,7 @@ func DefaultConfig() *Config {
 			Enabled:               false,
 			Expensive:             false,
 			PrometheusAddr:        "127.0.0.1:7071",
-			OpenCollectorEndpoint: "127.0.0.1:4317",
+			OpenCollectorEndpoint: "",
 			InfluxDB: &InfluxDBConfig{
 				V1Enabled:    false,
 				Endpoint:     "",


### PR DESCRIPTION
# Description

In this PR, we change the default `OpenCollectorEndpoint` to `empty` string. Earlier, logs were getting spammed by `traces exporter is disconnected from the server 127.0.0.1:4317` error. 