### PR TITLE
Use `big.Int#Set` instead of `big.Int#SetBytes` when possible

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -381,8 +381,8 @@ func (st *StateTransition) TransitionDb(interruptCtx context.Context) (*Executio
 	if !st.noFeeBurnAndTip {
 		st.state.AddBalance(st.evm.Context.Coinbase, amount)
 
-		output1 := new(big.Int).SetBytes(input1.Bytes())
-		output2 := new(big.Int).SetBytes(input2.Bytes())
+		output1 := new(big.Int).Set(input1)
+		output2 := new(big.Int).Set(input2)
 
 		// Deprecating transfer log and will be removed in future fork. PLEASE DO NOT USE this transfer log going forward. Parameters won't get updated as expected going forward with EIP1559
 		// add transfer log


### PR DESCRIPTION
There is no reason to make the bytes transformation and back to big int to assign a big int to another one.

The `Set` method should be used instead.

# Description

Please provide a detailed description of what was done in this PR

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
- [X] Improvements non-breaking
