### PR TITLE
Settle execution task after all tasks are completed

### DIFF
--- a/core/blockstm/executor.go
+++ b/core/blockstm/executor.go
@@ -376,16 +376,6 @@ func (pe *ParallelExecutor) Prepare() error {
 		}(i)
 	}
 
-	pe.settleWg.Add(1)
-
-	go func() {
-		for t := range pe.chSettle {
-			pe.tasks[t].Settle()
-		}
-
-		pe.settleWg.Done()
-	}()
-
 	// bootstrap first execution
 	tx := pe.execTasks.takeNextPending()
 

--- a/core/blockstm/executor.go
+++ b/core/blockstm/executor.go
@@ -197,9 +197,6 @@ type ParallelExecutor struct {
 	// A priority queue that stores the transaction index of results, so we can validate the results in order
 	resultQueue SafeQueue
 
-	// A wait group to wait for all settling tasks to finish
-	settleWg sync.WaitGroup
-
 	// An integer that tracks the index of last settled transaction
 	lastSettled int
 
@@ -397,10 +394,6 @@ func (pe *ParallelExecutor) Close(wait bool) {
 
 	if wait {
 		pe.workerWg.Wait()
-	}
-
-	if wait {
-		pe.settleWg.Wait()
 	}
 }
 

--- a/core/parallel_state_processor.go
+++ b/core/parallel_state_processor.go
@@ -408,6 +408,10 @@ func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.Stat
 		return nil, nil, 0, err
 	}
 
+	for _, task := range tasks {
+		task.Settle()
+	}
+
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles(), nil)
 


### PR DESCRIPTION
# Description

This commit prevents different goroutines from reading the same statedb at the same time, resulting a concurrent read/write panic from trie tracer.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
