### PR TITLE
metrics/prometheus: fix count field of metric

### DIFF
--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -76,7 +76,7 @@ func (c *collector) addHistogram(name string, m metrics.Histogram) {
 	}
 
 	c.writeSummarySum(name, fmt.Sprintf("%f", sum))
-	c.writeSummaryCounter(name, len(ps))
+	c.writeSummaryCounter(name, m.Count())
 	c.buff.WriteRune('\n')
 }
 
@@ -97,7 +97,7 @@ func (c *collector) addTimer(name string, m metrics.Timer) {
 	}
 
 	c.writeSummarySum(name, fmt.Sprintf("%f", sum))
-	c.writeSummaryCounter(name, len(ps))
+	c.writeSummaryCounter(name, m.Count())
 	c.buff.WriteRune('\n')
 }
 

--- a/metrics/prometheus/collector_test.go
+++ b/metrics/prometheus/collector_test.go
@@ -49,6 +49,7 @@ func TestCollector(t *testing.T) {
 	timer.Update(120 * time.Millisecond)
 	timer.Update(23 * time.Millisecond)
 	timer.Update(24 * time.Millisecond)
+	timer.Update(30 * time.Millisecond)
 	c.addTimer("test/timer", timer)
 
 	resettingTimer := metrics.NewResettingTimer()
@@ -58,6 +59,7 @@ func TestCollector(t *testing.T) {
 	resettingTimer.Update(120 * time.Millisecond)
 	resettingTimer.Update(13 * time.Millisecond)
 	resettingTimer.Update(14 * time.Millisecond)
+	resettingTimer.Update(30 * time.Millisecond)
 	c.addResettingTimer("test/resetting_timer", resettingTimer.Snapshot())
 
 	emptyResettingTimer := metrics.NewResettingTimer().Snapshot()
@@ -83,27 +85,27 @@ test_histogram {quantile="0.99"} 0
 test_histogram {quantile="0.999"} 0
 test_histogram {quantile="0.9999"} 0
 test_histogram_sum 0.000000
-test_histogram_count 6
+test_histogram_count 0
 
 # TYPE test_meter gauge
 test_meter 9999999
 
 # TYPE test_timer summary
-test_timer {quantile="0.5"} 2.25e+07
-test_timer {quantile="0.75"} 4.8e+07
+test_timer {quantile="0.5"} 2.3e+07
+test_timer {quantile="0.75"} 3e+07
 test_timer {quantile="0.95"} 1.2e+08
 test_timer {quantile="0.99"} 1.2e+08
 test_timer {quantile="0.999"} 1.2e+08
 test_timer {quantile="0.9999"} 1.2e+08
-test_timer_sum 550500000.000000
-test_timer_count 6
+test_timer_sum 533000000.000000
+test_timer_count 7
 
 # TYPE test_resetting_timer summary
-test_resetting_timer {quantile="0.50"} 12000000
+test_resetting_timer {quantile="0.50"} 13000000
 test_resetting_timer {quantile="0.95"} 120000000
 test_resetting_timer {quantile="0.99"} 120000000
-test_resetting_timer_sum 180000000
-test_resetting_timer_count 6
+test_resetting_timer_sum 210000000
+test_resetting_timer_count 7
 
 `
 


### PR DESCRIPTION
# Description

With changes done in https://github.com/maticnetwork/bor/pull/881/ and https://github.com/maticnetwork/bor/pull/893/, the `count` field of a metric was added into summary and was calculated in wrong way. The tests didn't complain as they were updated in few places to cater to the new logic or the values according to the new logic vs old logic turned out to be same for the test case 

E.g. histogram count should be ideally 0 as no values are reported but it was changed to 6 which actually denotes the total percentile values reported. In case of timers, the values reported were 6 and the percentiles were also 6 so the test didn't catch this check. 

This PR updates (or actually reverts) the reporting of count metric. Instead of reporting count as `len(values)` where values are the total percentiles reported, we fetch it directly from `metric.Count()` function as earlier (and also similar to how geth does). 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
