### PR TITLE
Fix Bor key-value config look-up

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -749,7 +749,7 @@ func (c *BorConfig) IsSprintStart(number uint64) bool {
 	return number%c.CalculateSprint(number) == 0
 }
 
-func borKeyValueConfigHelper(field map[string]uint64, number uint64) uint64 {
+func borKeyValueConfigHelper[T uint64 | string](field map[string]T, number uint64) T {
 	keys := make([]string, 0, len(field))
 	for k := range field {
 		keys = append(keys, k)
@@ -770,23 +770,7 @@ func borKeyValueConfigHelper(field map[string]uint64, number uint64) uint64 {
 }
 
 func (c *BorConfig) CalculateBurntContract(number uint64) string {
-	keys := make([]string, 0, len(c.BurntContract))
-	for k := range c.BurntContract {
-		keys = append(keys, k)
-	}
-
-	sort.Strings(keys)
-
-	for i := 0; i < len(keys)-1; i++ {
-		valUint, _ := strconv.ParseUint(keys[i], 10, 64)
-		valUintNext, _ := strconv.ParseUint(keys[i+1], 10, 64)
-
-		if number > valUint && number < valUintNext {
-			return c.BurntContract[keys[i]]
-		}
-	}
-
-	return c.BurntContract[keys[len(keys)-1]]
+	return borKeyValueConfigHelper(c.BurntContract, number)
 }
 
 // Description returns a human-readable description of ChainConfig.

--- a/params/config.go
+++ b/params/config.go
@@ -750,23 +750,26 @@ func (c *BorConfig) IsSprintStart(number uint64) bool {
 }
 
 func borKeyValueConfigHelper[T uint64 | string](field map[string]T, number uint64) T {
-	keys := make([]string, 0, len(field))
-	for k := range field {
-		keys = append(keys, k)
+	keys := make([]uint64, 0, len(field))
+	fieldUint := make(map[uint64]T)
+	for k, v := range field {
+		keyUint, err := strconv.ParseUint(k, 10, 64)
+		if err != nil {
+			panic(err)
+		}
+		keys = append(keys, keyUint)
+		fieldUint[keyUint] = v
 	}
 
-	sort.Strings(keys)
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 
 	for i := 0; i < len(keys)-1; i++ {
-		valUint, _ := strconv.ParseUint(keys[i], 10, 64)
-		valUintNext, _ := strconv.ParseUint(keys[i+1], 10, 64)
-
-		if number >= valUint && number < valUintNext {
-			return field[keys[i]]
+		if number >= keys[i] && number < keys[i+1] {
+			return fieldUint[keys[i]]
 		}
 	}
 
-	return field[keys[len(keys)-1]]
+	return fieldUint[keys[len(keys)-1]]
 }
 
 func (c *BorConfig) CalculateBurntContract(number uint64) string {

--- a/params/config.go
+++ b/params/config.go
@@ -711,11 +711,11 @@ func (c *BorConfig) CalculateSprint(number uint64) uint64 {
 }
 
 func (c *BorConfig) CalculateBackupMultiplier(number uint64) uint64 {
-	return c.calculateBorConfigHelper(c.BackupMultiplier, number)
+	return borKeyValueConfigHelper(c.BackupMultiplier, number)
 }
 
 func (c *BorConfig) CalculatePeriod(number uint64) uint64 {
-	return c.calculateBorConfigHelper(c.Period, number)
+	return borKeyValueConfigHelper(c.Period, number)
 }
 
 func (c *BorConfig) IsJaipur(number *big.Int) bool {
@@ -747,26 +747,6 @@ func (c *BorConfig) IsParallelUniverse(number *big.Int) bool {
 
 func (c *BorConfig) IsSprintStart(number uint64) bool {
 	return number%c.CalculateSprint(number) == 0
-}
-
-func (c *BorConfig) calculateBorConfigHelper(field map[string]uint64, number uint64) uint64 {
-	keys := make([]string, 0, len(field))
-	for k := range field {
-		keys = append(keys, k)
-	}
-
-	sort.Strings(keys)
-
-	for i := 0; i < len(keys)-1; i++ {
-		valUint, _ := strconv.ParseUint(keys[i], 10, 64)
-		valUintNext, _ := strconv.ParseUint(keys[i+1], 10, 64)
-
-		if number > valUint && number < valUintNext {
-			return field[keys[i]]
-		}
-	}
-
-	return field[keys[len(keys)-1]]
 }
 
 func borKeyValueConfigHelper(field map[string]uint64, number uint64) uint64 {

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -162,4 +162,18 @@ func TestBorKeyValueConfigHelper(t *testing.T) {
 	assert.Equal(t, borKeyValueConfigHelper(backupMultiplier, 29638656-1), uint64(5))
 	assert.Equal(t, borKeyValueConfigHelper(backupMultiplier, 29638656), uint64(2))
 	assert.Equal(t, borKeyValueConfigHelper(backupMultiplier, 29638656+1), uint64(2))
+
+	config := map[string]uint64{
+		"0":         1,
+		"90000000":  2,
+		"100000000": 3,
+	}
+	assert.Equal(t, borKeyValueConfigHelper(config, 0), uint64(1))
+	assert.Equal(t, borKeyValueConfigHelper(config, 1), uint64(1))
+	assert.Equal(t, borKeyValueConfigHelper(config, 90000000-1), uint64(1))
+	assert.Equal(t, borKeyValueConfigHelper(config, 90000000), uint64(2))
+	assert.Equal(t, borKeyValueConfigHelper(config, 90000000+1), uint64(2))
+	assert.Equal(t, borKeyValueConfigHelper(config, 100000000-1), uint64(2))
+	assert.Equal(t, borKeyValueConfigHelper(config, 100000000), uint64(3))
+	assert.Equal(t, borKeyValueConfigHelper(config, 100000000+1), uint64(3))
 }

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"gotest.tools/assert"
+
 	"github.com/ethereum/go-ethereum/common/math"
 )
 
@@ -144,4 +146,20 @@ func TestConfigRules(t *testing.T) {
 	if r := c.Rules(big.NewInt(0), true, stamp); !r.IsShanghai {
 		t.Errorf("expected %v to be shanghai", stamp)
 	}
+}
+
+func TestBorKeyValueConfigHelper(t *testing.T) {
+	backupMultiplier := map[string]uint64{
+		"0":        2,
+		"25275000": 5,
+		"29638656": 2,
+	}
+	assert.Equal(t, borKeyValueConfigHelper(backupMultiplier, 0), uint64(2))
+	assert.Equal(t, borKeyValueConfigHelper(backupMultiplier, 1), uint64(2))
+	assert.Equal(t, borKeyValueConfigHelper(backupMultiplier, 25275000-1), uint64(2))
+	assert.Equal(t, borKeyValueConfigHelper(backupMultiplier, 25275000), uint64(5))
+	assert.Equal(t, borKeyValueConfigHelper(backupMultiplier, 25275000+1), uint64(5))
+	assert.Equal(t, borKeyValueConfigHelper(backupMultiplier, 29638656-1), uint64(5))
+	assert.Equal(t, borKeyValueConfigHelper(backupMultiplier, 29638656), uint64(2))
+	assert.Equal(t, borKeyValueConfigHelper(backupMultiplier, 29638656+1), uint64(2))
 }


### PR DESCRIPTION
# Description

Please provide a detailed description of what was done in this PR

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Mumbai-only: `CalculateBackupMultiplier(25275000)` & `CalculatePeriod(25275000)` now correctly return 5 instead of 2.

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

# Additional comments

This PR fixes 3 issues:
1. `calculateBorConfigHelper`, previously used  by `CalculateBackupMultiplier` & `CalculatePeriod` incorrectly returned the very last entry for block numbers that matched exactly a key in the map. Practically, it only affected Mumbai since BorMainnet has a single entry in the `BackupMultiplier` & `Period` maps.
2. `CalculateBurntContract`, used for the upcoming Agra fork, would've suffered from the same issue. 
3.  Lexicographic instead of numerical ordering, previously used in `borKeyValueConfigHelper`, can lead to bugs with blocks like 90M vs 100M (90,000,000 < 100,000,000, but lexicographically "90000000" > "100000000")
