### PR TITLE
fix : eth_getLogs

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2178,6 +2178,7 @@ func RegisterFilterAPI(stack *node.Node, backend ethapi.Backend, ethcfg *ethconf
 
 	// avoiding constructor changed by introducing new method to set genesis
 	filterAPI.SetChainConfig(ethcfg.Genesis.Config)
+
 	return filterSystem
 }
 

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -490,6 +490,7 @@ func TestInvalidGetLogsRequest(t *testing.T) {
 		api       = NewFilterAPI(sys, false, true)
 		blockHash = common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
 	)
+
 	api.SetChainConfig(params.BorUnittestChainConfig)
 
 	// Reason: Cannot specify both BlockHash and FromBlock/ToBlock)


### PR DESCRIPTION
In this PR, we fix the error response from `eth_getLogs` which was :
`{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"No chain config found. Proper PublicFilterAPI initialization required"}}`