### PR TITLE
bor: make withdrawal objects nil

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -816,14 +816,14 @@ func (c *Bor) Finalize(chain consensus.ChainHeaderReader, header *types.Header, 
 
 	headerNumber := header.Number.Uint64()
 
-	if len(withdrawals) > 0 {
+	if withdrawals != nil {
+		withdrawals = nil
 		log.Error("Bor does not support withdrawals", "number", headerNumber)
-		return
 	}
 
 	if header.WithdrawalsHash != nil {
+		header.WithdrawalsHash = nil
 		log.Error("Bor does not support withdrawalHash", "number", headerNumber)
-		return
 	}
 
 	if IsSprintStart(headerNumber, c.config.CalculateSprint(headerNumber)) {
@@ -898,17 +898,17 @@ func (c *Bor) FinalizeAndAssemble(ctx context.Context, chain consensus.ChainHead
 	finalizeCtx, finalizeSpan := tracing.StartSpan(ctx, "bor.FinalizeAndAssemble")
 	defer tracing.EndSpan(finalizeSpan)
 
-	if len(withdrawals) > 0 {
-		return nil, errors.New("Bor does not support withdrawals")
+	headerNumber := header.Number.Uint64()
+
+	if withdrawals != nil {
+		log.Error("Bor does not support withdrawals", "number", headerNumber)
 	}
 
 	if header.WithdrawalsHash != nil {
-		return nil, errors.New("Bor does not support withdrawalHash")
+		log.Error("Bor does not support withdrawalHash", "number", headerNumber)
 	}
 
 	stateSyncData := []*types.StateSyncData{}
-
-	headerNumber := header.Number.Uint64()
 
 	var err error
 

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -822,15 +822,11 @@ func (c *Bor) Finalize(chain consensus.ChainHeaderReader, header *types.Header, 
 
 	headerNumber := header.Number.Uint64()
 
-	if withdrawals != nil {
+	if withdrawals != nil || header.WithdrawalsHash != nil {
 		// withdrawals = nil is not required because withdrawals are not used
-		log.Warn("Bor does not support withdrawals", "number", headerNumber)
-	}
-
-	if header.WithdrawalsHash != nil {
 		header.WithdrawalsHash = nil
 
-		log.Warn("Bor does not support withdrawalHash", "number", headerNumber)
+		log.Warn("Bor does not support withdrawals", "number", headerNumber)
 	}
 
 	if IsSprintStart(headerNumber, c.config.CalculateSprint(headerNumber)) {
@@ -907,15 +903,11 @@ func (c *Bor) FinalizeAndAssemble(ctx context.Context, chain consensus.ChainHead
 
 	headerNumber := header.Number.Uint64()
 
-	if withdrawals != nil {
+	if withdrawals != nil || header.WithdrawalsHash != nil {
 		// withdrawals != nil not required because withdrawals are not used
-		log.Warn("Bor does not support withdrawals", "number", headerNumber)
-	}
-
-	if header.WithdrawalsHash != nil {
 		header.WithdrawalsHash = nil
 
-		log.Warn("Bor does not support withdrawalHash", "number", headerNumber)
+		log.Warn("Bor does not support withdrawals", "number", headerNumber)
 	}
 
 	stateSyncData := []*types.StateSyncData{}

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -172,6 +172,12 @@ func encodeSigHeader(w io.Writer, header *types.Header, c *params.BorConfig) {
 		}
 	}
 
+	if header.WithdrawalsHash != nil {
+		header.WithdrawalsHash = nil
+
+		log.Warn("Bor does not support withdrawals", "number", header.Number)
+	}
+
 	if err := rlp.Encode(w, enc); err != nil {
 		panic("can't encode: " + err.Error())
 	}
@@ -817,13 +823,14 @@ func (c *Bor) Finalize(chain consensus.ChainHeaderReader, header *types.Header, 
 	headerNumber := header.Number.Uint64()
 
 	if withdrawals != nil {
-		withdrawals = nil
-		log.Error("Bor does not support withdrawals", "number", headerNumber)
+		// withdrawals = nil is not required because withdrawals are not used
+		log.Warn("Bor does not support withdrawals", "number", headerNumber)
 	}
 
 	if header.WithdrawalsHash != nil {
 		header.WithdrawalsHash = nil
-		log.Error("Bor does not support withdrawalHash", "number", headerNumber)
+
+		log.Warn("Bor does not support withdrawalHash", "number", headerNumber)
 	}
 
 	if IsSprintStart(headerNumber, c.config.CalculateSprint(headerNumber)) {
@@ -901,11 +908,14 @@ func (c *Bor) FinalizeAndAssemble(ctx context.Context, chain consensus.ChainHead
 	headerNumber := header.Number.Uint64()
 
 	if withdrawals != nil {
-		log.Error("Bor does not support withdrawals", "number", headerNumber)
+		// withdrawals != nil not required because withdrawals are not used
+		log.Warn("Bor does not support withdrawals", "number", headerNumber)
 	}
 
 	if header.WithdrawalsHash != nil {
-		log.Error("Bor does not support withdrawalHash", "number", headerNumber)
+		header.WithdrawalsHash = nil
+
+		log.Warn("Bor does not support withdrawalHash", "number", headerNumber)
 	}
 
 	stateSyncData := []*types.StateSyncData{}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -529,8 +529,8 @@ func (g *Genesis) ToBlock() *types.Block {
 	var withdrawals []*types.Withdrawal
 
 	if g.Config != nil && g.Config.IsShanghai(new(big.Int).SetUint64(g.Number)) {
-		head.WithdrawalsHash = &types.EmptyWithdrawalsHash
-		withdrawals = make([]*types.Withdrawal, 0)
+		head.WithdrawalsHash = nil
+		withdrawals = nil
 	}
 
 	return types.NewBlock(head, nil, nil, nil, trie.NewStackTrie(nil)).WithWithdrawals(withdrawals)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -101,8 +101,12 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 	// Fail if Shanghai not enabled and len(withdrawals) is non-zero.
 	withdrawals := block.Withdrawals()
-	if len(withdrawals) > 0 && !p.config.IsShanghai(block.Number()) {
+	if !p.config.IsShanghai(block.Number()) && withdrawals != nil {
 		return nil, nil, 0, fmt.Errorf("withdrawals before shanghai")
+	}
+	// Bor does not support withdrawals
+	if withdrawals != nil {
+		withdrawals = nil
 	}
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles(), withdrawals)

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -367,11 +367,7 @@ func TestGetBlockBodies68(t *testing.T) {
 func testGetBlockBodies(t *testing.T, protocol uint) {
 	gen := func(n int, g *core.BlockGen) {
 		if n%2 == 0 {
-			w := &types.Withdrawal{
-				Address: common.Address{0xaa},
-				Amount:  42,
-			}
-			g.AddWithdrawal(w)
+			g.AddWithdrawal(&types.Withdrawal{})
 		}
 	}
 


### PR DESCRIPTION
# Description

Makes withdrawals objects `nil`

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [x] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
