### PR TITLE
Removed the check for milestoneID in the GetVoteOnHash()

### DIFF
--- a/eth/bor_api_backend.go
+++ b/eth/bor_api_backend.go
@@ -83,21 +83,6 @@ func (b *EthAPIBackend) GetVoteOnHash(ctx context.Context, starBlockNr uint64, e
 		return false, fmt.Errorf("Hash mismatch: localChainHash %s, milestoneHash %s", localEndBlockHash, hash)
 	}
 
-	ethHandler := (*ethHandler)(b.eth.handler)
-
-	bor, ok := ethHandler.chain.Engine().(*bor.Bor)
-
-	if !ok {
-		return false, fmt.Errorf("Bor not available")
-	}
-
-	err = bor.HeimdallClient.FetchMilestoneID(ctx, milestoneId)
-
-	if err != nil {
-		downloader.UnlockMutex(false, "", endBlockNr, common.Hash{})
-		return false, fmt.Errorf("Milestone ID doesn't exist in Heimdall")
-	}
-
 	downloader.UnlockMutex(true, milestoneId, endBlockNr, localEndBlock.Hash())
 
 	return true, nil


### PR DESCRIPTION
# Description

Removed the check for milestoneID in the GetVoteOnHash() function, in present system there is an extra check which query the authenticity of the milestone being voted by querying the milestoneID from the Heimdall.
It seemed to be an extra check which extra call overhead and sometime also causing delay.


# Changes

- [.] Bugfix (non-breaking change that solves an issue)

