### PR TITLE
Add CLI flags to config LevelDB table/total sizes

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -195,7 +195,7 @@ func initGenesis(ctx *cli.Context) error {
 	defer stack.Close()
 
 	for _, name := range []string{"chaindata", "lightchaindata"} {
-		chaindb, err := stack.OpenDatabaseWithFreezer(name, 0, 0, ctx.String(utils.AncientFlag.Name), "", false, map[string]interface{}{})
+		chaindb, err := stack.OpenDatabaseWithFreezer(name, 0, 0, ctx.String(utils.AncientFlag.Name), "", false, rawdb.ExtraDBConfig{})
 		if err != nil {
 			utils.Fatalf("Failed to open database: %v", err)
 		}
@@ -229,7 +229,7 @@ func dumpGenesis(ctx *cli.Context) error {
 	// dump whatever already exists in the datadir
 	stack, _ := makeConfigNode(ctx)
 	for _, name := range []string{"chaindata", "lightchaindata"} {
-		db, err := stack.OpenDatabase(name, 0, 0, "", true, map[string]interface{}{})
+		db, err := stack.OpenDatabase(name, 0, 0, "", true, rawdb.ExtraDBConfig{})
 
 		if err != nil {
 			if !os.IsNotExist(err) {

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -195,7 +195,7 @@ func initGenesis(ctx *cli.Context) error {
 	defer stack.Close()
 
 	for _, name := range []string{"chaindata", "lightchaindata"} {
-		chaindb, err := stack.OpenDatabaseWithFreezer(name, 0, 0, ctx.String(utils.AncientFlag.Name), "", false)
+		chaindb, err := stack.OpenDatabaseWithFreezer(name, 0, 0, ctx.String(utils.AncientFlag.Name), "", false, map[string]interface{}{})
 		if err != nil {
 			utils.Fatalf("Failed to open database: %v", err)
 		}
@@ -229,7 +229,7 @@ func dumpGenesis(ctx *cli.Context) error {
 	// dump whatever already exists in the datadir
 	stack, _ := makeConfigNode(ctx)
 	for _, name := range []string{"chaindata", "lightchaindata"} {
-		db, err := stack.OpenDatabase(name, 0, 0, "", true)
+		db, err := stack.OpenDatabase(name, 0, 0, "", true, map[string]interface{}{})
 
 		if err != nil {
 			if !os.IsNotExist(err) {

--- a/cmd/geth/dao_test.go
+++ b/cmd/geth/dao_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -124,7 +123,7 @@ func testDAOForkBlockNewChain(t *testing.T, test int, genesis string, expectBloc
 	// Retrieve the DAO config flag from the database
 	path := filepath.Join(datadir, "geth", "chaindata")
 
-	db, err := rawdb.NewLevelDBDatabase(path, 0, 0, "", false, leveldb.LevelDBConfig{})
+	db, err := rawdb.NewLevelDBDatabase(path, 0, 0, "", false, rawdb.ExtraDBConfig{})
 	if err != nil {
 		t.Fatalf("test %d: failed to open test database: %v", test, err)
 	}

--- a/cmd/geth/dao_test.go
+++ b/cmd/geth/dao_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -123,7 +124,7 @@ func testDAOForkBlockNewChain(t *testing.T, test int, genesis string, expectBloc
 	// Retrieve the DAO config flag from the database
 	path := filepath.Join(datadir, "geth", "chaindata")
 
-	db, err := rawdb.NewLevelDBDatabase(path, 0, 0, "", false)
+	db, err := rawdb.NewLevelDBDatabase(path, 0, 0, "", false, leveldb.LevelDBConfig{})
 	if err != nil {
 		t.Fatalf("test %d: failed to open test database: %v", test, err)
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2313,7 +2313,7 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 		err     error
 		chainDb ethdb.Database
 
-		dbOptions = resolveDbOptions(ctx)
+		dbOptions = resolveExtraDBConfig(ctx)
 	)
 
 	switch {
@@ -2339,16 +2339,13 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 	return chainDb
 }
 
-func resolveDbOptions(ctx *cli.Context) map[string]interface{} {
-	dbOptions := map[string]interface{}{}
-
-	// Set LevelDB options
-	dbOptions["levelDbCompactionTableSize"] = ctx.Uint64(LevelDbCompactionTableSizeFlag.Name)
-	dbOptions["levelDbCompactionTableSizeMultiplier"] = ctx.Float64(LevelDbCompactionTableSizeMultiplierFlag.Name)
-	dbOptions["levelDbCompactionTotalSize"] = ctx.Uint64(LevelDbCompactionTotalSizeFlag.Name)
-	dbOptions["levelDbCompactionTotalSizeMultiplier"] = ctx.Float64(LevelDbCompactionTotalSizeMultiplierFlag.Name)
-
-	return dbOptions
+func resolveExtraDBConfig(ctx *cli.Context) rawdb.ExtraDBConfig {
+	return rawdb.ExtraDBConfig{
+		LevelDBCompactionTableSize:           ctx.Uint64(LevelDbCompactionTableSizeFlag.Name),
+		LevelDBCompactionTableSizeMultiplier: ctx.Float64(LevelDbCompactionTableSizeMultiplierFlag.Name),
+		LevelDBCompactionTotalSize:           ctx.Uint64(LevelDbCompactionTotalSizeFlag.Name),
+		LevelDBCompactionTotalSizeMultiplier: ctx.Float64(LevelDbCompactionTotalSizeMultiplierFlag.Name),
+	}
 }
 
 func IsNetworkPreset(ctx *cli.Context) bool {

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -193,7 +194,7 @@ func benchInsertChain(b *testing.B, disk bool, gen func(int, *BlockGen)) {
 	} else {
 		dir := b.TempDir()
 
-		db, err = rawdb.NewLevelDBDatabase(dir, 128, 128, "", false)
+		db, err = rawdb.NewLevelDBDatabase(dir, 128, 128, "", false, leveldb.LevelDBConfig{})
 		if err != nil {
 			b.Fatalf("cannot create temporary database: %v", err)
 		}
@@ -296,7 +297,7 @@ func makeChainForBench(db ethdb.Database, full bool, count uint64) {
 func benchWriteChain(b *testing.B, full bool, count uint64) {
 	for i := 0; i < b.N; i++ {
 		dir := b.TempDir()
-		db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false)
+		db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false, leveldb.LevelDBConfig{})
 
 		if err != nil {
 			b.Fatalf("error opening database at %v: %v", dir, err)
@@ -310,7 +311,7 @@ func benchWriteChain(b *testing.B, full bool, count uint64) {
 func benchReadChain(b *testing.B, full bool, count uint64) {
 	dir := b.TempDir()
 
-	db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false)
+	db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false, leveldb.LevelDBConfig{})
 	if err != nil {
 		b.Fatalf("error opening database at %v: %v", dir, err)
 	}
@@ -325,7 +326,7 @@ func benchReadChain(b *testing.B, full bool, count uint64) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false)
+		db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false, leveldb.LevelDBConfig{})
 		if err != nil {
 			b.Fatalf("error opening database at %v: %v", dir, err)
 		}

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -194,7 +193,7 @@ func benchInsertChain(b *testing.B, disk bool, gen func(int, *BlockGen)) {
 	} else {
 		dir := b.TempDir()
 
-		db, err = rawdb.NewLevelDBDatabase(dir, 128, 128, "", false, leveldb.LevelDBConfig{})
+		db, err = rawdb.NewLevelDBDatabase(dir, 128, 128, "", false, rawdb.ExtraDBConfig{})
 		if err != nil {
 			b.Fatalf("cannot create temporary database: %v", err)
 		}
@@ -297,7 +296,7 @@ func makeChainForBench(db ethdb.Database, full bool, count uint64) {
 func benchWriteChain(b *testing.B, full bool, count uint64) {
 	for i := 0; i < b.N; i++ {
 		dir := b.TempDir()
-		db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false, leveldb.LevelDBConfig{})
+		db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false, rawdb.ExtraDBConfig{})
 
 		if err != nil {
 			b.Fatalf("error opening database at %v: %v", dir, err)
@@ -311,7 +310,7 @@ func benchWriteChain(b *testing.B, full bool, count uint64) {
 func benchReadChain(b *testing.B, full bool, count uint64) {
 	dir := b.TempDir()
 
-	db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false, leveldb.LevelDBConfig{})
+	db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false, rawdb.ExtraDBConfig{})
 	if err != nil {
 		b.Fatalf("error opening database at %v: %v", dir, err)
 	}
@@ -326,7 +325,7 @@ func benchReadChain(b *testing.B, full bool, count uint64) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false, leveldb.LevelDBConfig{})
+		db, err := rawdb.NewLevelDBDatabase(dir, 128, 1024, "", false, rawdb.ExtraDBConfig{})
 		if err != nil {
 			b.Fatalf("error opening database at %v: %v", dir, err)
 		}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -394,9 +394,11 @@ func openKeyValueDatabase(o OpenOptions) (ethdb.Database, error) {
 		return nil, fmt.Errorf("unknown db.engine %v", o.Type)
 	}
 
-	log.Info("Using leveldb as the backing database")
-	leveldbConfig := resolveLevelDbConfig(o.DbOptions)
 	// Use leveldb, either as default (no explicit choice), or pre-existing, or chosen explicitly
+	log.Info("Using leveldb as the backing database")
+	
+	leveldbConfig := resolveLevelDbConfig(o.DbOptions)
+
 	return NewLevelDBDatabase(o.Directory, o.Cache, o.Handles, o.Namespace, o.ReadOnly, leveldbConfig)
 }
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -190,6 +190,16 @@ The ```bor server``` command runs the Bor client.
 
 - ```graphql```: Enable GraphQL on the HTTP-RPC server. Note that GraphQL can only be started if an HTTP server is started as well. (default: false)
 
+### LevelDb Options
+
+- ```leveldb.compaction.table.size```: LevelDB SSTable/file size in mebibytes (default: 2)
+
+- ```leveldb.compaction.table.size.multiplier```: Multiplier on LevelDB SSTable/file size. Size for a level is determined by: `leveldb.compaction.table.size * (leveldb.compaction.table.size.multiplier ^ Level)` (default: 1)
+
+- ```leveldb.compaction.total.size```: Total size in mebibytes of SSTables in a given LevelDB level. Size for a level is determined by: `leveldb.compaction.total.size * (leveldb.compaction.total.size.multiplier ^ Level)` (default: 10)
+
+- ```leveldb.compaction.total.size.multiplier```: Multiplier on level size on LevelDB levels. Size for a level is determined by: `leveldb.compaction.total.size * (leveldb.compaction.total.size.multiplier ^ Level)` (default: 10)
+
 ### Logging Options
 
 - ```vmodule```: Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=5,p2p=4)

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -126,6 +126,16 @@ The ```bor server``` command runs the Bor client.
 
 - ```fdlimit```: Raise the open file descriptor resource limit (default = system fd limit) (default: 0)
 
+### ExtraDB Options
+
+- ```leveldb.compaction.table.size```: LevelDB SSTable/file size in mebibytes (default: 2)
+
+- ```leveldb.compaction.table.size.multiplier```: Multiplier on LevelDB SSTable/file size. Size for a level is determined by: `leveldb.compaction.table.size * (leveldb.compaction.table.size.multiplier ^ Level)` (default: 1)
+
+- ```leveldb.compaction.total.size```: Total size in mebibytes of SSTables in a given LevelDB level. Size for a level is determined by: `leveldb.compaction.total.size * (leveldb.compaction.total.size.multiplier ^ Level)` (default: 10)
+
+- ```leveldb.compaction.total.size.multiplier```: Multiplier on level size on LevelDB levels. Size for a level is determined by: `leveldb.compaction.total.size * (leveldb.compaction.total.size.multiplier ^ Level)` (default: 10)
+
 ### JsonRPC Options
 
 - ```rpc.gascap```: Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite) (default: 50000000)
@@ -189,16 +199,6 @@ The ```bor server``` command runs the Bor client.
 - ```ws.ep-requesttimeout```: Request Timeout for rpc execution pool for WS requests (default: 0s)
 
 - ```graphql```: Enable GraphQL on the HTTP-RPC server. Note that GraphQL can only be started if an HTTP server is started as well. (default: false)
-
-### LevelDb Options
-
-- ```leveldb.compaction.table.size```: LevelDB SSTable/file size in mebibytes (default: 2)
-
-- ```leveldb.compaction.table.size.multiplier```: Multiplier on LevelDB SSTable/file size. Size for a level is determined by: `leveldb.compaction.table.size * (leveldb.compaction.table.size.multiplier ^ Level)` (default: 1)
-
-- ```leveldb.compaction.total.size```: Total size in mebibytes of SSTables in a given LevelDB level. Size for a level is determined by: `leveldb.compaction.total.size * (leveldb.compaction.total.size.multiplier ^ Level)` (default: 10)
-
-- ```leveldb.compaction.total.size.multiplier```: Multiplier on level size on LevelDB levels. Size for a level is determined by: `leveldb.compaction.total.size * (leveldb.compaction.total.size.multiplier ^ Level)` (default: 10)
 
 ### Logging Options
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -141,7 +141,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	log.Info("Allocated trie memory caches", "clean", common.StorageSize(config.TrieCleanCache)*1024*1024, "dirty", common.StorageSize(config.TrieDirtyCache)*1024*1024)
 
 	// Assemble the Ethereum object
-	chainDb, err := stack.OpenDatabaseWithFreezer("chaindata", config.DatabaseCache, config.DatabaseHandles, config.DatabaseFreezer, "ethereum/db/chaindata/", false)
+	dbOptions := resolveDbOptions(config)
+	chainDb, err := stack.OpenDatabaseWithFreezer("chaindata", config.DatabaseCache, config.DatabaseHandles, config.DatabaseFreezer, "ethereum/db/chaindata/", false, dbOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -330,6 +331,18 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	ethereum.shutdownTracker.MarkStartup()
 
 	return ethereum, nil
+}
+
+func resolveDbOptions(config *ethconfig.Config) map[string]interface{} {
+	dbOptions := map[string]interface{}{}
+
+	// Set LevelDB options
+	dbOptions["levelDbCompactionTableSize"] = config.LevelDbCompactionTableSize
+	dbOptions["levelDbCompactionTableSizeMultiplier"] = config.LevelDbCompactionTableSizeMultiplier
+	dbOptions["levelDbCompactionTotalSize"] = config.LevelDbCompactionTotalSize
+	dbOptions["levelDbCompactionTotalSizeMultiplier"] = config.LevelDbCompactionTotalSizeMultiplier
+
+	return dbOptions
 }
 
 func makeExtraData(extra []byte) []byte {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -141,8 +141,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	log.Info("Allocated trie memory caches", "clean", common.StorageSize(config.TrieCleanCache)*1024*1024, "dirty", common.StorageSize(config.TrieDirtyCache)*1024*1024)
 
 	// Assemble the Ethereum object
-	dbOptions := resolveDbOptions(config)
-	chainDb, err := stack.OpenDatabaseWithFreezer("chaindata", config.DatabaseCache, config.DatabaseHandles, config.DatabaseFreezer, "ethereum/db/chaindata/", false, dbOptions)
+	extraDBConfig := resolveExtraDBConfig(config)
+	chainDb, err := stack.OpenDatabaseWithFreezer("chaindata", config.DatabaseCache, config.DatabaseHandles, config.DatabaseFreezer, "ethereum/db/chaindata/", false, extraDBConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -333,16 +333,13 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	return ethereum, nil
 }
 
-func resolveDbOptions(config *ethconfig.Config) map[string]interface{} {
-	dbOptions := map[string]interface{}{}
-
-	// Set LevelDB options
-	dbOptions["levelDbCompactionTableSize"] = config.LevelDbCompactionTableSize
-	dbOptions["levelDbCompactionTableSizeMultiplier"] = config.LevelDbCompactionTableSizeMultiplier
-	dbOptions["levelDbCompactionTotalSize"] = config.LevelDbCompactionTotalSize
-	dbOptions["levelDbCompactionTotalSizeMultiplier"] = config.LevelDbCompactionTotalSizeMultiplier
-
-	return dbOptions
+func resolveExtraDBConfig(config *ethconfig.Config) rawdb.ExtraDBConfig {
+	return rawdb.ExtraDBConfig{
+		LevelDBCompactionTableSize:           config.LevelDbCompactionTableSize,
+		LevelDBCompactionTableSizeMultiplier: config.LevelDbCompactionTableSizeMultiplier,
+		LevelDBCompactionTotalSize:           config.LevelDbCompactionTotalSize,
+		LevelDBCompactionTotalSizeMultiplier: config.LevelDbCompactionTotalSizeMultiplier,
+	}
 }
 
 func makeExtraData(extra []byte) []byte {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -169,6 +169,12 @@ type Config struct {
 	DatabaseCache      int
 	DatabaseFreezer    string
 
+	// Database - LevelDB options
+	LevelDbCompactionTableSize           uint64
+	LevelDbCompactionTableSizeMultiplier float64
+	LevelDbCompactionTotalSize           uint64
+	LevelDbCompactionTotalSizeMultiplier float64
+
 	TrieCleanCache          int
 	TrieCleanCacheJournal   string        `toml:",omitempty"` // Disk journal directory for trie cache to survive node restarts
 	TrieCleanCacheRejournal time.Duration `toml:",omitempty"` // Time interval to regenerate the journal for clean cache

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/node"
 )
 
@@ -69,7 +68,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 
 	b.Log("Running bloombits benchmark   section size:", sectionSize)
 
-	db, err := rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false, leveldb.LevelDBConfig{})
+	db, err := rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false, rawdb.ExtraDBConfig{})
 	if err != nil {
 		b.Fatalf("error opening database at %v: %v", benchDataDir, err)
 	}
@@ -146,7 +145,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 	for i := 0; i < benchFilterCnt; i++ {
 		if i%20 == 0 {
 			db.Close()
-			db, _ = rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false, leveldb.LevelDBConfig{})
+			db, _ = rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false, rawdb.ExtraDBConfig{})
 			backend = &testBackend{db: db, sections: cnt}
 			sys = NewFilterSystem(backend, Config{})
 		}
@@ -188,7 +187,7 @@ func BenchmarkNoBloomBits(b *testing.B) {
 
 	b.Log("Running benchmark without bloombits")
 
-	db, err := rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false, leveldb.LevelDBConfig{})
+	db, err := rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false, rawdb.ExtraDBConfig{})
 	if err != nil {
 		b.Fatalf("error opening database at %v: %v", benchDataDir, err)
 	}

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/node"
 )
 
@@ -68,7 +69,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 
 	b.Log("Running bloombits benchmark   section size:", sectionSize)
 
-	db, err := rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false)
+	db, err := rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false, leveldb.LevelDBConfig{})
 	if err != nil {
 		b.Fatalf("error opening database at %v: %v", benchDataDir, err)
 	}
@@ -145,7 +146,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 	for i := 0; i < benchFilterCnt; i++ {
 		if i%20 == 0 {
 			db.Close()
-			db, _ = rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false)
+			db, _ = rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false, leveldb.LevelDBConfig{})
 			backend = &testBackend{db: db, sections: cnt}
 			sys = NewFilterSystem(backend, Config{})
 		}
@@ -187,7 +188,7 @@ func BenchmarkNoBloomBits(b *testing.B) {
 
 	b.Log("Running benchmark without bloombits")
 
-	db, err := rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false)
+	db, err := rawdb.NewLevelDBDatabase(benchDataDir, 128, 1024, "", false, leveldb.LevelDBConfig{})
 	if err != nil {
 		b.Fatalf("error opening database at %v: %v", benchDataDir, err)
 	}

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -43,7 +44,7 @@ func makeReceipt(addr common.Address) *types.Receipt {
 
 func BenchmarkFilters(b *testing.B) {
 	var (
-		db, _   = rawdb.NewLevelDBDatabase(b.TempDir(), 0, 0, "", false)
+		db, _   = rawdb.NewLevelDBDatabase(b.TempDir(), 0, 0, "", false, leveldb.LevelDBConfig{})
 		_, sys  = newTestFilterSystem(b, db, Config{})
 		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
@@ -106,7 +107,7 @@ func BenchmarkFilters(b *testing.B) {
 
 func TestFilters(t *testing.T) {
 	var (
-		db, _   = rawdb.NewLevelDBDatabase(t.TempDir(), 0, 0, "", false)
+		db, _   = rawdb.NewLevelDBDatabase(t.TempDir(), 0, 0, "", false, leveldb.LevelDBConfig{})
 		_, sys  = newTestFilterSystem(t, db, Config{})
 		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr    = crypto.PubkeyToAddress(key1.PublicKey)

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -44,7 +43,7 @@ func makeReceipt(addr common.Address) *types.Receipt {
 
 func BenchmarkFilters(b *testing.B) {
 	var (
-		db, _   = rawdb.NewLevelDBDatabase(b.TempDir(), 0, 0, "", false, leveldb.LevelDBConfig{})
+		db, _   = rawdb.NewLevelDBDatabase(b.TempDir(), 0, 0, "", false, rawdb.ExtraDBConfig{})
 		_, sys  = newTestFilterSystem(b, db, Config{})
 		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
@@ -107,7 +106,7 @@ func BenchmarkFilters(b *testing.B) {
 
 func TestFilters(t *testing.T) {
 	var (
-		db, _   = rawdb.NewLevelDBDatabase(t.TempDir(), 0, 0, "", false, leveldb.LevelDBConfig{})
+		db, _   = rawdb.NewLevelDBDatabase(t.TempDir(), 0, 0, "", false, rawdb.ExtraDBConfig{})
 		_, sys  = newTestFilterSystem(t, db, Config{})
 		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr    = crypto.PubkeyToAddress(key1.PublicKey)

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -84,10 +84,10 @@ type Database struct {
 }
 
 type LevelDBConfig struct {
-	CompactionTableSize           uint64
-	CompactionTableSizeMultiplier float64
-	CompactionTotalSize           uint64
-	CompactionTotalSizeMultiplier float64
+	CompactionTableSize           uint64  // LevelDB SSTable/file size in mebibytes
+	CompactionTableSizeMultiplier float64 // Multiplier on LevelDB SSTable/file size
+	CompactionTotalSize           uint64  // Total size in mebibytes of SSTables in a given LevelDB level
+	CompactionTotalSizeMultiplier float64 // Multiplier on level size on LevelDB levels
 }
 
 // New returns a wrapped LevelDB object. The namespace is the prefix that the

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -83,9 +83,16 @@ type Database struct {
 	log log.Logger // Contextual logger tracking the database path
 }
 
+type LevelDBConfig struct {
+	CompactionTableSize           uint64
+	CompactionTableSizeMultiplier float64
+	CompactionTotalSize           uint64
+	CompactionTotalSizeMultiplier float64
+}
+
 // New returns a wrapped LevelDB object. The namespace is the prefix that the
 // metrics reporting should use for surfacing internal stats.
-func New(file string, cache int, handles int, namespace string, readonly bool) (*Database, error) {
+func New(file string, cache int, handles int, namespace string, readonly bool, config LevelDBConfig) (*Database, error) {
 	return NewCustom(file, namespace, func(options *opt.Options) {
 		// Ensure we have some minimal caching and file guarantees
 		if cache < minCache {
@@ -99,6 +106,22 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 		options.OpenFilesCacheCapacity = handles
 		options.BlockCacheCapacity = cache / 2 * opt.MiB
 		options.WriteBuffer = cache / 4 * opt.MiB // Two of these are used internally
+
+		if config.CompactionTableSize != 0 {
+			options.CompactionTableSize = int(config.CompactionTableSize * opt.MiB)
+		}
+
+		if config.CompactionTableSizeMultiplier != 0 {
+			options.CompactionTableSizeMultiplier = config.CompactionTableSizeMultiplier
+		}
+
+		if config.CompactionTotalSize != 0 {
+			options.CompactionTotalSize = int(config.CompactionTotalSize * opt.MiB)
+		}
+
+		if config.CompactionTotalSizeMultiplier != 0 {
+			options.CompactionTotalSizeMultiplier = config.CompactionTotalSizeMultiplier
+		}
 
 		if readonly {
 			options.ReadOnly = true
@@ -114,7 +137,14 @@ func NewCustom(file string, namespace string, customize func(options *opt.Option
 	logger := log.New("database", file)
 	usedCache := options.GetBlockCacheCapacity() + options.GetWriteBuffer()*2
 
-	logCtx := []interface{}{"cache", common.StorageSize(usedCache), "handles", options.GetOpenFilesCacheCapacity()}
+	logCtx := []interface{}{
+		"cache", common.StorageSize(usedCache),
+		"handles", options.GetOpenFilesCacheCapacity(),
+		"compactionTableSize", options.CompactionTableSize,
+		"compactionTableSizeMultiplier", options.CompactionTableSizeMultiplier,
+		"compactionTotalSize", options.CompactionTotalSize,
+		"compactionTotalSizeMultiplier", options.CompactionTotalSizeMultiplier}
+
 	if options.ReadOnly {
 		logCtx = append(logCtx, "readonly", "true")
 	}

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -121,7 +121,7 @@ type Config struct {
 	// Cache has the cache related settings
 	Cache *CacheConfig `hcl:"cache,block" toml:"cache,block"`
 
-	LevelDb *LevelDbConfig `hcl:"leveldb,block" toml:"leveldb,block"`
+	ExtraDB *ExtraDBConfig `hcl:"leveldb,block" toml:"leveldb,block"`
 
 	// Account has the validator account related settings
 	Accounts *AccountsConfig `hcl:"accounts,block" toml:"accounts,block"`
@@ -553,7 +553,7 @@ type CacheConfig struct {
 	FDLimit int `hcl:"fdlimit,optional" toml:"fdlimit,optional"`
 }
 
-type LevelDbConfig struct {
+type ExtraDBConfig struct {
 	LevelDbCompactionTableSize           uint64  `hcl:"compactiontablesize,optional" toml:"compactiontablesize,optional"`
 	LevelDbCompactionTableSizeMultiplier float64 `hcl:"compactiontablesizemultiplier,optional" toml:"compactiontablesizemultiplier,optional"`
 	LevelDbCompactionTotalSize           uint64  `hcl:"compactiontotalsize,optional" toml:"compactiontotalsize,optional"`
@@ -751,7 +751,7 @@ func DefaultConfig() *Config {
 			TrieTimeout:   60 * time.Minute,
 			FDLimit:       0,
 		},
-		LevelDb: &LevelDbConfig{
+		ExtraDB: &ExtraDBConfig{
 			// These are LevelDB defaults, specifying here for clarity in code and in logging.
 			// See: https://github.com/syndtr/goleveldb/blob/126854af5e6d8295ef8e8bee3040dd8380ae72e8/leveldb/opt/options.go
 			LevelDbCompactionTableSize:           2, // MiB
@@ -1120,10 +1120,10 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 
 	// LevelDB
 	{
-		n.LevelDbCompactionTableSize = c.LevelDb.LevelDbCompactionTableSize
-		n.LevelDbCompactionTableSizeMultiplier = c.LevelDb.LevelDbCompactionTableSizeMultiplier
-		n.LevelDbCompactionTotalSize = c.LevelDb.LevelDbCompactionTotalSize
-		n.LevelDbCompactionTotalSizeMultiplier = c.LevelDb.LevelDbCompactionTotalSizeMultiplier
+		n.LevelDbCompactionTableSize = c.ExtraDB.LevelDbCompactionTableSize
+		n.LevelDbCompactionTableSizeMultiplier = c.ExtraDB.LevelDbCompactionTableSizeMultiplier
+		n.LevelDbCompactionTotalSize = c.ExtraDB.LevelDbCompactionTotalSize
+		n.LevelDbCompactionTotalSizeMultiplier = c.ExtraDB.LevelDbCompactionTotalSizeMultiplier
 	}
 
 	n.RPCGasCap = c.JsonRPC.GasCap

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -452,30 +452,30 @@ func (c *Command) Flags() *flagset.Flagset {
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "leveldb.compaction.table.size",
 		Usage:   "LevelDB SSTable/file size in mebibytes",
-		Value:   &c.cliConfig.LevelDb.LevelDbCompactionTableSize,
-		Default: c.cliConfig.LevelDb.LevelDbCompactionTableSize,
-		Group:   "LevelDb",
+		Value:   &c.cliConfig.ExtraDB.LevelDbCompactionTableSize,
+		Default: c.cliConfig.ExtraDB.LevelDbCompactionTableSize,
+		Group:   "ExtraDB",
 	})
 	f.Float64Flag(&flagset.Float64Flag{
 		Name:    "leveldb.compaction.table.size.multiplier",
 		Usage:   "Multiplier on LevelDB SSTable/file size. Size for a level is determined by: `leveldb.compaction.table.size * (leveldb.compaction.table.size.multiplier ^ Level)`",
-		Value:   &c.cliConfig.LevelDb.LevelDbCompactionTableSizeMultiplier,
-		Default: c.cliConfig.LevelDb.LevelDbCompactionTableSizeMultiplier,
-		Group:   "LevelDb",
+		Value:   &c.cliConfig.ExtraDB.LevelDbCompactionTableSizeMultiplier,
+		Default: c.cliConfig.ExtraDB.LevelDbCompactionTableSizeMultiplier,
+		Group:   "ExtraDB",
 	})
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "leveldb.compaction.total.size",
 		Usage:   "Total size in mebibytes of SSTables in a given LevelDB level. Size for a level is determined by: `leveldb.compaction.total.size * (leveldb.compaction.total.size.multiplier ^ Level)`",
-		Value:   &c.cliConfig.LevelDb.LevelDbCompactionTotalSize,
-		Default: c.cliConfig.LevelDb.LevelDbCompactionTotalSize,
-		Group:   "LevelDb",
+		Value:   &c.cliConfig.ExtraDB.LevelDbCompactionTotalSize,
+		Default: c.cliConfig.ExtraDB.LevelDbCompactionTotalSize,
+		Group:   "ExtraDB",
 	})
 	f.Float64Flag(&flagset.Float64Flag{
 		Name:    "leveldb.compaction.total.size.multiplier",
 		Usage:   "Multiplier on level size on LevelDB levels. Size for a level is determined by: `leveldb.compaction.total.size * (leveldb.compaction.total.size.multiplier ^ Level)`",
-		Value:   &c.cliConfig.LevelDb.LevelDbCompactionTotalSizeMultiplier,
-		Default: c.cliConfig.LevelDb.LevelDbCompactionTotalSizeMultiplier,
-		Group:   "LevelDb",
+		Value:   &c.cliConfig.ExtraDB.LevelDbCompactionTotalSizeMultiplier,
+		Default: c.cliConfig.ExtraDB.LevelDbCompactionTotalSizeMultiplier,
+		Group:   "ExtraDB",
 	})
 
 	// rpc options

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -448,6 +448,36 @@ func (c *Command) Flags() *flagset.Flagset {
 		Group:   "Cache",
 	})
 
+	// LevelDB options
+	f.Uint64Flag(&flagset.Uint64Flag{
+		Name:    "leveldb.compaction.table.size",
+		Usage:   "LevelDB SSTable/file size in mebibytes",
+		Value:   &c.cliConfig.LevelDb.LevelDbCompactionTableSize,
+		Default: c.cliConfig.LevelDb.LevelDbCompactionTableSize,
+		Group:   "LevelDb",
+	})
+	f.Float64Flag(&flagset.Float64Flag{
+		Name:    "leveldb.compaction.table.size.multiplier",
+		Usage:   "Multiplier on LevelDB SSTable/file size. Size for a level is determined by: `leveldb.compaction.table.size * (leveldb.compaction.table.size.multiplier ^ Level)`",
+		Value:   &c.cliConfig.LevelDb.LevelDbCompactionTableSizeMultiplier,
+		Default: c.cliConfig.LevelDb.LevelDbCompactionTableSizeMultiplier,
+		Group:   "LevelDb",
+	})
+	f.Uint64Flag(&flagset.Uint64Flag{
+		Name:    "leveldb.compaction.total.size",
+		Usage:   "Total size in mebibytes of SSTables in a given LevelDB level. Size for a level is determined by: `leveldb.compaction.total.size * (leveldb.compaction.total.size.multiplier ^ Level)`",
+		Value:   &c.cliConfig.LevelDb.LevelDbCompactionTotalSize,
+		Default: c.cliConfig.LevelDb.LevelDbCompactionTotalSize,
+		Group:   "LevelDb",
+	})
+	f.Float64Flag(&flagset.Float64Flag{
+		Name:    "leveldb.compaction.total.size.multiplier",
+		Usage:   "Multiplier on level size on LevelDB levels. Size for a level is determined by: `leveldb.compaction.total.size * (leveldb.compaction.total.size.multiplier ^ Level)`",
+		Value:   &c.cliConfig.LevelDb.LevelDbCompactionTotalSizeMultiplier,
+		Default: c.cliConfig.LevelDb.LevelDbCompactionTotalSizeMultiplier,
+		Group:   "LevelDb",
+	})
+
 	// rpc options
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "rpc.gascap",

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -161,7 +161,7 @@ func (c *PruneStateCommand) Run(args []string) int {
 		return 1
 	}
 
-	chaindb, err := node.OpenDatabaseWithFreezer(chaindataPath, int(c.cache), dbHandles, c.datadirAncient, "", false)
+	chaindb, err := node.OpenDatabaseWithFreezer(chaindataPath, int(c.cache), dbHandles, c.datadirAncient, "", false, map[string]interface{}{})
 
 	if err != nil {
 		c.UI.Error(err.Error())

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/pruner"
 	"github.com/ethereum/go-ethereum/internal/cli/flagset"
 	"github.com/ethereum/go-ethereum/internal/cli/server"
@@ -161,7 +162,7 @@ func (c *PruneStateCommand) Run(args []string) int {
 		return 1
 	}
 
-	chaindb, err := node.OpenDatabaseWithFreezer(chaindataPath, int(c.cache), dbHandles, c.datadirAncient, "", false, map[string]interface{}{})
+	chaindb, err := node.OpenDatabaseWithFreezer(chaindataPath, int(c.cache), dbHandles, c.datadirAncient, "", false, rawdb.ExtraDBConfig{})
 
 	if err != nil {
 		c.UI.Error(err.Error())

--- a/les/client.go
+++ b/les/client.go
@@ -86,12 +86,14 @@ type LightEthereum struct {
 
 // New creates an instance of the light client.
 func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
-	chainDb, err := stack.OpenDatabase("lightchaindata", config.DatabaseCache, config.DatabaseHandles, "eth/db/chaindata/", false)
+	dbOptions := resolveDbOptions(config)
+
+	chainDb, err := stack.OpenDatabase("lightchaindata", config.DatabaseCache, config.DatabaseHandles, "eth/db/chaindata/", false, dbOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	lesDb, err := stack.OpenDatabase("les.client", 0, 0, "eth/db/lesclient/", false)
+	lesDb, err := stack.OpenDatabase("les.client", 0, 0, "eth/db/lesclient/", false, dbOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -222,6 +224,18 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	leth.shutdownTracker.MarkStartup()
 
 	return leth, nil
+}
+
+func resolveDbOptions(config *ethconfig.Config) map[string]interface{} {
+	dbOptions := map[string]interface{}{}
+
+	// Set LevelDB options
+	dbOptions["levelDbCompactionTableSize"] = config.LevelDbCompactionTableSize
+	dbOptions["levelDbCompactionTableSizeMultiplier"] = config.LevelDbCompactionTableSizeMultiplier
+	dbOptions["levelDbCompactionTotalSize"] = config.LevelDbCompactionTotalSize
+	dbOptions["levelDbCompactionTotalSizeMultiplier"] = config.LevelDbCompactionTotalSizeMultiplier
+
+	return dbOptions
 }
 
 // VfluxRequest sends a batch of requests to the given node through discv5 UDP TalkRequest and returns the responses

--- a/les/client.go
+++ b/les/client.go
@@ -86,14 +86,14 @@ type LightEthereum struct {
 
 // New creates an instance of the light client.
 func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
-	dbOptions := resolveDbOptions(config)
+	extraDBConfig := resolveExtraDBConfig(config)
 
-	chainDb, err := stack.OpenDatabase("lightchaindata", config.DatabaseCache, config.DatabaseHandles, "eth/db/chaindata/", false, dbOptions)
+	chainDb, err := stack.OpenDatabase("lightchaindata", config.DatabaseCache, config.DatabaseHandles, "eth/db/chaindata/", false, extraDBConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	lesDb, err := stack.OpenDatabase("les.client", 0, 0, "eth/db/lesclient/", false, dbOptions)
+	lesDb, err := stack.OpenDatabase("les.client", 0, 0, "eth/db/lesclient/", false, extraDBConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -226,16 +226,13 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	return leth, nil
 }
 
-func resolveDbOptions(config *ethconfig.Config) map[string]interface{} {
-	dbOptions := map[string]interface{}{}
-
-	// Set LevelDB options
-	dbOptions["levelDbCompactionTableSize"] = config.LevelDbCompactionTableSize
-	dbOptions["levelDbCompactionTableSizeMultiplier"] = config.LevelDbCompactionTableSizeMultiplier
-	dbOptions["levelDbCompactionTotalSize"] = config.LevelDbCompactionTotalSize
-	dbOptions["levelDbCompactionTotalSizeMultiplier"] = config.LevelDbCompactionTotalSizeMultiplier
-
-	return dbOptions
+func resolveExtraDBConfig(config *ethconfig.Config) rawdb.ExtraDBConfig {
+	return rawdb.ExtraDBConfig{
+		LevelDBCompactionTableSize:           config.LevelDbCompactionTableSize,
+		LevelDBCompactionTableSizeMultiplier: config.LevelDbCompactionTableSizeMultiplier,
+		LevelDBCompactionTotalSize:           config.LevelDbCompactionTotalSize,
+		LevelDBCompactionTotalSizeMultiplier: config.LevelDbCompactionTotalSizeMultiplier,
+	}
 }
 
 // VfluxRequest sends a batch of requests to the given node through discv5 UDP TalkRequest and returns the responses

--- a/les/server.go
+++ b/les/server.go
@@ -78,7 +78,7 @@ type LesServer struct {
 }
 
 func NewLesServer(node *node.Node, e ethBackend, config *ethconfig.Config) (*LesServer, error) {
-	dbOptions := resolveDbOptions(config)
+	dbOptions := resolveExtraDBConfig(config)
 	lesDb, err := node.OpenDatabase("les.server", 0, 0, "eth/db/lesserver/", false, dbOptions)
 	if err != nil {
 		return nil, err

--- a/les/server.go
+++ b/les/server.go
@@ -78,7 +78,8 @@ type LesServer struct {
 }
 
 func NewLesServer(node *node.Node, e ethBackend, config *ethconfig.Config) (*LesServer, error) {
-	lesDb, err := node.OpenDatabase("les.server", 0, 0, "eth/db/lesserver/", false)
+	dbOptions := resolveDbOptions(config)
+	lesDb, err := node.OpenDatabase("les.server", 0, 0, "eth/db/lesserver/", false, dbOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -771,7 +771,7 @@ func (n *Node) EventMux() *event.TypeMux {
 // OpenDatabase opens an existing database with the given name (or creates one if no
 // previous can be found) from within the node's instance directory. If the node is
 // ephemeral, a memory database is returned.
-func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, readonly bool) (ethdb.Database, error) {
+func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, readonly bool, dbOptions map[string]interface{}) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 
@@ -793,6 +793,7 @@ func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, r
 			Cache:     cache,
 			Handles:   handles,
 			ReadOnly:  readonly,
+			DbOptions: dbOptions,
 		})
 	}
 
@@ -808,7 +809,7 @@ func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, r
 // also attaching a chain freezer to it that moves ancient chain data from the
 // database to immutable append-only files. If the node is an ephemeral one, a
 // memory database is returned.
-func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, ancient string, namespace string, readonly bool) (ethdb.Database, error) {
+func (n *Node) OpenDatabaseWithFreezer(name string, cache int, handles int, ancient string, namespace string, readonly bool, dbOptions map[string]interface{}) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 
@@ -831,6 +832,7 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, ancient 
 			Cache:             cache,
 			Handles:           handles,
 			ReadOnly:          readonly,
+			DbOptions:         dbOptions,
 		})
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -771,7 +771,7 @@ func (n *Node) EventMux() *event.TypeMux {
 // OpenDatabase opens an existing database with the given name (or creates one if no
 // previous can be found) from within the node's instance directory. If the node is
 // ephemeral, a memory database is returned.
-func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, readonly bool, dbOptions map[string]interface{}) (ethdb.Database, error) {
+func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, readonly bool, extraDBConfig rawdb.ExtraDBConfig) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 
@@ -787,13 +787,13 @@ func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, r
 		db = rawdb.NewMemoryDatabase()
 	} else {
 		db, err = rawdb.Open(rawdb.OpenOptions{
-			Type:      n.config.DBEngine,
-			Directory: n.ResolvePath(name),
-			Namespace: namespace,
-			Cache:     cache,
-			Handles:   handles,
-			ReadOnly:  readonly,
-			DbOptions: dbOptions,
+			Type:          n.config.DBEngine,
+			Directory:     n.ResolvePath(name),
+			Namespace:     namespace,
+			Cache:         cache,
+			Handles:       handles,
+			ReadOnly:      readonly,
+			ExtraDBConfig: extraDBConfig,
 		})
 	}
 
@@ -809,7 +809,7 @@ func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, r
 // also attaching a chain freezer to it that moves ancient chain data from the
 // database to immutable append-only files. If the node is an ephemeral one, a
 // memory database is returned.
-func (n *Node) OpenDatabaseWithFreezer(name string, cache int, handles int, ancient string, namespace string, readonly bool, dbOptions map[string]interface{}) (ethdb.Database, error) {
+func (n *Node) OpenDatabaseWithFreezer(name string, cache int, handles int, ancient string, namespace string, readonly bool, extraDBConfig rawdb.ExtraDBConfig) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 
@@ -832,7 +832,7 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache int, handles int, anci
 			Cache:             cache,
 			Handles:           handles,
 			ReadOnly:          readonly,
-			DbOptions:         dbOptions,
+			ExtraDBConfig:     extraDBConfig,
 		})
 	}
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rpc"
 
@@ -157,7 +158,7 @@ func TestNodeCloseClosesDB(t *testing.T) {
 	stack, _ := New(testNodeConfig())
 	defer stack.Close()
 
-	db, err := stack.OpenDatabase("mydb", 0, 0, "", false)
+	db, err := stack.OpenDatabase("mydb", 0, leveldb.LevelDBConfig{}, 0, "", false)
 	if err != nil {
 		t.Fatal("can't open DB:", err)
 	}
@@ -184,7 +185,7 @@ func TestNodeOpenDatabaseFromLifecycleStart(t *testing.T) {
 
 	stack.RegisterLifecycle(&InstrumentedService{
 		startHook: func() {
-			db, err = stack.OpenDatabase("mydb", 0, 0, "", false)
+			db, err = stack.OpenDatabase("mydb", 0, leveldb.LevelDBConfig{}, 0, "", false)
 			if err != nil {
 				t.Fatal("can't open DB:", err)
 			}
@@ -205,7 +206,7 @@ func TestNodeOpenDatabaseFromLifecycleStop(t *testing.T) {
 
 	stack.RegisterLifecycle(&InstrumentedService{
 		stopHook: func() {
-			db, err := stack.OpenDatabase("mydb", 0, 0, "", false)
+			db, err := stack.OpenDatabase("mydb", 0, leveldb.LevelDBConfig{}, 0, "", false)
 			if err != nil {
 				t.Fatal("can't open DB:", err)
 			}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -26,9 +26,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rpc"
 
@@ -158,7 +158,7 @@ func TestNodeCloseClosesDB(t *testing.T) {
 	stack, _ := New(testNodeConfig())
 	defer stack.Close()
 
-	db, err := stack.OpenDatabase("mydb", 0, leveldb.LevelDBConfig{}, 0, "", false)
+	db, err := stack.OpenDatabase("mydb", 0, 0, "", false, rawdb.ExtraDBConfig{})
 	if err != nil {
 		t.Fatal("can't open DB:", err)
 	}
@@ -185,7 +185,7 @@ func TestNodeOpenDatabaseFromLifecycleStart(t *testing.T) {
 
 	stack.RegisterLifecycle(&InstrumentedService{
 		startHook: func() {
-			db, err = stack.OpenDatabase("mydb", 0, leveldb.LevelDBConfig{}, 0, "", false)
+			db, err = stack.OpenDatabase("mydb", 0, 0, "", false, rawdb.ExtraDBConfig{})
 			if err != nil {
 				t.Fatal("can't open DB:", err)
 			}
@@ -206,7 +206,7 @@ func TestNodeOpenDatabaseFromLifecycleStop(t *testing.T) {
 
 	stack.RegisterLifecycle(&InstrumentedService{
 		stopHook: func() {
-			db, err := stack.OpenDatabase("mydb", 0, leveldb.LevelDBConfig{}, 0, "", false)
+			db, err := stack.OpenDatabase("mydb", 0, 0, "", false, rawdb.ExtraDBConfig{})
 			if err != nil {
 				t.Fatal("can't open DB:", err)
 			}


### PR DESCRIPTION
# Description

I wired up CLI flags to allow configuring LevelDB table and total sizes:
  - `--leveldb.compaction.table.size`, LevelDB SSTable file size factor in MiB (default: 2)
  - `--leveldb.compaction.table.multiplier`, multiplier on LevelDB SSTable file size (default: 1)
  - `--leveldb.compaction.total.size`, total size factor in MiB of LevelDB levels (default: 10)
  - `--leveldb.compaction.total.multiplier`, multiplier on LevelDB total level size (default: 10)

N.B. that the default values for these configs are exactly the same as before this changset and so Bor behavior should not change unless these flags are deliberately overridden. Bor/Geth inherited the default values from [the `goleveldb`
defaults](https://github.com/syndtr/goleveldb/blob/126854af5e6d8295ef8e8bee3040dd8380ae72e8/leveldb/opt/options.go).

We (Alchemy) found it necessary to override these configs as follows to keep Bor archive nodes tracking the canonical chain:
  - `--leveldb.compaction.table.size=4`
  - `--leveldb.compaction.total.size=20`

These overrides double the size of LevelDB SSTable files (2 MiB -> 4 MiB) and also the total amount of data in each level (100 MiB -> 200 MiB, 1,000 MiB -> 2,000 MiB, etc.). The idea is to have LevelDB read and write data in larger chunks while keeping the proportional frequency of compaction operations the same as in the original defaults defined by Dean and Ghemawat.

Without these overrides we found that our archive nodes would tend to fall into a "LevelDB compaction loop of death" where the incoming stream of blockchain data could not be flowed into LevelDB's structure quickly enough, resulting in the node blocking writes for long periods of time while LevelDB's single-threaded compaction organized the data.  Over time the nodes would fall farther and farther behind the canonical chain head, metaphorically dying a slow node's death.

These configs can be changed on existing node databases (resyncing is not necessary). LevelDB appears to work correctly with SSTable files of different sizes. Note that the database does not undergo any sort of migration when changing these configs. Only newly-written files (due to new data or compaction) are affected by these configs.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Nodes audience

We added the following flags to our nodes' `bor server` invocation: `--leveldb.compaction.table.size=4 --leveldb.compaction.total.size=20` to allow them to catch back up to the canonical chain head.

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] We have been running this code in production mainnet for a couple of months
- [ ] I have created new e2e tests into express-cli

### Manual tests

1. Added flags as specified above and started `bor server`.
2. Observed Bor archive node logs and block sync rate across many nodes in production.
  - Nodes that had previously fallen behind and had a sync rate of 0 at times increasing their block sync rate substantially and caught back up to head.
3. Verified that JSON-RPC responses and request durations were nominal as compared to nodes without this patch.
4. Also deployed to Bor full nodes to minimize config drift and observed no ill effects.