### PR TITLE
eth, consensus/bor: handle 503 status code in heimdall client

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/bor"
+	"github.com/ethereum/go-ethereum/consensus/bor/heimdall"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
@@ -788,6 +789,10 @@ func (s *Ethereum) handleMilestone(ctx context.Context, ethHandler *ethHandler, 
 		ethHandler.downloader.ProcessFutureMilestone(num, hash)
 	}
 
+	if errors.Is(err, heimdall.ErrServiceUnavailable) {
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}
@@ -800,7 +805,10 @@ func (s *Ethereum) handleMilestone(ctx context.Context, ethHandler *ethHandler, 
 func (s *Ethereum) handleNoAckMilestone(ctx context.Context, ethHandler *ethHandler, bor *bor.Bor) error {
 	milestoneID, err := ethHandler.fetchNoAckMilestone(ctx, bor)
 
-	//If failed to fetch the no-ack milestone then it give the error.
+	if errors.Is(err, heimdall.ErrServiceUnavailable) {
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}

--- a/eth/handler_bor.go
+++ b/eth/handler_bor.go
@@ -66,7 +66,7 @@ func (h *ethHandler) fetchWhitelistMilestone(ctx context.Context, bor *bor.Bor, 
 	milestone, err := bor.HeimdallClient.FetchMilestone(ctx)
 	if errors.Is(err, heimdall.ErrServiceUnavailable) {
 		log.Debug("Failed to fetch latest milestone for whitelisting", "err", err)
-		return num, hash, errMilestone
+		return num, hash, err
 	}
 
 	if err != nil {
@@ -100,7 +100,7 @@ func (h *ethHandler) fetchNoAckMilestone(ctx context.Context, bor *bor.Bor) (str
 	milestoneID, err := bor.HeimdallClient.FetchLastNoAckMilestone(ctx)
 	if errors.Is(err, heimdall.ErrServiceUnavailable) {
 		log.Debug("Failed to fetch latest no-ack milestone", "err", err)
-		return milestoneID, errMilestone
+		return milestoneID, err
 	}
 
 	if err != nil {

--- a/eth/handler_bor.go
+++ b/eth/handler_bor.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/bor"
+	"github.com/ethereum/go-ethereum/consensus/bor/heimdall"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -63,6 +64,11 @@ func (h *ethHandler) fetchWhitelistMilestone(ctx context.Context, bor *bor.Bor, 
 
 	// fetch latest milestone
 	milestone, err := bor.HeimdallClient.FetchMilestone(ctx)
+	if errors.Is(err, heimdall.ErrServiceUnavailable) {
+		log.Debug("Failed to fetch latest milestone for whitelisting", "err", err)
+		return num, hash, errMilestone
+	}
+
 	if err != nil {
 		log.Error("Failed to fetch latest milestone for whitelisting", "err", err)
 		return num, hash, errMilestone
@@ -92,9 +98,13 @@ func (h *ethHandler) fetchNoAckMilestone(ctx context.Context, bor *bor.Bor) (str
 
 	// fetch latest milestone
 	milestoneID, err := bor.HeimdallClient.FetchLastNoAckMilestone(ctx)
+	if errors.Is(err, heimdall.ErrServiceUnavailable) {
+		log.Debug("Failed to fetch latest no-ack milestone", "err", err)
+		return milestoneID, errMilestone
+	}
+
 	if err != nil {
 		log.Error("Failed to fetch latest no-ack milestone", "err", err)
-
 		return milestoneID, errMilestone
 	}
 
@@ -104,6 +114,10 @@ func (h *ethHandler) fetchNoAckMilestone(ctx context.Context, bor *bor.Bor) (str
 func (h *ethHandler) fetchNoAckMilestoneByID(ctx context.Context, bor *bor.Bor, milestoneID string) error {
 	// fetch latest milestone
 	err := bor.HeimdallClient.FetchNoAckMilestone(ctx, milestoneID)
+	if errors.Is(err, heimdall.ErrServiceUnavailable) {
+		log.Debug("Failed to fetch no-ack milestone by ID", "err", err)
+		return err
+	}
 
 	// fixme: handle different types of errors
 	if errors.Is(err, ErrNotInRejectedList) {

--- a/eth/handler_bor.go
+++ b/eth/handler_bor.go
@@ -115,7 +115,7 @@ func (h *ethHandler) fetchNoAckMilestoneByID(ctx context.Context, bor *bor.Bor, 
 	// fetch latest milestone
 	err := bor.HeimdallClient.FetchNoAckMilestone(ctx, milestoneID)
 	if errors.Is(err, heimdall.ErrServiceUnavailable) {
-		log.Debug("Failed to fetch no-ack milestone by ID", "err", err)
+		log.Debug("Failed to fetch no-ack milestone by ID", "milestoneID", milestoneID, "err", err)
 		return err
 	}
 


### PR DESCRIPTION
# Description

When a new feature (like for the upcoming `Aalborg` hard fork) hasn't kicked in, the endpoints of heimdall will now return 503 (Service Unavailable) status code. This PR makes sure that bor handles that code separately and doesn't keep retying to fetch info. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [x] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [x] This PR requires changes to heimdall
    - In case link the PR here: https://github.com/maticnetwork/heimdall/pull/1073

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it