### PR TITLE
add : commitinterrupt flag to toml files

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -71,6 +71,7 @@ syncmode = "full"
   # etherbase = "VALIDATOR ADDRESS"
   # extradata = ""
   # recommit = "2m5s"
+  # commitinterrupt = true
 
 
 # [jsonrpc]

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -73,6 +73,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   gaslimit = 30000000      # Target gas ceiling for mined blocks
   gasprice = "1000000000"  # Minimum gas price for mining a transaction (recommended for mainnet = 30000000000, default suitable for mumbai/devnet)
   recommit = "2m5s"        # The time interval for miner to re-create mining work
+  commitinterrupt = true   # Interrupt the current mining work when time is exceeded and create partial blocks
 
 [jsonrpc]
   ipcdisable = false                               # Disable the IPC-RPC server

--- a/packaging/templates/mainnet-v1/archive/config.toml
+++ b/packaging/templates/mainnet-v1/archive/config.toml
@@ -66,6 +66,7 @@ gcmode = "archive"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
+    # commitinterrupt = true
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
@@ -66,6 +66,7 @@ syncmode = "full"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
+    # commitinterrupt = true
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
@@ -68,6 +68,7 @@ syncmode = "full"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
+    # commitinterrupt = true
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
@@ -68,6 +68,7 @@ syncmode = "full"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
+    # commitinterrupt = true
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/testnet-v4/archive/config.toml
+++ b/packaging/templates/testnet-v4/archive/config.toml
@@ -66,6 +66,7 @@ gcmode = "archive"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
+    # commitinterrupt = true
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
@@ -66,6 +66,7 @@ syncmode = "full"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
+    # commitinterrupt = true
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
@@ -68,6 +68,7 @@ syncmode = "full"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
+    # commitinterrupt = true
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"

--- a/packaging/templates/testnet-v4/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/without-sentry/bor/config.toml
@@ -68,6 +68,7 @@ syncmode = "full"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
+    # commitinterrupt = true
 
 [jsonrpc]
     ipcpath = "/var/lib/bor/bor.ipc"


### PR DESCRIPTION
# Description

In this PR, we add the `commitinterrupt` flag to the config toml files.