### PR TITLE
ethclient: use `bor_getRootHash` instead of eth namespace

### DIFF
--- a/ethclient/bor_ethclient.go
+++ b/ethclient/bor_ethclient.go
@@ -11,7 +11,7 @@ import (
 // GetRootHash returns the merkle root of the block headers
 func (ec *Client) GetRootHash(ctx context.Context, startBlockNumber uint64, endBlockNumber uint64) (string, error) {
 	var rootHash string
-	if err := ec.c.CallContext(ctx, &rootHash, "eth_getRootHash", startBlockNumber, endBlockNumber); err != nil {
+	if err := ec.c.CallContext(ctx, &rootHash, "bor_getRootHash", startBlockNumber, endBlockNumber); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
# Description

Bor is flexible enough to also reply to the call `eth_getRootHash` even though it belongs to `bor` namespace. Hence, the eth client used to call `eth_getRootHash` instead of `bor_getRootHash` and it's being used in heimdall for checkpoints. This works for bor and heimdall but causes issue in erigon because when heimdall asks an erigon node for the root hash, it responds with `method not available` error as this method lies in the `bor` namespace in erigon rpc. This PR fixes it by just calling the `bor` namespace instead of `eth` so that heimdall can also communicate with erigon. 

Will also raise a PR in heimdall to use this version of bor. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
