### PR TITLE
add : statesync execution verbosity

### DIFF
--- a/consensus/bor/contract/client.go
+++ b/consensus/bor/contract/client.go
@@ -88,10 +88,13 @@ func (gc *GenesisContractsClient) CommitState(
 	}
 
 	msg := statefull.GetSystemMessage(common.HexToAddress(gc.StateReceiverContract), data)
+
+	log.Info("→ committing new state", "eventRecord", event.ID)
+
 	gasUsed, err := statefull.ApplyMessage(context.Background(), msg, state, header, gc.chainConfig, chCtx)
 
 	// Logging event log with time and individual gasUsed
-	log.Info("→ committing new state", "eventRecord", event.String(gasUsed))
+	log.Info("→ committed new state", "eventRecord", event.String(gasUsed))
 
 	if err != nil {
 		return 0, err

--- a/consensus/bor/statefull/processor.go
+++ b/consensus/bor/statefull/processor.go
@@ -77,6 +77,7 @@ func ApplyMessage(
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, state, chainConfig, vm.Config{})
 
+	// nolint : contextcheck
 	// Apply the transaction to the current state (included in the env)
 	ret, gasLeft, err := vmenv.Call(
 		vm.AccountRef(msg.From()),

--- a/consensus/bor/statefull/processor.go
+++ b/consensus/bor/statefull/processor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -77,7 +78,7 @@ func ApplyMessage(
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, state, chainConfig, vm.Config{})
 
 	// Apply the transaction to the current state (included in the env)
-	_, gasLeft, err := vmenv.Call(
+	ret, gasLeft, err := vmenv.Call(
 		vm.AccountRef(msg.From()),
 		*msg.To(),
 		msg.Data(),
@@ -85,6 +86,13 @@ func ApplyMessage(
 		msg.Value(),
 		nil,
 	)
+
+	success := big.NewInt(5).SetBytes(ret)
+
+	if success.Cmp(big.NewInt(0)) == 0 {
+		log.Error("message execution failed on contract", "msgData", msg.Data)
+	}
+
 	// Update the state with pending changes
 	if err != nil {
 		state.Finalise(true)


### PR DESCRIPTION
In this PR, we log the cases in which state-sync fails to commit a tx on the contract inner-call level.