### PR TITLE
Fixed Panic - Added RLock on pool.pendingMu in validateTxBasics()

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -825,6 +825,9 @@ func (pool *TxPool) validateTxBasics(tx *types.Transaction, local bool) error {
 	// 	return core.ErrInsufficientFunds
 	// }
 	// Verify that replacing transactions will not result in overdraft
+	pool.pendingMu.RLock()
+	defer pool.pendingMu.RUnlock()
+
 	list := pool.pending[from]
 	if list != nil { // Sender already has pending txs
 		sum := new(big.Int).Add(tx.Cost(), list.totalcost)


### PR DESCRIPTION
# Description

Fixed `concurrent map read and map write` issue introduced during the upstream merge.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
