### PR TITLE
break out of loop when `delayFlag` becomes `false`

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1124,6 +1124,7 @@ mainloop:
 
 				if ok1 || ok2 {
 					delayFlag = false
+					break
 				}
 
 				for j := range deps[i] {


### PR DESCRIPTION
When `delayFlag` becomes `false`, `tempDeps` will be ignored, so there's no need to continue the loop.