### PR TITLE
internal/cli: add support to overwrite config.toml values via cli flags

### DIFF
--- a/internal/cli/dumpconfig.go
+++ b/internal/cli/dumpconfig.go
@@ -42,7 +42,7 @@ func (c *DumpconfigCommand) Synopsis() string {
 func (c *DumpconfigCommand) Run(args []string) int {
 	// Initialize an empty command instance to get flags
 	command := server.Command{}
-	flags := command.Flags()
+	flags := command.Flags(nil)
 
 	if err := flags.Parse(args); err != nil {
 		c.UI.Error(err.Error())

--- a/internal/cli/flagset/flagset.go
+++ b/internal/cli/flagset/flagset.go
@@ -161,7 +161,7 @@ func (f *Flagset) UpdateValue(names []string, values []string) {
 				case reflect.TypeOf(map[string]string{}):
 					newValue = GetMapString(value)
 				default:
-					log.Trace("Unable to parse the type while overriding flag, skipping", "flag", name, "got type", old.Kind())
+					log.Trace("Unable to parse the type while overriding flag, skipping", "flag", name, "got type", oldType)
 					continue
 				}
 			}
@@ -328,11 +328,11 @@ func (b *BigIntFlag) Set(value string) error {
 	return nil
 }
 
-func GetBigInt(value string) *big.Int {
+func GetBigInt(value string) big.Int {
 	v := new(big.Int)
 	v.SetString(value, 10)
 
-	return v
+	return *v
 }
 
 func (f *Flagset) BigIntFlag(b *BigIntFlag) {

--- a/internal/cli/flagset/flagset.go
+++ b/internal/cli/flagset/flagset.go
@@ -161,7 +161,7 @@ func (f *Flagset) UpdateValue(names []string, values []string) {
 				case reflect.TypeOf(map[string]string{}):
 					newValue = GetMapString(value)
 				default:
-					log.Trace("Unable to parse the type while overriding flag, skipping", "flag", name, "got type", oldType)
+					log.Info("Unable to parse the type while overriding flag, skipping", "flag", name, "got type", oldType)
 					continue
 				}
 			}

--- a/internal/cli/flagset/flagset_test.go
+++ b/internal/cli/flagset/flagset_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestFlagsetBool(t *testing.T) {
+	t.Parallel()
+
 	f := NewFlagSet("")
 
 	value := true
@@ -43,6 +45,8 @@ func TestFlagsetBool(t *testing.T) {
 }
 
 func TestFlagsetString(t *testing.T) {
+	t.Parallel()
+
 	f := NewFlagSet("")
 
 	value := "hello"
@@ -72,6 +76,8 @@ func TestFlagsetString(t *testing.T) {
 }
 
 func TestFlagsetInt(t *testing.T) {
+	t.Parallel()
+
 	f := NewFlagSet("")
 
 	value := 10
@@ -101,6 +107,8 @@ func TestFlagsetInt(t *testing.T) {
 }
 
 func TestFlagsetFloat64(t *testing.T) {
+	t.Parallel()
+
 	f := NewFlagSet("")
 
 	value := 10.0
@@ -134,6 +142,8 @@ func TestFlagsetFloat64(t *testing.T) {
 }
 
 func TestFlagsetBigInt(t *testing.T) {
+	t.Parallel()
+
 	f := NewFlagSet("")
 
 	value := big.NewInt(0)
@@ -159,6 +169,8 @@ func TestFlagsetBigInt(t *testing.T) {
 }
 
 func TestFlagsetSliceString(t *testing.T) {
+	t.Parallel()
+
 	f := NewFlagSet("")
 
 	value := []string{"a", "b", "c"}
@@ -185,6 +197,8 @@ func TestFlagsetSliceString(t *testing.T) {
 }
 
 func TestFlagsetDuration(t *testing.T) {
+	t.Parallel()
+
 	f := NewFlagSet("")
 
 	value := time.Duration(0)
@@ -210,6 +224,8 @@ func TestFlagsetDuration(t *testing.T) {
 }
 
 func TestFlagsetMapString(t *testing.T) {
+	t.Parallel()
+
 	f := NewFlagSet("")
 
 	value := map[string]string{}

--- a/internal/cli/flagset/flagset_test.go
+++ b/internal/cli/flagset/flagset_test.go
@@ -1,23 +1,161 @@
 package flagset
 
 import (
+	"math/big"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFlagsetBool(t *testing.T) {
 	f := NewFlagSet("")
 
-	value := false
+	value := true
 	f.BoolFlag(&BoolFlag{
 		Name:  "flag",
 		Value: &value,
 	})
 
-	assert.NoError(t, f.Parse([]string{"--flag", "true"}))
-	assert.Equal(t, value, true)
+	// Parse no value, should have default (of datatype)
+	require.NoError(t, f.Parse([]string{}))
+	require.Equal(t, false, value)
+
+	// Parse --flag true
+	require.NoError(t, f.Parse([]string{"--flag", "true"}))
+	require.Equal(t, true, value)
+
+	// Parse --flag=true
+	require.NoError(t, f.Parse([]string{"--flag=true"}))
+	require.Equal(t, true, value)
+
+	// Parse --flag false: won't parse false
+	require.NoError(t, f.Parse([]string{"--flag", "false"}))
+	require.Equal(t, true, value)
+
+	// Parse --flag=false
+	require.NoError(t, f.Parse([]string{"--flag=false"}))
+	require.Equal(t, false, value)
+
+	// Parse --flag
+	require.NoError(t, f.Parse([]string{"--flag"}))
+	require.Equal(t, true, value)
+}
+
+func TestFlagsetString(t *testing.T) {
+	f := NewFlagSet("")
+
+	value := "hello"
+	f.StringFlag(&StringFlag{
+		Name:  "flag",
+		Value: &value,
+	})
+
+	// Parse no value, should have default
+	require.NoError(t, f.Parse([]string{}))
+	require.Equal(t, "", value)
+
+	// Parse --flag value
+	require.NoError(t, f.Parse([]string{"--flag", "value"}))
+	require.Equal(t, "value", value)
+
+	// Parse --flag ""
+	require.NoError(t, f.Parse([]string{"--flag", ""}))
+	require.Equal(t, "", value)
+
+	// Parse --flag=newvalue
+	require.NoError(t, f.Parse([]string{"--flag=newvalue"}))
+	require.Equal(t, "newvalue", value)
+
+	// Parse --flag: should fail due to no args
+	require.Error(t, f.Parse([]string{"--flag"}))
+}
+
+func TestFlagsetInt(t *testing.T) {
+	f := NewFlagSet("")
+
+	value := 10
+	f.IntFlag(&IntFlag{
+		Name:  "flag",
+		Value: &value,
+	})
+
+	// Parse no value, should have default
+	require.NoError(t, f.Parse([]string{}))
+	require.Equal(t, 0, value)
+
+	// Parse --flag 20
+	require.NoError(t, f.Parse([]string{"--flag", "20"}))
+	require.Equal(t, 20, value)
+
+	// Parse --flag 0
+	require.NoError(t, f.Parse([]string{"--flag", "0"}))
+	require.Equal(t, 0, value)
+
+	// Parse --flag=30
+	require.NoError(t, f.Parse([]string{"--flag=30"}))
+	require.Equal(t, 30, value)
+
+	// Parse --flag: should fail due to no args
+	require.Error(t, f.Parse([]string{"--flag"}))
+}
+
+func TestFlagsetFloat64(t *testing.T) {
+	f := NewFlagSet("")
+
+	value := 10.0
+	f.Float64Flag(&Float64Flag{
+		Name:  "flag",
+		Value: &value,
+	})
+
+	// Parse no value, should have default
+	require.NoError(t, f.Parse([]string{}))
+	require.Equal(t, 0.0, value)
+
+	// Parse --flag 20
+	require.NoError(t, f.Parse([]string{"--flag", "20.1"}))
+	require.Equal(t, 20.1, value)
+
+	// Parse --flag 0
+	require.NoError(t, f.Parse([]string{"--flag", "0"}))
+	require.Equal(t, 0.0, value)
+
+	// Parse --flag 0.0
+	require.NoError(t, f.Parse([]string{"--flag", "0.0"}))
+	require.Equal(t, 0.0, value)
+
+	// Parse --flag=30.1
+	require.NoError(t, f.Parse([]string{"--flag=30.1"}))
+	require.Equal(t, 30.1, value)
+
+	// Parse --flag: should fail due to no args
+	require.Error(t, f.Parse([]string{"--flag"}))
+}
+
+func TestFlagsetBigInt(t *testing.T) {
+	f := NewFlagSet("")
+
+	value := big.NewInt(0)
+	f.BigIntFlag(&BigIntFlag{
+		Name:  "flag",
+		Value: value,
+	})
+
+	// Parse no value, should have initial value (0 here)
+	require.NoError(t, f.Parse([]string{}))
+	require.Equal(t, big.NewInt(0), value)
+
+	// Parse --flag 20
+	require.NoError(t, f.Parse([]string{"--flag", "20"}))
+	require.Equal(t, big.NewInt(20), value)
+
+	// Parse --flag=30
+	require.NoError(t, f.Parse([]string{"--flag=30"}))
+	require.Equal(t, big.NewInt(30), value)
+
+	// Parse --flag: should fail due to no args
+	require.Error(t, f.Parse([]string{"--flag"}))
 }
 
 func TestFlagsetSliceString(t *testing.T) {
@@ -30,10 +168,20 @@ func TestFlagsetSliceString(t *testing.T) {
 		Default: value,
 	})
 
-	assert.NoError(t, f.Parse([]string{}))
-	assert.Equal(t, value, []string{"a", "b", "c"})
-	assert.NoError(t, f.Parse([]string{"--flag", "a,b"}))
-	assert.Equal(t, value, []string{"a", "b"})
+	// Parse no value, should have initial value
+	require.NoError(t, f.Parse([]string{}))
+	require.Equal(t, []string{"a", "b", "c"}, value)
+
+	// Parse --flag a,b
+	require.NoError(t, f.Parse([]string{"--flag", "a,b"}))
+	require.Equal(t, []string{"a", "b"}, value)
+
+	// Parse --flag ""
+	require.NoError(t, f.Parse([]string{"--flag", ""}))
+	require.Equal(t, []string(nil), value)
+
+	// Parse --flag: should fail due to no args
+	require.Error(t, f.Parse([]string{"--flag"}))
 }
 
 func TestFlagsetDuration(t *testing.T) {
@@ -45,8 +193,20 @@ func TestFlagsetDuration(t *testing.T) {
 		Value: &value,
 	})
 
-	assert.NoError(t, f.Parse([]string{"--flag", "1m"}))
-	assert.Equal(t, value, 1*time.Minute)
+	// Parse no value, should have initial value
+	require.NoError(t, f.Parse([]string{}))
+	require.Equal(t, time.Duration(0), value)
+
+	// Parse --flag 1m
+	require.NoError(t, f.Parse([]string{"--flag", "1m"}))
+	require.Equal(t, time.Minute, value)
+
+	// Parse --flag=1h
+	require.NoError(t, f.Parse([]string{"--flag=1h"}))
+	require.Equal(t, time.Hour, value)
+
+	// Parse --flag: should fail due to no args
+	require.Error(t, f.Parse([]string{"--flag"}))
 }
 
 func TestFlagsetMapString(t *testing.T) {
@@ -58,6 +218,18 @@ func TestFlagsetMapString(t *testing.T) {
 		Value: &value,
 	})
 
-	assert.NoError(t, f.Parse([]string{"--flag", "a=b,c=d"}))
-	assert.Equal(t, value, map[string]string{"a": "b", "c": "d"})
+	// Parse no value, should have initial value
+	require.NoError(t, f.Parse([]string{}))
+	require.Equal(t, map[string]string{}, value)
+
+	// Parse --flag a=b,c=d
+	require.NoError(t, f.Parse([]string{"--flag", "a=b,c=d"}))
+	require.Equal(t, map[string]string{"a": "b", "c": "d"}, value)
+
+	// Parse --flag=x=y
+	require.NoError(t, f.Parse([]string{"--flag=x=y"}))
+	require.Equal(t, map[string]string{"a": "b", "c": "d", "x": "y"}, value)
+
+	// Parse --flag: should fail due to no args
+	require.Error(t, f.Parse([]string{"--flag"}))
 }

--- a/internal/cli/flagset/flagset_test.go
+++ b/internal/cli/flagset/flagset_test.go
@@ -244,7 +244,7 @@ func TestFlagsetMapString(t *testing.T) {
 
 	// Parse --flag=x=y
 	require.NoError(t, f.Parse([]string{"--flag=x=y"}))
-	require.Equal(t, map[string]string{"a": "b", "c": "d", "x": "y"}, value)
+	require.Equal(t, map[string]string{"x": "y"}, value)
 
 	// Parse --flag: should fail due to no args
 	require.Error(t, f.Parse([]string{"--flag"}))

--- a/internal/cli/server/command.go
+++ b/internal/cli/server/command.go
@@ -99,6 +99,7 @@ func (c *Command) extractFlags(args []string) error {
 
 		// Check for explicit cli args
 		cmd := Command{} // use a new variable to keep the original config intact
+
 		cliFlags := cmd.Flags(nil)
 		if err := cliFlags.Parse(args); err != nil {
 			c.UI.Error(err.Error())

--- a/internal/cli/server/command.go
+++ b/internal/cli/server/command.go
@@ -35,7 +35,7 @@ func (c *Command) MarkDown() string {
 	items := []string{
 		"# Server",
 		"The ```bor server``` command runs the Bor client.",
-		c.Flags().MarkDown(),
+		c.Flags(nil).MarkDown(),
 	}
 
 	return strings.Join(items, "\n\n")
@@ -46,7 +46,7 @@ func (c *Command) Help() string {
 	return `Usage: bor [options]
 
 	Run the Bor server.
-  ` + c.Flags().Help()
+  ` + c.Flags(nil).Help()
 }
 
 // Synopsis implements the cli.Command interface
@@ -54,40 +54,68 @@ func (c *Command) Synopsis() string {
 	return "Run the Bor server"
 }
 
+// checkConfigFlag checks if the config flag is set or not. If set,
+// it returns the value else an empty string.
+func checkConfigFlag(args []string) string {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		// Check for single or double dashes
+		if strings.HasPrefix(arg, "-config") || strings.HasPrefix(arg, "--config") {
+			parts := strings.SplitN(arg, "=", 2)
+			if len(parts) == 2 {
+				return parts[1]
+			}
+
+			// If there's no equal sign, check the next argument
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+		}
+	}
+
+	return ""
+}
+
 func (c *Command) extractFlags(args []string) error {
-	config := *DefaultConfig()
+	// Check if config file is provided or not
+	configFilePath := checkConfigFlag(args)
 
-	flags := c.Flags()
-	if err := flags.Parse(args); err != nil {
-		c.UI.Error(err.Error())
-		c.config = &config
+	if configFilePath != "" {
+		log.Info("Reading config file", "path", configFilePath)
 
-		return err
-	}
-
-	// TODO: Check if this can be removed or not
-	// read cli flags
-	if err := config.Merge(c.cliConfig); err != nil {
-		c.UI.Error(err.Error())
-		c.config = &config
-
-		return err
-	}
-	// read if config file is provided, this will overwrite the cli flags, if provided
-	if c.configFile != "" {
-		log.Warn("Config File provided, this will overwrite the cli flags", "path", c.configFile)
-
-		cfg, err := readConfigFile(c.configFile)
+		// Parse the config file
+		cfg, err := readConfigFile(configFilePath)
 		if err != nil {
 			c.UI.Error(err.Error())
-			c.config = &config
 
 			return err
 		}
 
-		if err := config.Merge(cfg); err != nil {
+		log.Warn("Config set via config file will be overridden by cli flags")
+
+		// Initialse a flagset based on the config created above
+		flags := c.Flags(cfg)
+
+		// Check for explicit cli args
+		cmd := Command{} // use a new variable to keep the original config intact
+		cliFlags := cmd.Flags(nil)
+		if err := cliFlags.Parse(args); err != nil {
 			c.UI.Error(err.Error())
-			c.config = &config
+
+			return err
+		}
+
+		// Get the list of flags set explicitly
+		names, values := cliFlags.Visit()
+
+		// Set these flags using the flagset created earlier
+		flags.UpdateValue(names, values)
+	} else {
+		flags := c.Flags(nil)
+
+		if err := flags.Parse(args); err != nil {
+			c.UI.Error(err.Error())
 
 			return err
 		}
@@ -95,33 +123,33 @@ func (c *Command) extractFlags(args []string) error {
 
 	// nolint: nestif
 	// check for log-level and verbosity here
-	if c.configFile != "" {
-		data, _ := toml.LoadFile(c.configFile)
+	if configFilePath != "" {
+		data, _ := toml.LoadFile(configFilePath)
 		if data.Has("verbosity") && data.Has("log-level") {
 			log.Warn("Config contains both, verbosity and log-level, log-level will be deprecated soon. Use verbosity only.", "using", data.Get("verbosity"))
 		} else if !data.Has("verbosity") && data.Has("log-level") {
 			log.Warn("Config contains log-level only, note that log-level will be deprecated soon. Use verbosity instead.", "using", data.Get("log-level"))
-			config.Verbosity = VerbosityStringToInt(strings.ToLower(data.Get("log-level").(string)))
+			c.cliConfig.Verbosity = VerbosityStringToInt(strings.ToLower(data.Get("log-level").(string)))
 		}
 	} else {
 		tempFlag := 0
 
 		for _, val := range args {
-			if (strings.HasPrefix(val, "-verbosity") || strings.HasPrefix(val, "--verbosity")) && config.LogLevel != "" {
+			if (strings.HasPrefix(val, "-verbosity") || strings.HasPrefix(val, "--verbosity")) && c.cliConfig.LogLevel != "" {
 				tempFlag = 1
 				break
 			}
 		}
 
 		if tempFlag == 1 {
-			log.Warn("Both, verbosity and log-level flags are provided, log-level will be deprecated soon. Use verbosity only.", "using", config.Verbosity)
-		} else if tempFlag == 0 && config.LogLevel != "" {
-			log.Warn("Only log-level flag is provided, note that log-level will be deprecated soon. Use verbosity instead.", "using", config.LogLevel)
-			config.Verbosity = VerbosityStringToInt(strings.ToLower(config.LogLevel))
+			log.Warn("Both, verbosity and log-level flags are provided, log-level will be deprecated soon. Use verbosity only.", "using", c.cliConfig.Verbosity)
+		} else if tempFlag == 0 && c.cliConfig.LogLevel != "" {
+			log.Warn("Only log-level flag is provided, note that log-level will be deprecated soon. Use verbosity instead.", "using", c.cliConfig.LogLevel)
+			c.cliConfig.Verbosity = VerbosityStringToInt(strings.ToLower(c.cliConfig.LogLevel))
 		}
 	}
 
-	c.config = &config
+	c.config = c.cliConfig
 
 	return nil
 }

--- a/internal/cli/server/command_test.go
+++ b/internal/cli/server/command_test.go
@@ -8,43 +8,135 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFlags(t *testing.T) {
+// TestFlagsWithoutConfig tests all types of flags passed only
+// via cli args.
+func TestFlagsWithoutConfig(t *testing.T) {
 	t.Parallel()
 
 	var c Command
 
 	args := []string{
-		"--txpool.rejournal", "30m0s",
-		"--txpool.lifetime", "30m0s",
-		"--miner.gasprice", "20000000000",
-		"--gpo.maxprice", "70000000000",
-		"--gpo.ignoreprice", "1",
-		"--cache.trie.rejournal", "40m0s",
-		"--dev",
-		"--dev.period", "2",
+		"--identity", "",
 		"--datadir", "./data",
-		"--maxpeers", "30",
+		"--verbosity", "3",
+		"--rpc.batchlimit", "0",
+		"--snapshot",
+		"--bor.logs=false",
 		"--eth.requiredblocks", "a=b",
-		"--http.api", "eth,web3,bor",
+		"--miner.gasprice", "30000000000",
+		"--miner.recommit", "20s",
+		"--rpc.evmtimeout", "5s",
+		"--rpc.txfeecap", "6.0",
+		"--http.api", "eth,bor",
+		"--ws.api", "",
+		"--gpo.maxprice", "5000000000000",
 	}
+
 	err := c.extractFlags(args)
 
 	require.NoError(t, err)
 
-	txRe, _ := time.ParseDuration("30m0s")
-	txLt, _ := time.ParseDuration("30m0s")
-	caRe, _ := time.ParseDuration("40m0s")
+	recommit, _ := time.ParseDuration("20s")
+	evmTimeout, _ := time.ParseDuration("5s")
 
+	require.Equal(t, c.config.Identity, "")
 	require.Equal(t, c.config.DataDir, "./data")
-	require.Equal(t, c.config.Developer.Enabled, true)
-	require.Equal(t, c.config.Developer.Period, uint64(2))
-	require.Equal(t, c.config.TxPool.Rejournal, txRe)
-	require.Equal(t, c.config.TxPool.LifeTime, txLt)
-	require.Equal(t, c.config.Sealer.GasPrice, big.NewInt(20000000000))
-	require.Equal(t, c.config.Gpo.MaxPrice, big.NewInt(70000000000))
-	require.Equal(t, c.config.Gpo.IgnorePrice, big.NewInt(1))
-	require.Equal(t, c.config.Cache.Rejournal, caRe)
-	require.Equal(t, c.config.P2P.MaxPeers, uint64(30))
+	require.Equal(t, c.config.Verbosity, 3)
+	require.Equal(t, c.config.RPCBatchLimit, uint64(0))
+	require.Equal(t, c.config.Snapshot, true)
+	require.Equal(t, c.config.BorLogs, false)
 	require.Equal(t, c.config.RequiredBlocks, map[string]string{"a": "b"})
-	require.Equal(t, c.config.JsonRPC.Http.API, []string{"eth", "web3", "bor"})
+	require.Equal(t, c.config.Sealer.GasPrice, big.NewInt(30000000000))
+	require.Equal(t, c.config.Sealer.Recommit, recommit)
+	require.Equal(t, c.config.JsonRPC.RPCEVMTimeout, evmTimeout)
+	require.Equal(t, c.config.JsonRPC.Http.API, []string{"eth", "bor"})
+	require.Equal(t, c.config.JsonRPC.Ws.API, []string(nil))
+	require.Equal(t, c.config.Gpo.MaxPrice, big.NewInt(5000000000000))
+}
+
+// TestFlagsWithoutConfig tests all types of flags passed only
+// via config file.
+func TestFlagsWithConfig(t *testing.T) {
+	t.Parallel()
+
+	var c Command
+
+	args := []string{
+		"--config", "./testdata/test.toml",
+	}
+
+	err := c.extractFlags(args)
+
+	require.NoError(t, err)
+
+	recommit, _ := time.ParseDuration("20s")
+	evmTimeout, _ := time.ParseDuration("5s")
+
+	require.Equal(t, c.config.Identity, "")
+	require.Equal(t, c.config.DataDir, "./data")
+	require.Equal(t, c.config.Verbosity, 3)
+	require.Equal(t, c.config.RPCBatchLimit, uint64(0))
+	require.Equal(t, c.config.Snapshot, true)
+	require.Equal(t, c.config.BorLogs, false)
+	require.Equal(t, c.config.RequiredBlocks,
+		map[string]string{
+			"31000000": "0x2087b9e2b353209c2c21e370c82daa12278efd0fe5f0febe6c29035352cf050e",
+			"32000000": "0x875500011e5eecc0c554f95d07b31cf59df4ca2505f4dbbfffa7d4e4da917c68",
+		},
+	)
+	require.Equal(t, c.config.Sealer.GasPrice, big.NewInt(30000000000))
+	require.Equal(t, c.config.Sealer.Recommit, recommit)
+	require.Equal(t, c.config.JsonRPC.RPCEVMTimeout, evmTimeout)
+	require.Equal(t, c.config.JsonRPC.Http.API, []string{"eth", "bor"})
+	require.Equal(t, c.config.JsonRPC.Ws.API, []string{""})
+	require.Equal(t, c.config.Gpo.MaxPrice, big.NewInt(5000000000000))
+}
+
+// TestFlagsWithConfig tests all types of flags passed via both
+// config file and cli args. The cli args should overwrite the
+// value of flag.
+func TestFlagsWithConfigAndFlags(t *testing.T) {
+	t.Parallel()
+
+	var c Command
+
+	// Set the config and also override
+	args := []string{
+		"--config", "./testdata/test.toml",
+		"--identity", "Anon",
+		"--datadir", "",
+		"--verbosity", "0",
+		"--rpc.batchlimit", "5",
+		"--snapshot=false",
+		"--bor.logs=true",
+		"--eth.requiredblocks", "x=y",
+		"--miner.gasprice", "60000000000",
+		"--miner.recommit", "30s",
+		"--rpc.evmtimeout", "0s",
+		"--rpc.txfeecap", "0",
+		"--http.api", "",
+		"--ws.api", "eth,bor,web3",
+		"--gpo.maxprice", "0",
+	}
+
+	err := c.extractFlags(args)
+
+	require.NoError(t, err)
+
+	recommit, _ := time.ParseDuration("30s")
+	evmTimeout, _ := time.ParseDuration("0s")
+
+	require.Equal(t, c.config.Identity, "Anon")
+	require.Equal(t, c.config.DataDir, "")
+	require.Equal(t, c.config.Verbosity, 0)
+	require.Equal(t, c.config.RPCBatchLimit, uint64(5))
+	require.Equal(t, c.config.Snapshot, false)
+	require.Equal(t, c.config.BorLogs, true)
+	require.Equal(t, c.config.RequiredBlocks, map[string]string{"x": "y"})
+	require.Equal(t, c.config.Sealer.GasPrice, big.NewInt(60000000000))
+	require.Equal(t, c.config.Sealer.Recommit, recommit)
+	require.Equal(t, c.config.JsonRPC.RPCEVMTimeout, evmTimeout)
+	require.Equal(t, c.config.JsonRPC.Http.API, []string(nil))
+	require.Equal(t, c.config.JsonRPC.Ws.API, []string{"eth", "bor", "web3"})
+	require.Equal(t, c.config.Gpo.MaxPrice, big.NewInt(0))
 }

--- a/internal/cli/server/config_legacy_test.go
+++ b/internal/cli/server/config_legacy_test.go
@@ -15,21 +15,23 @@ func TestConfigLegacy(t *testing.T) {
 
 		testConfig := DefaultConfig()
 
+		testConfig.Identity = ""
 		testConfig.DataDir = "./data"
-		testConfig.Snapshot = false
+		testConfig.Verbosity = 3
+		testConfig.RPCBatchLimit = 0
+		testConfig.Snapshot = true
+		testConfig.BorLogs = false
 		testConfig.RequiredBlocks = map[string]string{
 			"31000000": "0x2087b9e2b353209c2c21e370c82daa12278efd0fe5f0febe6c29035352cf050e",
 			"32000000": "0x875500011e5eecc0c554f95d07b31cf59df4ca2505f4dbbfffa7d4e4da917c68",
 		}
-		testConfig.P2P.MaxPeers = 30
-		testConfig.TxPool.Locals = []string{}
-		testConfig.TxPool.LifeTime = time.Second
-		testConfig.Sealer.Enabled = true
-		testConfig.Sealer.GasCeil = 30000000
-		testConfig.Sealer.GasPrice = big.NewInt(1000000000)
-		testConfig.Gpo.IgnorePrice = big.NewInt(4)
-		testConfig.Cache.Cache = 1024
-		testConfig.Cache.Rejournal = time.Second
+		testConfig.Sealer.GasPrice = big.NewInt(30000000000)
+		testConfig.Sealer.Recommit = 20 * time.Second
+		testConfig.JsonRPC.RPCEVMTimeout = 5 * time.Second
+		testConfig.JsonRPC.TxFeeCap = 6.0
+		testConfig.JsonRPC.Http.API = []string{"eth", "bor"}
+		testConfig.JsonRPC.Ws.API = []string{""}
+		testConfig.Gpo.MaxPrice = big.NewInt(5000000000000)
 
 		assert.Equal(t, expectedConfig, testConfig)
 	}

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -4,8 +4,12 @@ import (
 	"github.com/ethereum/go-ethereum/internal/cli/flagset"
 )
 
-func (c *Command) Flags() *flagset.Flagset {
-	c.cliConfig = DefaultConfig()
+func (c *Command) Flags(config *Config) *flagset.Flagset {
+	if config != nil {
+		c.cliConfig = config
+	} else {
+		c.cliConfig = DefaultConfig()
+	}
 
 	f := flagset.NewFlagSet("server")
 

--- a/internal/cli/server/testdata/test.toml
+++ b/internal/cli/server/testdata/test.toml
@@ -1,25 +1,25 @@
+identity = ""
 datadir = "./data"
-snapshot = false
+verbosity = 3
+"rpc.batchlimit" = 0
+snapshot = true
+"bor.logs" = false
 
 ["eth.requiredblocks"]
 "31000000" = "0x2087b9e2b353209c2c21e370c82daa12278efd0fe5f0febe6c29035352cf050e"
 "32000000" = "0x875500011e5eecc0c554f95d07b31cf59df4ca2505f4dbbfffa7d4e4da917c68"
 
-[p2p]
-maxpeers = 30
-
-[txpool]
-locals = []
-lifetime = "1s"
-
 [miner]
-mine = true
-gaslimit = 30000000
-gasprice = "1000000000"
+  gasprice = "30000000000"
+  recommit = "20s"
+
+[jsonrpc]
+  evmtimeout = "5s"
+  txfeecap = 6.0
+  [jsonrpc.http]
+    api = ["eth", "bor"]
+  [jsonrpc.ws]
+    api = [""]
 
 [gpo]
-ignoreprice = "4"
-
-[cache]
-cache = 1024
-rejournal = "1s"
+  maxprice = "5000000000000"

--- a/scripts/getconfig.go
+++ b/scripts/getconfig.go
@@ -699,7 +699,7 @@ func main() {
 	args, ignoreForNow := beautifyArgs(args)
 
 	c := server.Command{}
-	flags := c.Flags()
+	flags := c.Flags(nil)
 	allFlags := flags.GetAllFlags()
 	flagsToCheck := getFlagsToCheck(args)
 


### PR DESCRIPTION
# Description

With the new-cli introduced in v0.3.0, there were 2 ways to set the configuration required to run bor. One can either do it via normal cli flags (args) or via a toml based config. Due to some restrictions, if the toml based config is provided, bor overwrites all the given cli flags (explicitly by the user) with those provided in toml config. 

An ideal behaviour should in any cli application should be that explicitly provided flags should take control no matter what value is provided in the toml based config. This PR implements that. Sufficient tests have been added and existing tests have been improved to cover all cases for all data types. 

The order of flag will now be as follows:
1. If set in cli args, use that value
2. If not set in cli args and set in config, use that value
3. If not set in any of them, use default value

Example:
If the toml config looks something like this: 
```toml
chain = "mainnet"
identity = "Anon"
datadir = "config_datadir"
### More values
```
and the user runs the following command
```
bor server --config=config.toml --datadir=cli_datadir
```

Currently bor would set the `datadir` the value mentioned in config i.e. `config_datadir`. 

With this PR, the value set for `datadir` would be `cli_datadir`. 

This is a breaking change as it changes the way people run their bor nodes. It mostly affects those who run a combination of both. Until now, their cli flags weren't set if config was set but now onwards, their additional flags will also be set. This might require an explicit communication to node operators. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

As mentioned above, it changes the way flags are parsed and handled. Cli args will overwrite config flags. 

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [x] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Manual testing of flags with different datatypes have been carried to make sure it works for all types of values. 