### PR TITLE
core/types: fix receipt EffectiveGasPrice unmarshaling

### DIFF
--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -25,7 +25,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
 		ContractAddress   common.Address `json:"contractAddress"`
 		GasUsed           hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
-		EffectiveGasPrice *big.Int       `json:"effectiveGasPrice"`
+		EffectiveGasPrice *hexutil.Big   `json:"effectiveGasPrice"`
 		BlockHash         common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big   `json:"blockNumber,omitempty"`
 		TransactionIndex  hexutil.Uint   `json:"transactionIndex"`
@@ -40,7 +40,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.TxHash = r.TxHash
 	enc.ContractAddress = r.ContractAddress
 	enc.GasUsed = hexutil.Uint64(r.GasUsed)
-	enc.EffectiveGasPrice = r.EffectiveGasPrice
+	enc.EffectiveGasPrice = (*hexutil.Big)(r.EffectiveGasPrice)
 	enc.BlockHash = r.BlockHash
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
@@ -59,7 +59,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		TxHash            *common.Hash    `json:"transactionHash" gencodec:"required"`
 		ContractAddress   *common.Address `json:"contractAddress"`
 		GasUsed           *hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
-		EffectiveGasPrice *big.Int        `json:"effectiveGasPrice"`
+		EffectiveGasPrice *hexutil.Big    `json:"effectiveGasPrice"`
 		BlockHash         *common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex  *hexutil.Uint   `json:"transactionIndex"`
@@ -101,7 +101,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	r.GasUsed = uint64(*dec.GasUsed)
 	if dec.EffectiveGasPrice != nil {
-		r.EffectiveGasPrice = dec.EffectiveGasPrice
+		r.EffectiveGasPrice = (*big.Int)(dec.EffectiveGasPrice)
 	}
 	if dec.BlockHash != nil {
 		r.BlockHash = *dec.BlockHash

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -76,6 +76,7 @@ type receiptMarshaling struct {
 	PostState         hexutil.Bytes
 	Status            hexutil.Uint64
 	CumulativeGasUsed hexutil.Uint64
+	EffectiveGasPrice *hexutil.Big
 	GasUsed           hexutil.Uint64
 	BlockNumber       *hexutil.Big
 	TransactionIndex  hexutil.Uint

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2105,6 +2105,10 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
 	}
 
+	if receipt.EffectiveGasPrice == nil {
+		fields["effectiveGasPrice"] = new(hexutil.Big)
+	}
+
 	// Assign receipt status or post state.
 	if len(receipt.PostState) > 0 {
 		fields["root"] = hexutil.Bytes(receipt.PostState)

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -21,11 +21,12 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/stretchr/testify/require"
 )
 
 func testTransactionMarshal(t *testing.T, tests []txData, config *params.ChainConfig) {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -18,6 +18,7 @@ package ethapi
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/require"
 	"math/big"
 	"testing"
 
@@ -27,6 +28,48 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
+func testTransactionMarshal(t *testing.T, tests []txData, config *params.ChainConfig) {
+	t.Parallel()
+	var (
+		signer = types.LatestSigner(config)
+		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	)
+
+	for i, tt := range tests {
+		var tx2 types.Transaction
+		tx, err := types.SignNewTx(key, signer, tt.Tx)
+		if err != nil {
+			t.Fatalf("test %d: signing failed: %v", i, err)
+		}
+		// Regular transaction
+		if data, err := json.Marshal(tx); err != nil {
+			t.Fatalf("test %d: marshalling failed; %v", i, err)
+		} else if err = tx2.UnmarshalJSON(data); err != nil {
+			t.Fatalf("test %d: sunmarshal failed: %v", i, err)
+		} else if want, have := tx.Hash(), tx2.Hash(); want != have {
+			t.Fatalf("test %d: stx changed, want %x have %x", i, want, have)
+		}
+
+		// rpcTransaction
+		rpcTx := newRPCTransaction(tx, common.Hash{}, 0, 0, big.NewInt(0), config)
+		if data, err := json.Marshal(rpcTx); err != nil {
+			t.Fatalf("test %d: marshalling failed; %v", i, err)
+		} else if err = tx2.UnmarshalJSON(data); err != nil {
+			t.Fatalf("test %d: unmarshal failed: %v", i, err)
+		} else if want, have := tx.Hash(), tx2.Hash(); want != have {
+			t.Fatalf("test %d: tx changed, want %x have %x", i, want, have)
+		} else {
+			want, have := tt.Want, string(data)
+			require.JSONEqf(t, want, have, "test %d: rpc json not match, want %s have %s", i, want, have)
+		}
+	}
+}
+
+type txData struct {
+	Tx   types.TxData
+	Want string
+}
+
 func TestTransaction_RoundTripRpcJSON(t *testing.T) {
 	var (
 		config = params.AllEthashProtocolChanges
@@ -35,12 +78,12 @@ func TestTransaction_RoundTripRpcJSON(t *testing.T) {
 		tests  = allTransactionTypes(common.Address{0xde, 0xad}, config)
 	)
 
-	t.Parallel()
+	testTransactionMarshal(t, tests, config)
 
 	for i, tt := range tests {
 		var tx2 types.Transaction
 
-		tx, err := types.SignNewTx(key, signer, tt)
+		tx, err := types.SignNewTx(key, signer, tt.Tx)
 		if err != nil {
 			t.Fatalf("test %d: signing failed: %v", i, err)
 		}
@@ -65,98 +108,243 @@ func TestTransaction_RoundTripRpcJSON(t *testing.T) {
 	}
 }
 
-func allTransactionTypes(addr common.Address, config *params.ChainConfig) []types.TxData {
-	return []types.TxData{
-		&types.LegacyTx{
-			Nonce:    5,
-			GasPrice: big.NewInt(6),
-			Gas:      7,
-			To:       &addr,
-			Value:    big.NewInt(8),
-			Data:     []byte{0, 1, 2, 3, 4},
-			V:        big.NewInt(9),
-			R:        big.NewInt(10),
-			S:        big.NewInt(11),
-		},
-		&types.LegacyTx{
-			Nonce:    5,
-			GasPrice: big.NewInt(6),
-			Gas:      7,
-			To:       nil,
-			Value:    big.NewInt(8),
-			Data:     []byte{0, 1, 2, 3, 4},
-			V:        big.NewInt(32),
-			R:        big.NewInt(10),
-			S:        big.NewInt(11),
-		},
-		&types.AccessListTx{
-			ChainID:  config.ChainID,
-			Nonce:    5,
-			GasPrice: big.NewInt(6),
-			Gas:      7,
-			To:       &addr,
-			Value:    big.NewInt(8),
-			Data:     []byte{0, 1, 2, 3, 4},
-			AccessList: types.AccessList{
-				types.AccessTuple{
-					Address:     common.Address{0x2},
-					StorageKeys: []common.Hash{types.EmptyRootHash},
-				},
+func allTransactionTypes(addr common.Address, config *params.ChainConfig) []txData {
+	return []txData{
+		{
+			Tx: &types.LegacyTx{
+				Nonce:    5,
+				GasPrice: big.NewInt(6),
+				Gas:      7,
+				To:       &addr,
+				Value:    big.NewInt(8),
+				Data:     []byte{0, 1, 2, 3, 4},
+				V:        big.NewInt(9),
+				R:        big.NewInt(10),
+				S:        big.NewInt(11),
 			},
-			V: big.NewInt(32),
-			R: big.NewInt(10),
-			S: big.NewInt(11),
-		},
-		&types.AccessListTx{
-			ChainID:  config.ChainID,
-			Nonce:    5,
-			GasPrice: big.NewInt(6),
-			Gas:      7,
-			To:       nil,
-			Value:    big.NewInt(8),
-			Data:     []byte{0, 1, 2, 3, 4},
-			AccessList: types.AccessList{
-				types.AccessTuple{
-					Address:     common.Address{0x2},
-					StorageKeys: []common.Hash{types.EmptyRootHash},
-				},
+			Want: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"hash": "0x5f3240454cd09a5d8b1c5d651eefae7a339262875bcd2d0e6676f3d989967008",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": "0xdead000000000000000000000000000000000000",
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x0",
+				"chainId": "0x539",
+				"v": "0xa96",
+				"r": "0xbc85e96592b95f7160825d837abb407f009df9ebe8f1b9158a4b8dd093377f75",
+				"s": "0x1b55ea3af5574c536967b039ba6999ef6c89cf22fc04bcb296e0e8b0b9b576f5"
+			}`,
+		}, {
+			Tx: &types.LegacyTx{
+				Nonce:    5,
+				GasPrice: big.NewInt(6),
+				Gas:      7,
+				To:       nil,
+				Value:    big.NewInt(8),
+				Data:     []byte{0, 1, 2, 3, 4},
+				V:        big.NewInt(32),
+				R:        big.NewInt(10),
+				S:        big.NewInt(11),
 			},
-			V: big.NewInt(32),
-			R: big.NewInt(10),
-			S: big.NewInt(11),
+			Want: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"hash": "0x806e97f9d712b6cb7e781122001380a2837531b0fc1e5f5d78174ad4cb699873",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": null,
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x0",
+				"chainId": "0x539",
+				"v": "0xa96",
+				"r": "0x9dc28b267b6ad4e4af6fe9289668f9305c2eb7a3241567860699e478af06835a",
+				"s": "0xa0b51a071aa9bed2cd70aedea859779dff039e3630ea38497d95202e9b1fec7"
+			}`,
 		},
-		&types.DynamicFeeTx{
-			ChainID:   config.ChainID,
-			Nonce:     5,
-			GasTipCap: big.NewInt(6),
-			GasFeeCap: big.NewInt(9),
-			Gas:       7,
-			To:        &addr,
-			Value:     big.NewInt(8),
-			Data:      []byte{0, 1, 2, 3, 4},
-			AccessList: types.AccessList{
-				types.AccessTuple{
-					Address:     common.Address{0x2},
-					StorageKeys: []common.Hash{types.EmptyRootHash},
+		{
+			Tx: &types.AccessListTx{
+				ChainID:  config.ChainID,
+				Nonce:    5,
+				GasPrice: big.NewInt(6),
+				Gas:      7,
+				To:       &addr,
+				Value:    big.NewInt(8),
+				Data:     []byte{0, 1, 2, 3, 4},
+				AccessList: types.AccessList{
+					types.AccessTuple{
+						Address:     common.Address{0x2},
+						StorageKeys: []common.Hash{types.EmptyRootHash},
+					},
 				},
+				V: big.NewInt(32),
+				R: big.NewInt(10),
+				S: big.NewInt(11),
 			},
-			V: big.NewInt(32),
-			R: big.NewInt(10),
-			S: big.NewInt(11),
-		},
-		&types.DynamicFeeTx{
-			ChainID:    config.ChainID,
-			Nonce:      5,
-			GasTipCap:  big.NewInt(6),
-			GasFeeCap:  big.NewInt(9),
-			Gas:        7,
-			To:         nil,
-			Value:      big.NewInt(8),
-			Data:       []byte{0, 1, 2, 3, 4},
-			AccessList: types.AccessList{},
-			V:          big.NewInt(32),
-			R:          big.NewInt(10),
-			S:          big.NewInt(11),
+			Want: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"hash": "0x121347468ee5fe0a29f02b49b4ffd1c8342bc4255146bb686cd07117f79e7129",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": "0xdead000000000000000000000000000000000000",
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x1",
+				"accessList": [
+					{
+						"address": "0x0200000000000000000000000000000000000000",
+						"storageKeys": [
+							"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+						]
+					}
+				],
+				"chainId": "0x539",
+				"v": "0x0",
+				"r": "0xf372ad499239ae11d91d34c559ffc5dab4daffc0069e03afcabdcdf231a0c16b",
+				"s": "0x28573161d1f9472fa0fd4752533609e72f06414f7ab5588699a7141f65d2abf"
+			}`,
+		}, {
+			Tx: &types.AccessListTx{
+				ChainID:  config.ChainID,
+				Nonce:    5,
+				GasPrice: big.NewInt(6),
+				Gas:      7,
+				To:       nil,
+				Value:    big.NewInt(8),
+				Data:     []byte{0, 1, 2, 3, 4},
+				AccessList: types.AccessList{
+					types.AccessTuple{
+						Address:     common.Address{0x2},
+						StorageKeys: []common.Hash{types.EmptyRootHash},
+					},
+				},
+				V: big.NewInt(32),
+				R: big.NewInt(10),
+				S: big.NewInt(11),
+			},
+			Want: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x6",
+				"hash": "0x067c3baebede8027b0f828a9d933be545f7caaec623b00684ac0659726e2055b",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": null,
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x1",
+				"accessList": [
+					{
+						"address": "0x0200000000000000000000000000000000000000",
+						"storageKeys": [
+							"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+						]
+					}
+				],
+				"chainId": "0x539",
+				"v": "0x1",
+				"r": "0x542981b5130d4613897fbab144796cb36d3cb3d7807d47d9c7f89ca7745b085c",
+				"s": "0x7425b9dd6c5deaa42e4ede35d0c4570c4624f68c28d812c10d806ffdf86ce63"
+			}`,
+		}, {
+			Tx: &types.DynamicFeeTx{
+				ChainID:   config.ChainID,
+				Nonce:     5,
+				GasTipCap: big.NewInt(6),
+				GasFeeCap: big.NewInt(9),
+				Gas:       7,
+				To:        &addr,
+				Value:     big.NewInt(8),
+				Data:      []byte{0, 1, 2, 3, 4},
+				AccessList: types.AccessList{
+					types.AccessTuple{
+						Address:     common.Address{0x2},
+						StorageKeys: []common.Hash{types.EmptyRootHash},
+					},
+				},
+				V: big.NewInt(32),
+				R: big.NewInt(10),
+				S: big.NewInt(11),
+			},
+			Want: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x9",
+				"maxFeePerGas": "0x9",
+				"maxPriorityFeePerGas": "0x6",
+				"hash": "0xb63e0b146b34c3e9cb7fbabb5b3c081254a7ded6f1b65324b5898cc0545d79ff",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": "0xdead000000000000000000000000000000000000",
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x2",
+				"accessList": [
+					{
+						"address": "0x0200000000000000000000000000000000000000",
+						"storageKeys": [
+							"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+						]
+					}
+				],
+				"chainId": "0x539",
+				"v": "0x1",
+				"r": "0x3b167e05418a8932cd53d7578711fe1a76b9b96c48642402bb94978b7a107e80",
+				"s": "0x22f98a332d15ea2cc80386c1ebaa31b0afebfa79ebc7d039a1e0074418301fef"
+			}`,
+		}, {
+			Tx: &types.DynamicFeeTx{
+				ChainID:    config.ChainID,
+				Nonce:      5,
+				GasTipCap:  big.NewInt(6),
+				GasFeeCap:  big.NewInt(9),
+				Gas:        7,
+				To:         nil,
+				Value:      big.NewInt(8),
+				Data:       []byte{0, 1, 2, 3, 4},
+				AccessList: types.AccessList{},
+				V:          big.NewInt(32),
+				R:          big.NewInt(10),
+				S:          big.NewInt(11),
+			},
+			Want: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x9",
+				"maxFeePerGas": "0x9",
+				"maxPriorityFeePerGas": "0x6",
+				"hash": "0xcbab17ee031a9d5b5a09dff909f0a28aedb9b295ac0635d8710d11c7b806ec68",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": null,
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x2",
+				"accessList": [],
+				"chainId": "0x539",
+				"v": "0x0",
+				"r": "0x6446b8a682db7e619fc6b4f6d1f708f6a17351a41c7fbd63665f469bc78b41b9",
+				"s": "0x7626abc15834f391a117c63450047309dbf84c5ce3e8e609b607062641e2de43"
+			}`,
 		},
 	}
 }

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -18,7 +18,6 @@ package ethapi
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"math/big"
 	"testing"
 
@@ -26,10 +25,13 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
 )
 
 func testTransactionMarshal(t *testing.T, tests []txData, config *params.ChainConfig) {
+	t.Helper()
 	t.Parallel()
+
 	var (
 		signer = types.LatestSigner(config)
 		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
@@ -37,6 +39,7 @@ func testTransactionMarshal(t *testing.T, tests []txData, config *params.ChainCo
 
 	for i, tt := range tests {
 		var tx2 types.Transaction
+
 		tx, err := types.SignNewTx(key, signer, tt.Tx)
 		if err != nil {
 			t.Fatalf("test %d: signing failed: %v", i, err)


### PR DESCRIPTION
# Description

During some tests, I found the following error while getting main chain receipts: `math/big: cannot unmarshal "\"0x0\"" into a *big.Int`
The changes in this PR fixed the error. Without the fixes, `heimdall`, which uses `bor` as a dependency, would not be able to properly unmarshal the receipts while fetching all the events from L1 (stateSynced, topup, unstakeInit events etc...).
[This is present already in geth](https://github.com/ethereum/go-ethereum/blob/master/core/types/receipt.go#L82).

Also, added a `nil`  check for `EffectiveGasPrice` and implemented its unit tests. Missing that would break the `eth_getTransactionReceipt` correct functioning.

The current version undergoing tests on Mumbai (`v1.0.0-beta`) is also affected, but the error does not appear because the version of `bor` used in `heimdall` as dependency in `go.mod` is `v0.3.x`, where the field `EffectiveGasPrice` was not introduced yet.

As an advice, as `bor` is used as a dependency in `heimdall`, we should always keep the dependencies aligned, every time a new `bor` version is released.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli