### PR TITLE
fix : wrong chainID on rpc

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1742,6 +1742,7 @@ func newRPCTransactionFromBlockIndex(b *types.Block, index uint64, config *param
 	// If the transaction is a bor transaction, we need to set the hash to the derived bor tx hash. BorTx is always the last index.
 	if borReceipt != nil && index == uint64(len(txs)-1) {
 		rpcTx.Hash = borReceipt.TxHash
+		rpcTx.ChainID = nil
 	}
 
 	return rpcTx

--- a/internal/ethapi/bor_api.go
+++ b/internal/ethapi/bor_api.go
@@ -44,6 +44,7 @@ func (s *BlockChainAPI) appendRPCMarshalBorTransaction(ctx context.Context, bloc
 				// newRPCTransaction calculates hash based on RLP of the transaction data.
 				// In case of bor block tx, we need simple derived tx hash (same as function argument) instead of RLP hash
 				marshalledTx.Hash = txHash
+				marshalledTx.ChainID = nil
 				fields["transactions"] = append(formattedTxs, marshalledTx)
 			} else {
 				fields["transactions"] = append(formattedTxs, txHash)


### PR DESCRIPTION
# Description

In #1021 , we fixed the borTx chainID for method `eth_getTransactionByHash`.  Some methods like `eth_getBlockByNumber` got missed. In this PR, we are fixing the rest of the methods that we identified to also send false borTx chainID. 