### PR TITLE
Update client.go to allow the use of paths with the heimdall url

### DIFF
--- a/consensus/bor/heimdall/client.go
+++ b/consensus/bor/heimdall/client.go
@@ -421,6 +421,7 @@ func makeURL(urlString, rawPath, rawQuery string) (*url.URL, error) {
 	}
 
 	u.Path = rawPath
+	u.Path = path.Join(u.Path, rawPath)
 	u.RawQuery = rawQuery
 
 	return u, err

--- a/consensus/bor/heimdall/client.go
+++ b/consensus/bor/heimdall/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"sort"
 	"time"
 

--- a/consensus/bor/heimdall/client.go
+++ b/consensus/bor/heimdall/client.go
@@ -421,7 +421,6 @@ func makeURL(urlString, rawPath, rawQuery string) (*url.URL, error) {
 		return nil, err
 	}
 
-	u.Path = rawPath
 	u.Path = path.Join(u.Path, rawPath)
 	u.RawQuery = rawQuery
 

--- a/consensus/bor/heimdall/client_test.go
+++ b/consensus/bor/heimdall/client_test.go
@@ -399,7 +399,7 @@ func TestSpanURL(t *testing.T) {
 	const expected = "http://bor0/bor/span/1"
 
 	if url.String() != expected {
-		t.Fatalf("expected URL %q, got %q", url.String(), expected)
+		t.Fatalf("expected URL %q, got %q", expected, url.String())
 	}
 }
 
@@ -414,6 +414,6 @@ func TestStateSyncURL(t *testing.T) {
 	const expected = "http://bor0/clerk/event-record/list?from-id=10&to-time=100&limit=50"
 
 	if url.String() != expected {
-		t.Fatalf("expected URL %q, got %q", url.String(), expected)
+		t.Fatalf("expected URL %q, got %q", expected, url.String())
 	}
 }


### PR DESCRIPTION
As reported to the polygon team 2 months ago in the Ankr polygon slack, the current code prevents the use of a path with the heimdall url, this was fixed in erigon https://github.com/ledgerwatch/erigon/commit/a3a61701e2cee5b1302ddf2c02dbfcb291522c64 in response to my request by Mark Holt, and it seems this code was just copied from bor where it is incorrect too. This patch fixes that.