### PR TITLE
core: remove tracing and handle err in reorg call

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -33,15 +33,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/common/prque"
-	"github.com/ethereum/go-ethereum/common/tracing"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/blockstm"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -1722,77 +1718,34 @@ func (bc *BlockChain) WriteBlockAndSetHead(ctx context.Context, block *types.Blo
 // writeBlockAndSetHead is the internal implementation of WriteBlockAndSetHead.
 // This function expects the chain mutex to be held.
 func (bc *BlockChain) writeBlockAndSetHead(ctx context.Context, block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (status WriteStatus, err error) {
-	writeBlockAndSetHeadCtx, span := tracing.StartSpan(ctx, "blockchain.writeBlockAndSetHead")
-	defer tracing.EndSpan(span)
-
-	var stateSyncLogs []*types.Log
-
-	tracing.Exec(writeBlockAndSetHeadCtx, "", "blockchain.writeBlockWithState", func(_ context.Context, span trace.Span) {
-		stateSyncLogs, err = bc.writeBlockWithState(block, receipts, logs, state)
-		tracing.SetAttributes(
-			span,
-			attribute.Int("number", int(block.Number().Uint64())),
-			attribute.Bool("error", err != nil),
-		)
-	})
-
+	stateSyncLogs, err := bc.writeBlockWithState(block, receipts, logs, state)
 	if err != nil {
 		return NonStatTy, err
 	}
 
 	currentBlock := bc.CurrentBlock()
-
-	var reorg bool
-
-	tracing.Exec(writeBlockAndSetHeadCtx, "", "blockchain.ReorgNeeded", func(_ context.Context, span trace.Span) {
-		reorg, err = bc.forker.ReorgNeeded(currentBlock, block.Header())
-		tracing.SetAttributes(
-			span,
-			attribute.Int("number", int(block.Number().Uint64())),
-			attribute.Int("current block", int(currentBlock.Number.Uint64())),
-			attribute.Bool("reorg needed", reorg),
-			attribute.Bool("error", err != nil),
-		)
-	})
-
+	reorg, err := bc.forker.ReorgNeeded(currentBlock, block.Header())
 	if err != nil {
 		return NonStatTy, err
 	}
 
-	tracing.Exec(writeBlockAndSetHeadCtx, "", "blockchain.reorg", func(_ context.Context, span trace.Span) {
-		if reorg {
-			// Reorganise the chain if the parent is not the head block
-			if block.ParentHash() != currentBlock.Hash() {
-				if err = bc.reorg(currentBlock, block); err != nil {
-					status = NonStatTy
-				}
+	if reorg {
+		// Reorganise the chain if the parent is not the head block
+		if block.ParentHash() != currentBlock.Hash() {
+			if err = bc.reorg(currentBlock, block); err != nil {
+				return NonStatTy, err
 			}
-
-			status = CanonStatTy
-		} else {
-			status = SideStatTy
 		}
 
-		tracing.SetAttributes(
-			span,
-			attribute.Int("number", int(block.Number().Uint64())),
-			attribute.Int("current block", int(currentBlock.Number.Uint64())),
-			attribute.Bool("reorg needed", reorg),
-			attribute.Bool("error", err != nil),
-			attribute.String("status", string(status)),
-		)
-	})
-
-	if status == NonStatTy {
-		return
+		status = CanonStatTy
+	} else {
+		status = SideStatTy
 	}
+
 	// Set new head.
 	if status == CanonStatTy {
-		tracing.Exec(writeBlockAndSetHeadCtx, "", "blockchain.writeHeadBlock", func(_ context.Context, _ trace.Span) {
-			bc.writeHeadBlock(block)
-		})
+		bc.writeHeadBlock(block)
 	}
-
 	bc.futureBlocks.Remove(block.Hash())
 
 	if status == CanonStatTy {


### PR DESCRIPTION
# Description

This PR does 2 things:

- Removes tracing in writeBlockAndSetHead function: tracing isn't used anymore and this simplifies the code a lot
- Fixes a bug when the reorg function returns error (when we receive an error we update the status to NonStatTy but don't return at that point. Later the status is updated irrespective of the above error and may lead to wrong processing. This PR fixes that and returns from the function immediately). This change also matches with the upstream implementation of the same function.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
