### PR TITLE
DEVOPS-829 format Timer as summary/histogram type

### DIFF
--- a/metrics/prometheus/collector_test.go
+++ b/metrics/prometheus/collector_test.go
@@ -80,9 +80,6 @@ test_histogram_count 6
 # TYPE test_meter gauge
 test_meter 9999999
 
-# TYPE test_timer_count counter
-test_timer_count 6
-
 # TYPE test_timer summary
 test_timer {quantile="0.5"} 2.25e+07
 test_timer {quantile="0.75"} 4.8e+07
@@ -90,6 +87,8 @@ test_timer {quantile="0.95"} 1.2e+08
 test_timer {quantile="0.99"} 1.2e+08
 test_timer {quantile="0.999"} 1.2e+08
 test_timer {quantile="0.9999"} 1.2e+08
+test_timer_sum 550500000.000000
+test_timer_count 6
 
 # TYPE test_resetting_timer summary
 test_resetting_timer {quantile="0.50"} 12000000


### PR DESCRIPTION
# Description
Follow up PR to complete efforts from #881 as it did not produce the desired results. Digging in revealed that the metrics in question are registered as a [Timer](https://github.com/maticnetwork/bor/blob/develop/core/blockchain.go#L82), not as Summary. Timer metrics are not part of the defined [Prometheus metrics types](https://prometheus.io/docs/concepts/metric_types/). 

This PR updates the Timer metric type to format and display as a Prometheus Summary metric (which I think was the intended behavior all along), consistent with the changes introduced in #881. 
No breaking changes, all data previously presented by the metrics endpoint is still there. Formatting has been changed to follow Prometheus-type definitions, resulting in compatibility with the Open Telemetry Collector.


# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli
