### PR TITLE
eth: handle nil blocks and state when pending is not available

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -277,6 +277,9 @@ func (api *DebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error) {
 		// both the pending block as well as the pending state from
 		// the miner and operate on those
 		_, stateDb := api.eth.miner.Pending()
+		if stateDb == nil {
+			return state.Dump{}, errors.New("pending state is not available")
+		}
 		return stateDb.RawDump(opts), nil
 	}
 
@@ -385,6 +388,9 @@ func (api *DebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, start hex
 			// both the pending block as well as the pending state from
 			// the miner and operate on those
 			_, stateDb = api.eth.miner.Pending()
+			if stateDb == nil {
+				return state.IteratorDump{}, errors.New("pending state is not available")
+			}
 		} else {
 			var header *types.Header
 			if number == rpc.LatestBlockNumber {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -68,6 +68,9 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	// Pending block is only known by the miner
 	if number == rpc.PendingBlockNumber {
 		block := b.eth.miner.PendingBlock()
+		if block == nil {
+			return nil, errors.New("pending block is not available")
+		}
 		return block.Header(), nil
 	}
 	// Otherwise resolve and return the block
@@ -136,6 +139,9 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	// Pending block is only known by the miner
 	if number == rpc.PendingBlockNumber {
 		block := b.eth.miner.PendingBlock()
+		if block == nil {
+			return nil, errors.New("pending block is not available")
+		}
 		return block, nil
 	}
 	// Otherwise resolve and return the block
@@ -217,6 +223,9 @@ func (b *EthAPIBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.B
 	// Pending state is only known by the miner
 	if number == rpc.PendingBlockNumber {
 		block, state := b.eth.miner.Pending()
+		if block == nil || state == nil {
+			return nil, nil, errors.New("pending state is not available")
+		}
 		return state, block.Header(), nil
 	}
 	// Otherwise resolve the block number and return its state

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -328,6 +328,9 @@ func (f *Filter) checkMatches(ctx context.Context, header *types.Header) ([]*typ
 // pendingLogs returns the logs matching the filter criteria within the pending block.
 func (f *Filter) pendingLogs() ([]*types.Log, error) {
 	block, receipts := f.sys.backend.PendingBlockAndReceipts()
+	if block == nil || receipts == nil {
+		return nil, errors.New("pending block is not available")
+	}
 	if bloomFilter(block.Bloom(), f.addresses, f.topics) {
 		var unfiltered []*types.Log
 		for _, r := range receipts {

--- a/internal/ethapi/bor_api.go
+++ b/internal/ethapi/bor_api.go
@@ -74,7 +74,11 @@ func (api *BorAPI) SendRawTransactionConditional(ctx context.Context, input hexu
 	}
 
 	currentHeader := api.b.CurrentHeader()
-	currentState, _, _ := api.b.StateAndHeaderByNumber(ctx, rpc.BlockNumber(currentHeader.Number.Int64()))
+	currentState, _, err := api.b.StateAndHeaderByNumber(ctx, rpc.BlockNumber(currentHeader.Number.Int64()))
+
+	if currentState == nil || err != nil {
+		return common.Hash{}, err
+	}
 
 	// check block number range
 	if err := currentHeader.ValidateBlockNumberOptions4337(options.BlockNumberMin, options.BlockNumberMax); err != nil {


### PR DESCRIPTION
# Description

This PR includes a subset of changes from https://github.com/ethereum/go-ethereum/pull/27218 which checks for nil header, state and receipt values when node is syncing and calls to pending are made. 

Note that the rest of the changes in the PR will be pulled in routine upstream merge. Only the required fix is pulled. 

This PR also handles nil state or error in the `SendRawTransactionConditional` api. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated