### PR TITLE
Fix Indore hardfork block in genesis-testnet-v4.json

### DIFF
--- a/builder/files/genesis-testnet-v4.json
+++ b/builder/files/genesis-testnet-v4.json
@@ -17,9 +17,9 @@
       "jaipurBlock": 22770000,
       "delhiBlock": 29638656,
       "parallelUniverseBlock": 0,
-      "indoreBlock": 36877056,
+      "indoreBlock": 37075456,
       "stateSyncConfirmationDelay": {
-        "36877056": 128
+        "37075456": 128
       },
       "period": {
         "0": 2,


### PR DESCRIPTION
Causes `bad block` errors after upgrade to 0.4.5-beta-5.

# Description

set `indoreBlock` to `37075456` in bor testnet genesis.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [X] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


### Manual tests

The upgraded nodes work as expected without `bad block` errors.

# Additional comments

Fixes https://github.com/maticnetwork/bor/issues/906
