### PR TITLE
Disable reverted tx optimization in block-stm validation

### DIFF
--- a/core/blockstm/mvhashmap.go
+++ b/core/blockstm/mvhashmap.go
@@ -269,13 +269,6 @@ func ValidateVersion(txIdx int, lastInputOutput *TxnInputOutput, versionedData *
 		mvResult := versionedData.Read(rd.Path, txIdx)
 		switch mvResult.Status() {
 		case MVReadResultDone:
-			// Having a write record for a path in MVHashmap doesn't necessarily mean there is a conflict, because MVHashmap
-			// is a superset of the actual write set.
-			// Check if the write record is actually in write set. If not, skip the key.
-			if mvResult.depIdx >= 0 && !lastInputOutput.HasWritten(mvResult.depIdx, rd.Path) {
-				continue
-			}
-
 			valid = rd.Kind == ReadKindMap && rd.V == Version{
 				TxnIndex:    mvResult.depIdx,
 				Incarnation: mvResult.incarnation,


### PR DESCRIPTION
A reverted transaction, X, can incorrectly write to a slot, which might be read by another transaction, Y. If we skip checking states written by X, then Y might end up with reading the wrong value and we won't be able to detect this error.

# Description

Please provide a detailed description of what was done in this PR

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
