### PR TITLE
Stop execution pool in rpc handler

### DIFF
--- a/rpc/execution_pool.go
+++ b/rpc/execution_pool.go
@@ -21,7 +21,8 @@ type SafePool struct {
 	service   string       // the service using ep
 	processed atomic.Int64 // keeps count of total processed requests
 
-	close chan struct{}
+	close     chan struct{}
+	closeOnce sync.Once
 
 	// Skip sending task to execution pool
 	fastPath bool
@@ -103,7 +104,9 @@ func (s *SafePool) Size() int {
 }
 
 func (s *SafePool) Stop() {
-	close(s.close)
+	s.closeOnce.Do(func() {
+		close(s.close)
+	})
 
 	if s.executionPool.Load() != nil {
 		s.executionPool.Load().Stop()

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -302,6 +302,7 @@ func (h *handler) close(err error, inflightReq *requestOp) {
 	h.callWG.Wait()
 	h.cancelRoot()
 	h.cancelServerSubscriptions(err)
+	h.executionPool.Stop()
 }
 
 // addRequestOp registers a request operation.


### PR DESCRIPTION
# Description

All execution pools need to be closed properly. This fixes a potential goroutine leak caused by metric goutine created by each execution pool.


# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
