### PR TITLE
Fix worker `nil` pointer exception because of `baseFee == nil`

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -32,6 +32,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/holiman/uint256"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -672,7 +673,12 @@ func (w *worker) mainLoop(ctx context.Context) {
 					txs[acc] = append(txs[acc], tx)
 				}
 
-				txset := types.NewTransactionsByPriceAndNonce(w.current.signer, txs, cmath.FromBig(w.current.header.BaseFee))
+				var baseFee *uint256.Int
+				if w.current.header.BaseFee != nil {
+					baseFee = cmath.FromBig(w.current.header.BaseFee)
+				}
+
+				txset := types.NewTransactionsByPriceAndNonce(w.current.signer, txs, baseFee)
 				tcount := w.current.tcount
 
 				//nolint:contextcheck
@@ -1517,7 +1523,12 @@ func (w *worker) fillTransactions(ctx context.Context, interrupt *int32, env *en
 		var txs *types.TransactionsByPriceAndNonce
 
 		tracing.Exec(ctx, "", "worker.LocalTransactionsByPriceAndNonce", func(ctx context.Context, span trace.Span) {
-			txs = types.NewTransactionsByPriceAndNonce(env.signer, localTxs, cmath.FromBig(env.header.BaseFee))
+			var baseFee *uint256.Int
+			if env.header.BaseFee != nil {
+				baseFee = cmath.FromBig(env.header.BaseFee)
+			}
+
+			txs = types.NewTransactionsByPriceAndNonce(env.signer, localTxs, baseFee)
 
 			tracing.SetAttributes(
 				span,
@@ -1540,7 +1551,12 @@ func (w *worker) fillTransactions(ctx context.Context, interrupt *int32, env *en
 		var txs *types.TransactionsByPriceAndNonce
 
 		tracing.Exec(ctx, "", "worker.RemoteTransactionsByPriceAndNonce", func(ctx context.Context, span trace.Span) {
-			txs = types.NewTransactionsByPriceAndNonce(env.signer, remoteTxs, cmath.FromBig(env.header.BaseFee))
+			var baseFee *uint256.Int
+			if env.header.BaseFee != nil {
+				baseFee = cmath.FromBig(env.header.BaseFee)
+			}
+
+			txs = types.NewTransactionsByPriceAndNonce(env.signer, remoteTxs, baseFee)
 
 			tracing.SetAttributes(
 				span,


### PR DESCRIPTION
# Description

The `baseFee` can be `nil` in certain situations, the worker must not convert `baseFee` to `*big.Int` unless it was checked otherwise if such case happen, Go is going to panic:

```
goroutine 115 [running]:
math/big.(*Int).Bits(...)
	/opt/homebrew/Cellar/go/1.20.4/libexec/src/math/big/int.go:105
github.com/holiman/uint256.(*Int).SetFromBig(0x14001297410?, 0x107714520?)
	/Users/maoueh/go/pkg/mod/github.com/holiman/uint256@v1.2.0/conversion.go:102 +0x24
github.com/holiman/uint256.FromBig(...)
	/Users/maoueh/go/pkg/mod/github.com/holiman/uint256@v1.2.0/conversion.go:50
github.com/ethereum/go-ethereum/common/math.FromBig(0x1073923e0?)
	/Users/maoueh/work/sf/ethereum.chain/common/math/uint.go:20 +0x34
github.com/ethereum/go-ethereum/miner.(*worker).fillTransactions.func4({0x1400015c080?, 0x107827f08?}, {0x107836a40, 0x14000730be0})
	/Users/maoueh/work/sf/ethereum.chain/miner/worker.go:1521 +0x4c
github.com/ethereum/go-ethereum/common/tracing.Exec({0x107827f08, 0x140011b7020}, {0x0, 0x0}, {0x1066bde48, 0x27}, {0x140012975c0, 0x1, 0x0?})
	/Users/maoueh/work/sf/ethereum.chain/common/tracing/context.go:70 +0x1e4
github.com/ethereum/go-ethereum/miner.(*worker).fillTransactions(0x14000192780, {0x107827f08?, 0x140011b68d0?}, 0x1400060914c, 0x140002d4000, {0x107827e98, 0x1400005c0e8})
	/Users/maoueh/work/sf/ethereum.chain/miner/worker.go:1520 +0x1a4
github.com/ethereum/go-ethereum/miner.(*worker).commitWork(0x14000192780, {0x107827f08, 0x140011b6240}, 0x0?, 0x0, 0x6488d5f2)
	/Users/maoueh/work/sf/ethereum.chain/miner/worker.go:1663 +0x3e8
github.com/ethereum/go-ethereum/miner.(*worker).mainLoop(0x14000192780, {0x107827f08, 0x14000137290})
	/Users/maoueh/work/sf/ethereum.chain/miner/worker.go:603 +0x7e4
created by github.com/ethereum/go-ethereum/miner.newWorker
	/Users/maoueh/work/sf/ethereum.chain/miner/worker.go:344 +0x7e0
```


Please provide a detailed description of what was done in this PR

# Changes

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [X] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Ran a clique consensus engine mining node using Polygon codebase and send transactions to it, looking for the transactionReceipt of everything that has been pushed to chain.
