### PR TITLE
internal/cli: add db.engine flag

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -8,6 +8,7 @@ chain = "mainnet"
 # vmdebug = false
 datadir = "/var/lib/bor/data"
 # ancient = ""
+db.engine = "leveldb"
 # keystore = "/var/lib/bor/keystore"
 # "rpc.batchlimit" = 100
 # "rpc.returndatalimit" = 100000

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -8,6 +8,7 @@ verbosity = 3                   # Logging verbosity for the server (5=trace|4=de
 vmdebug = false                 # Record information useful for VM and contract debugging
 datadir = "var/lib/bor"         # Path of the data directory to store information
 ancient = ""                    # Data directory for ancient chain segments (default = inside chaindata)
+db.engine = "leveldb"           # Used to select leveldb or pebble as database (default = leveldb)
 keystore = ""                   # Path of the directory where keystores are located
 "rpc.batchlimit" = 100          # Maximum number of messages in a batch (default=100, use 0 for no limits)
 "rpc.returndatalimit" = 100000  # Maximum size (in bytes) a result of an rpc request could have (default=100000, use 0 for no limits)

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -18,6 +18,8 @@ The ```bor server``` command runs the Bor client.
 
 - ```datadir.ancient```: Data directory for ancient chain segments (default = inside chaindata)
 
+- ```db.engine```: Backing database implementation to use ('leveldb' or 'pebble') (default: leveldb)
+
 - ```keystore```: Path of the directory where keystores are located
 
 - ```rpc.batchlimit```: Maximum number of messages in a batch (default=100, use 0 for no limits) (default: 100)

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -67,6 +67,9 @@ type Config struct {
 	// Ancient is the directory to store the state in
 	Ancient string `hcl:"ancient,optional" toml:"ancient,optional"`
 
+	// DBEngine is used to select leveldb or pebble as database
+	DBEngine string `hcl:"dbengine,optional" toml:"dbengine,optional"`
+
 	// KeyStoreDir is the directory to store keystores
 	KeyStoreDir string `hcl:"keystore,optional" toml:"keystore,optional"`
 
@@ -1278,6 +1281,7 @@ func (c *Config) buildNode() (*node.Config, error) {
 	cfg := &node.Config{
 		Name:                  clientIdentifier,
 		DataDir:               c.DataDir,
+		DBEngine:              c.DBEngine,
 		KeyStoreDir:           c.KeyStoreDir,
 		UseLightweightKDF:     c.Accounts.UseLightweightKDF,
 		InsecureUnlockAllowed: c.Accounts.AllowInsecureUnlock,

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -595,6 +595,7 @@ func DefaultConfig() *Config {
 		EnablePreimageRecording: false,
 		DataDir:                 DefaultDataDir(),
 		Ancient:                 "",
+		DBEngine:                "leveldb",
 		Logging: &LoggingConfig{
 			Vmodule:   "",
 			Json:      false,

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -57,7 +57,7 @@ func (c *Command) Flags() *flagset.Flagset {
 		Name:    "db.engine",
 		Usage:   "Backing database implementation to use ('leveldb' or 'pebble')",
 		Value:   &c.cliConfig.DBEngine,
-		Default: "leveldb",
+		Default: c.cliConfig.DBEngine,
 	})
 	f.StringFlag(&flagset.StringFlag{
 		Name:  "keystore",

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -54,6 +54,12 @@ func (c *Command) Flags() *flagset.Flagset {
 		Default: c.cliConfig.Ancient,
 	})
 	f.StringFlag(&flagset.StringFlag{
+		Name:    "db.engine",
+		Usage:   "Backing database implementation to use ('leveldb' or 'pebble')",
+		Value:   &c.cliConfig.DBEngine,
+		Default: "leveldb",
+	})
+	f.StringFlag(&flagset.StringFlag{
 		Name:  "keystore",
 		Usage: "Path of the directory where keystores are located",
 		Value: &c.cliConfig.KeyStoreDir,

--- a/packaging/templates/mainnet-v1/archive/config.toml
+++ b/packaging/templates/mainnet-v1/archive/config.toml
@@ -4,6 +4,7 @@ chain = "mainnet"
 # vmdebug = false
 datadir = "/var/lib/bor/data"
 # ancient = ""
+# db.engine = "leveldb"
 # keystore = ""
 # "rpc.batchlimit" = 100
 # "rpc.returndatalimit" = 100000

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
@@ -4,6 +4,7 @@ chain = "mainnet"
 # vmdebug = false
 datadir = "/var/lib/bor/data"
 # ancient = ""
+# db.engine = "leveldb"
 # keystore = ""
 # "rpc.batchlimit" = 100
 # "rpc.returndatalimit" = 100000

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
@@ -6,6 +6,7 @@ chain = "mainnet"
 # vmdebug = false
 datadir = "/var/lib/bor/data"
 # ancient = ""
+# db.engine = "leveldb"
 # keystore = "$BOR_DIR/keystore"
 # "rpc.batchlimit" = 100
 # "rpc.returndatalimit" = 100000

--- a/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
@@ -6,6 +6,7 @@ chain = "mainnet"
 # vmdebug = false
 datadir = "/var/lib/bor/data"
 # ancient = ""
+# db.engine = "leveldb"
 # keystore = "$BOR_DIR/keystore"
 # "rpc.batchlimit" = 100
 # "rpc.returndatalimit" = 100000

--- a/packaging/templates/testnet-v4/archive/config.toml
+++ b/packaging/templates/testnet-v4/archive/config.toml
@@ -4,6 +4,7 @@ chain = "mumbai"
 # vmdebug = false
 datadir = "/var/lib/bor/data"
 # ancient = ""
+# db.engine = "leveldb"
 # keystore = ""
 # "rpc.batchlimit" = 100
 # "rpc.returndatalimit" = 100000

--- a/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
@@ -4,6 +4,7 @@ chain = "mumbai"
 # vmdebug = false
 datadir = "/var/lib/bor/data"
 # ancient = ""
+# db.engine = "leveldb"
 # keystore = ""
 # "rpc.batchlimit" = 100
 # "rpc.returndatalimit" = 100000

--- a/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
@@ -6,6 +6,7 @@ chain = "mumbai"
 # vmdebug = false
 datadir = "/var/lib/bor/data"
 # ancient = ""
+# db.engine = "leveldb"
 # keystore = "$BOR_DIR/keystore"
 # "rpc.batchlimit" = 100
 # "rpc.returndatalimit" = 100000

--- a/packaging/templates/testnet-v4/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/without-sentry/bor/config.toml
@@ -6,6 +6,7 @@ chain = "mumbai"
 # vmdebug = false
 datadir = "/var/lib/bor/data"
 # ancient = ""
+# db.engine = "leveldb"
 # keystore = "$BOR_DIR/keystore"
 # "rpc.batchlimit" = 100
 # "rpc.returndatalimit" = 100000


### PR DESCRIPTION
# Description

With recent changes in geth a new flag was introduced to select upon the database. We already have the required changes after upstream merge, I've just added the flag to select the database.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

N.A

# Nodes audience

N.A

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

I've tested it locally and it works well.

# Additional comments

[POS-1763](https://polygon.atlassian.net/browse/POS-1723)
