### PR TITLE
internal/cli: set default value for keystore

### DIFF
--- a/internal/cli/server/command_test.go
+++ b/internal/cli/server/command_test.go
@@ -41,6 +41,7 @@ func TestFlagsWithoutConfig(t *testing.T) {
 
 	require.Equal(t, c.config.Identity, "")
 	require.Equal(t, c.config.DataDir, "./data")
+	require.Equal(t, c.config.KeyStoreDir, "")
 	require.Equal(t, c.config.Verbosity, 3)
 	require.Equal(t, c.config.RPCBatchLimit, uint64(0))
 	require.Equal(t, c.config.Snapshot, true)
@@ -74,6 +75,7 @@ func TestFlagsWithConfig(t *testing.T) {
 
 	require.Equal(t, c.config.Identity, "")
 	require.Equal(t, c.config.DataDir, "./data")
+	require.Equal(t, c.config.KeyStoreDir, "./keystore")
 	require.Equal(t, c.config.Verbosity, 3)
 	require.Equal(t, c.config.RPCBatchLimit, uint64(0))
 	require.Equal(t, c.config.Snapshot, true)
@@ -105,6 +107,7 @@ func TestFlagsWithConfigAndFlags(t *testing.T) {
 		"--config", "./testdata/test.toml",
 		"--identity", "Anon",
 		"--datadir", "",
+		"--keystore", "",
 		"--verbosity", "0",
 		"--rpc.batchlimit", "5",
 		"--snapshot=false",
@@ -128,6 +131,7 @@ func TestFlagsWithConfigAndFlags(t *testing.T) {
 
 	require.Equal(t, c.config.Identity, "Anon")
 	require.Equal(t, c.config.DataDir, "")
+	require.Equal(t, c.config.KeyStoreDir, "")
 	require.Equal(t, c.config.Verbosity, 0)
 	require.Equal(t, c.config.RPCBatchLimit, uint64(5))
 	require.Equal(t, c.config.Snapshot, false)

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -605,6 +605,7 @@ func DefaultConfig() *Config {
 		DataDir:                 DefaultDataDir(),
 		Ancient:                 "",
 		DBEngine:                "leveldb",
+		KeyStoreDir:             "",
 		Logging: &LoggingConfig{
 			Vmodule:   "",
 			Json:      false,

--- a/internal/cli/server/config_legacy_test.go
+++ b/internal/cli/server/config_legacy_test.go
@@ -17,6 +17,7 @@ func TestConfigLegacy(t *testing.T) {
 
 		testConfig.Identity = ""
 		testConfig.DataDir = "./data"
+		testConfig.KeyStoreDir = "./keystore"
 		testConfig.Verbosity = 3
 		testConfig.RPCBatchLimit = 0
 		testConfig.Snapshot = true

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -64,9 +64,10 @@ func (c *Command) Flags(config *Config) *flagset.Flagset {
 		Default: c.cliConfig.DBEngine,
 	})
 	f.StringFlag(&flagset.StringFlag{
-		Name:  "keystore",
-		Usage: "Path of the directory where keystores are located",
-		Value: &c.cliConfig.KeyStoreDir,
+		Name:    "keystore",
+		Usage:   "Path of the directory where keystores are located",
+		Value:   &c.cliConfig.KeyStoreDir,
+		Default: c.cliConfig.KeyStoreDir,
 	})
 	f.Uint64Flag(&flagset.Uint64Flag{
 		Name:    "rpc.batchlimit",

--- a/internal/cli/server/testdata/test.toml
+++ b/internal/cli/server/testdata/test.toml
@@ -1,5 +1,6 @@
 identity = ""
 datadir = "./data"
+keystore = "./keystore"
 verbosity = 3
 "rpc.batchlimit" = 0
 snapshot = true


### PR DESCRIPTION
# Description

With the recent changes in new-cli to support overriding of config values by cli flags, due to the missing default value of the keystore flag, the flag library used empty string as the final value and the original value even if set get's ignored. This PR fixes it. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Nodes audience

Affects validators mostly as they're using keystore flag

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli