### PR TITLE
DEVOPS-829 format fix for prometheus metrics

### DIFF
--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -30,6 +30,7 @@ var (
 	typeCounterTpl         = "# TYPE %s counter\n"
 	typeSummaryTpl         = "# TYPE %s summary\n"
 	keyValueTpl            = "%s %v\n\n"
+	keyCounterTpl          = "%s %v\n"
 	keyQuantileTagValueTpl = "%s {quantile=\"%s\"} %v\n"
 )
 
@@ -61,11 +62,14 @@ func (c *collector) addGaugeFloat64(name string, m metrics.GaugeFloat64) {
 func (c *collector) addHistogram(name string, m metrics.Histogram) {
 	pv := []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
 	ps := m.Percentiles(pv)
-	c.writeSummaryCounter(name, m.Count())
+	var sum float64 = 0
 	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
 	for i := range pv {
 		c.writeSummaryPercentile(name, strconv.FormatFloat(pv[i], 'f', -1, 64), ps[i])
+		sum += ps[i]
 	}
+	c.writeSummarySum(name, fmt.Sprintf("%f", sum))
+	c.writeSummaryCounter(name, len(ps))
 	c.buff.WriteRune('\n')
 }
 
@@ -76,7 +80,7 @@ func (c *collector) addMeter(name string, m metrics.Meter) {
 func (c *collector) addTimer(name string, m metrics.Timer) {
 	pv := []float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999}
 	ps := m.Percentiles(pv)
-	c.writeSummaryCounter(name, m.Count())
+	c.writeCounter(name, m.Count())
 	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
 	for i := range pv {
 		c.writeSummaryPercentile(name, strconv.FormatFloat(pv[i], 'f', -1, 64), ps[i])
@@ -90,11 +94,16 @@ func (c *collector) addResettingTimer(name string, m metrics.ResettingTimer) {
 	}
 	ps := m.Percentiles([]float64{50, 95, 99})
 	val := m.Values()
-	c.writeSummaryCounter(name, len(val))
 	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
 	c.writeSummaryPercentile(name, "0.50", ps[0])
 	c.writeSummaryPercentile(name, "0.95", ps[1])
 	c.writeSummaryPercentile(name, "0.99", ps[2])
+	var sum int64 = 0
+	for _, v := range val {
+		sum += v
+	}
+	c.writeSummarySum(name, fmt.Sprintf("%d", sum))
+	c.writeSummaryCounter(name, len(val))
 	c.buff.WriteRune('\n')
 }
 
@@ -104,15 +113,25 @@ func (c *collector) writeGaugeCounter(name string, value interface{}) {
 	c.buff.WriteString(fmt.Sprintf(keyValueTpl, name, value))
 }
 
-func (c *collector) writeSummaryCounter(name string, value interface{}) {
+func (c *collector) writeCounter(name string, value interface{}) {
 	name = mutateKey(name + "_count")
 	c.buff.WriteString(fmt.Sprintf(typeCounterTpl, name))
 	c.buff.WriteString(fmt.Sprintf(keyValueTpl, name, value))
 }
 
+func (c *collector) writeSummaryCounter(name string, value interface{}) {
+	name = mutateKey(name + "_count")
+	c.buff.WriteString(fmt.Sprintf(keyCounterTpl, name, value))
+}
+
 func (c *collector) writeSummaryPercentile(name, p string, value interface{}) {
 	name = mutateKey(name)
 	c.buff.WriteString(fmt.Sprintf(keyQuantileTagValueTpl, name, p, value))
+}
+
+func (c *collector) writeSummarySum(name string, value string) {
+	name = mutateKey(name + "_sum")
+	c.buff.WriteString(fmt.Sprintf(keyCounterTpl, name, value))
 }
 
 func mutateKey(key string) string {

--- a/metrics/prometheus/collector_test.go
+++ b/metrics/prometheus/collector_test.go
@@ -67,9 +67,6 @@ test_gauge 23456
 # TYPE test_gauge_float64 gauge
 test_gauge_float64 34567.89
 
-# TYPE test_histogram_count counter
-test_histogram_count 0
-
 # TYPE test_histogram summary
 test_histogram {quantile="0.5"} 0
 test_histogram {quantile="0.75"} 0
@@ -77,6 +74,8 @@ test_histogram {quantile="0.95"} 0
 test_histogram {quantile="0.99"} 0
 test_histogram {quantile="0.999"} 0
 test_histogram {quantile="0.9999"} 0
+test_histogram_sum 0.000000
+test_histogram_count 6
 
 # TYPE test_meter gauge
 test_meter 9999999
@@ -92,15 +91,16 @@ test_timer {quantile="0.99"} 1.2e+08
 test_timer {quantile="0.999"} 1.2e+08
 test_timer {quantile="0.9999"} 1.2e+08
 
-# TYPE test_resetting_timer_count counter
-test_resetting_timer_count 6
-
 # TYPE test_resetting_timer summary
 test_resetting_timer {quantile="0.50"} 12000000
 test_resetting_timer {quantile="0.95"} 120000000
 test_resetting_timer {quantile="0.99"} 120000000
+test_resetting_timer_sum 180000000
+test_resetting_timer_count 6
 
 `
+	c.addResettingTimer("test/empty_resetting_timer", emptyResettingTimer)
+
 	exp := c.buff.String()
 	if exp != expectedOutput {
 		t.Log("Expected Output:\n", expectedOutput)


### PR DESCRIPTION
# Description

This PR changes the format of `summary` and `histogram` metrics as exposed by the metrics endpoint to adhere to the Prometheus metric type definitions as seen [here](https://prometheus.io/docs/concepts/metric_types/)

Prior to this change, a summary type metric would be exposed on the endpoint as two distinct metrics:
```
# TYPE chain_validation_count counter
chain_validation_count 397884

# TYPE chain_validation summary
chain_validation {quantile="0.5"} 199349
chain_validation {quantile="0.75"} 270883.5
chain_validation {quantile="0.95"} 460101.04999999993
chain_validation {quantile="0.99"} 641909.1200000001
chain_validation {quantile="0.999"} 1.0424829650000001e+06
chain_validation {quantile="0.9999"} 1.043075e+06
```

This PR updates the metric to display as:
```
# TYPE chain_validation summary
chain_validation {quantile="0.5"} 199349
chain_validation {quantile="0.75"} 270883.5
chain_validation {quantile="0.95"} 460101.04999999993
chain_validation {quantile="0.99"} 641909.1200000001
chain_validation {quantile="0.999"} 1.0424829650000001e+06
chain_validation {quantile="0.9999"} 1.043075e+06
chain_validation_sum some_sum_of_the_values_measured
chain_validation_count 397884
```

These metrics are affected by the change: chain_account, chain_account_hashes, chain_account_reads, chain_account_updates, chain_execution, chain_inserts, chain_prefetch_executes, chain_snapshot_account_reads, chain_snapshot_commits, chain_snapshot_storage_reads, chain_storage_commits, chain_storage_hashes, chain_storage_reads, chain_storage_updates, chain_validation, chain_write, client_requests_checkpoint_duration, client_requests_checkpointcount_duration, client_requests_span_duration, client_requests_statesync_duration, eth_downloader_bodies_req, eth_downloader_headers_req, eth_downloader_receipts_req, eth_fetcher_block_announces_out, eth_fetcher_block_broadcasts_out, les_client_req_rtt, les_client_req_sendDelay, les_connection_duration, les_misc_serve_body, les_misc_serve_code, les_misc_serve_header, les_misc_serve_helperTrie, les_misc_serve_proof, les_misc_serve_receipt, les_misc_serv_txStatus, les_misc_serve_txs, les_server_blockProcessingTime, les_server_req_estimatedTime, les_server_req_relative, les_server_req_relative_body, les_server_req_relative_code, les_server_req_relative_header, les_server_req_relative_helperTrie, les_server_req_relative_proof, les_server_req_relative_receipt, les_server_req_relative_txStatus, les_server_req_relative_txs, les_server_req_servedTime, p2p_handle_eth_66_0x01-p2p_handle_eth_66_0x0a, rpc_duration_all, rpc_duration_eth_getBlockByNumber, rpc_duration_eth_getRootHash_success, state_snapshot_bloom_index, state_snapshot_dirty_account_hit_depth, state_snapshot_dirty_storage_hit_depth, trie_memcache_gc_time, txpool_dropbetweenreorg, txpool_reheap, txpool_reorgtime


# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

