### PR TITLE
fix: Improve RETESTBOR.md document formatting

### DIFF
--- a/RETESTBOR.md
+++ b/RETESTBOR.md
@@ -70,7 +70,7 @@ Eventually. these config needs to be adapted according to the following doc
 https://ethereum-tests.readthedocs.io/en/latest/retesteth-tutorial.html
 Specifically:  
 ``` 
-f you look inside ~/tests/config, you’ll see a directory for each configured client. Typically this directory has these files:
+If you look inside ~/tests/config, you’ll see a directory for each configured client. Typically this directory has these files:
 
 config, which contains the configuration for the client:
 The communication protocol to use with the client (typically TCP)

--- a/RETESTBOR.md
+++ b/RETESTBOR.md
@@ -65,22 +65,21 @@ ls
 ```
 ./dretesteth.sh -t GeneralStateTests/stExample --  --testpath /home/ubuntu/retestethBuild/tests --datadir /tests/config
 ```
-This will create the config files for the different clients in ~/tests/config
-Eventually. these config needs to be adapted according to the following doc  
-https://ethereum-tests.readthedocs.io/en/latest/retesteth-tutorial.html
-Specifically:  
-``` 
-If you look inside ~/tests/config, you’ll see a directory for each configured client. Typically this directory has these files:
+This will create the config files for the different clients in `~/tests/config`
+Eventually, these configuration files need to be adapted according to the following document:
 
-config, which contains the configuration for the client:
-The communication protocol to use with the client (typically TCP)
-The address(es) to use with that protocol
-The forks the client supports
-The exceptions the client can throw, and how retesteth should interpret them. This is particularly important when testing the client’s behavior when given invalid blocks.
-start.sh, which starts the client inside the docker image
-stop.sh, which stops the client instance(s)
-genesis, a directory which includes the genesis blocks for various forks the client supports. If this directory does not exist for a client, it uses the genesis blocks for the default client.
-```
+https://ethereum-tests.readthedocs.io/en/latest/retesteth-tutorial.html
+
+Specifically, if you look inside `~/tests/config`, you'll see a directory for each configured client. Typically this directory contains the following:
+
+* `config`: Contains the test configuration for the client
+    * The communication protocol to use with the client (typically TCP).
+    * The address(es) to use with that protocol.
+    * The forks supported by the client.
+    * The exceptions the client can throw, and how retesteth should interpret them. This is particularly important when testing the client's behavior when given invalid blocks.
+* `start.sh`: Starts the client inside the Docker image
+* `stop.sh`: Stops the client instance(s)
+* `genesis`: A directory which includes the genesis blocks for the various forks supported by the cient. If this directory does not exist for a client, it uses the genesis blocks for the default client.
 
 We replaced geth inside docker by using https://ethereum-tests.readthedocs.io/en/latest/retesteth-tutorial.html#replace-geth-inside-the-docker  
 Theoretically, we would not need any additional config change  


### PR DESCRIPTION
# Description

This is a minor documentation change. While reviewing the `RETESTBOR.md` file I noticed that the section describing the testing config file was a bit hard to follow. I restructured it to hopefully be a bit easier to read.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

