### PR TITLE
fix : borTx chainID

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2021,6 +2021,7 @@ func (s *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.H
 			// newRPCTransaction calculates hash based on RLP of the transaction data.
 			// In case of bor block tx, we need simple derived tx hash (same as function argument) instead of RLP hash
 			resultTx.Hash = hash
+			resultTx.ChainID = nil
 		}
 
 		return resultTx, nil


### PR DESCRIPTION
# Description

In this PR, we fix the issue in which bor transaction was showing chainID `0x7fffffffffffffee`.  Bor transaction did not usually output a chainID but was recently introduced to do so with the upstream from go-ethereum ( below ). 

```
// if a legacy transaction has an EIP-155 chain id, include it explicitly

if id := tx.ChainId(); id.Sign() != 0 {
	result.ChainID = (*hexutil.Big)(id)
}
```