### PR TITLE
Added Indore block and parallel universe for mainnet

### DIFF
--- a/builder/files/genesis-mainnet-v1.json
+++ b/builder/files/genesis-mainnet-v1.json
@@ -16,6 +16,11 @@
     "bor": {
       "jaipurBlock": 23850000,
       "delhiBlock": 38189056,
+      "parallelUniverseBlock": 0,
+      "indoreBlock": 44915456,
+      "stateSyncConfirmationDelay": {
+        "44915456": 128
+      },
       "period": {
         "0": 2
       },

--- a/internal/cli/server/chains/mainnet.go
+++ b/internal/cli/server/chains/mainnet.go
@@ -29,8 +29,13 @@ var mainnetBor = &Chain{
 			BerlinBlock:         big.NewInt(14750000),
 			LondonBlock:         big.NewInt(23850000),
 			Bor: &params.BorConfig{
-				JaipurBlock: big.NewInt(23850000),
-				DelhiBlock:  big.NewInt(38189056),
+				JaipurBlock:           big.NewInt(23850000),
+				DelhiBlock:            big.NewInt(38189056),
+				ParallelUniverseBlock: big.NewInt(0),
+				IndoreBlock:           big.NewInt(44915456),
+				StateSyncConfirmationDelay: map[string]uint64{
+					"44915456": 128,
+				},
 				Period: map[string]uint64{
 					"0": 2,
 				},

--- a/params/config.go
+++ b/params/config.go
@@ -412,6 +412,11 @@ var (
 			JaipurBlock:           big.NewInt(23850000),
 			DelhiBlock:            big.NewInt(38189056),
 			ParallelUniverseBlock: big.NewInt(0),
+			IndoreBlock:           big.NewInt(44915456),
+			StateSyncConfirmationDelay: map[string]uint64{
+				"44915456": 128,
+			},
+
 			Period: map[string]uint64{
 				"0": 2,
 			},


### PR DESCRIPTION
# Description

Added [Indore block](https://polygonscan.com/block/countdown/44915456) and parallel universe for mainnet for the Indore Hard Fork.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

This PR adds the Indore HF block number (state-sync bug) and also adds the parallel universe block (which enables parallel execution of transactions while verifying blocks).

# Nodes audience

Every mainnet node must update.

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
