### PR TITLE
miner/worker :: add : start commit work only after connecting to peers

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -351,6 +351,10 @@ func makeExtraData(extra []byte) []byte {
 	return extra
 }
 
+func (s *Ethereum) PeerCount() int {
+	return s.p2pServer.PeerCount()
+}
+
 // APIs return the collection of RPC services the ethereum package offers.
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (s *Ethereum) APIs() []rpc.API {

--- a/miner/fake_miner.go
+++ b/miner/fake_miner.go
@@ -172,6 +172,11 @@ type mockBackend struct {
 	txPool *txpool.TxPool
 }
 
+// PeerCount implements Backend.
+func (*mockBackend) PeerCount() int {
+	panic("unimplemented")
+}
+
 func NewMockBackend(bc *core.BlockChain, txPool *txpool.TxPool) *mockBackend {
 	return &mockBackend{
 		bc:     bc,

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -41,6 +41,7 @@ import (
 type Backend interface {
 	BlockChain() *core.BlockChain
 	TxPool() *txpool.TxPool
+	PeerCount() int
 }
 
 // Config is the configuration parameters of mining.

--- a/miner/test_backend.go
+++ b/miner/test_backend.go
@@ -95,6 +95,11 @@ type testWorkerBackend struct {
 	uncleBlock *types.Block
 }
 
+// PeerCount implements Backend.
+func (*testWorkerBackend) PeerCount() int {
+	panic("unimplemented")
+}
+
 func newTestWorkerBackend(t TensingObject, chainConfig *params.ChainConfig, engine consensus.Engine, db ethdb.Database, n int) *testWorkerBackend {
 	var gspec = core.Genesis{
 		Config:   chainConfig,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -658,7 +658,13 @@ func (w *worker) mainLoop(ctx context.Context) {
 		select {
 		case req := <-w.newWorkCh:
 			//nolint:contextcheck
-			w.commitWork(req.ctx, req.interrupt, req.noempty, req.timestamp)
+			if w.chainConfig.ChainID.Cmp(params.BorMainnetChainConfig.ChainID) == 0 || w.chainConfig.ChainID.Cmp(params.BorTestChainConfig.ChainID) == 0 {
+				if w.eth.PeerCount() > 0 {
+					w.commitWork(req.ctx, req.interrupt, req.noempty, req.timestamp)
+				}
+			} else {
+				w.commitWork(req.ctx, req.interrupt, req.noempty, req.timestamp)
+			}
 
 		case req := <-w.getWorkCh:
 			block, fees, err := w.generateWork(req.ctx, req.params)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -658,7 +658,7 @@ func (w *worker) mainLoop(ctx context.Context) {
 		select {
 		case req := <-w.newWorkCh:
 			//nolint:contextcheck
-			if w.chainConfig.ChainID.Cmp(params.BorMainnetChainConfig.ChainID) == 0 || w.chainConfig.ChainID.Cmp(params.BorTestChainConfig.ChainID) == 0 {
+			if w.chainConfig.ChainID.Cmp(params.BorMainnetChainConfig.ChainID) == 0 || w.chainConfig.ChainID.Cmp(params.MumbaiChainConfig.ChainID) == 0 {
 				if w.eth.PeerCount() > 0 {
 					w.commitWork(req.ctx, req.interrupt, req.noempty, req.timestamp)
 				}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -657,12 +657,13 @@ func (w *worker) mainLoop(ctx context.Context) {
 	for {
 		select {
 		case req := <-w.newWorkCh:
-			//nolint:contextcheck
 			if w.chainConfig.ChainID.Cmp(params.BorMainnetChainConfig.ChainID) == 0 || w.chainConfig.ChainID.Cmp(params.MumbaiChainConfig.ChainID) == 0 {
 				if w.eth.PeerCount() > 0 {
+					//nolint:contextcheck
 					w.commitWork(req.ctx, req.interrupt, req.noempty, req.timestamp)
 				}
 			} else {
+				//nolint:contextcheck
 				w.commitWork(req.ctx, req.interrupt, req.noempty, req.timestamp)
 			}
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -356,6 +356,10 @@ func (srv *Server) SetMaxPeers(maxPeers int) {
 
 // PeerCount returns the number of connected peers.
 func (srv *Server) PeerCount() int {
+	if !srv.running {
+		return 0
+	}
+
 	var count int
 
 	srv.doPeerOp(func(ps map[enode.ID]*Peer) {

--- a/params/config.go
+++ b/params/config.go
@@ -229,7 +229,7 @@ var (
 
 	// BorTestChainConfig contains the chain parameters to run a node on the Test network.
 	BorTestChainConfig = &ChainConfig{
-		ChainID:             big.NewInt(80001),
+		ChainID:             big.NewInt(80002),
 		HomesteadBlock:      big.NewInt(0),
 		DAOForkBlock:        nil,
 		DAOForkSupport:      true,
@@ -264,7 +264,7 @@ var (
 		},
 	}
 	BorUnittestChainConfig = &ChainConfig{
-		ChainID:             big.NewInt(80001),
+		ChainID:             big.NewInt(80003),
 		HomesteadBlock:      big.NewInt(0),
 		DAOForkBlock:        nil,
 		DAOForkSupport:      true,


### PR DESCRIPTION
In this PR, we wait for a validator node to connect to atleast 1 peer before starting to produce blocks. This helps in stopping the validator to creating its own fork which might later result in the entire networking getting reorged to that fork. This PR tries to improve the stability of the network. 

This is only implemented to work on `mainnet` and `mumbai`. It will not work on devnets/testnets. 