### PR TITLE
Add: Changes reverted in PR#1124

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -883,6 +883,10 @@ func (c *Bor) changeContractCodeIfNeeded(headerNumber uint64, state *state.State
 			for addr, account := range allocs {
 				log.Info("change contract code", "address", addr)
 				state.SetCode(addr, account.Code)
+
+				if state.GetBalance(addr).Cmp(big.NewInt(0)) == 0 {
+					state.SetBalance(addr, account.Balance)
+				}
 			}
 		}
 	}

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -155,7 +155,8 @@ var DefaultConfig = Config{
 	AccountQueue: 64,
 	GlobalQueue:  1024,
 
-	Lifetime: 3 * time.Hour,
+	Lifetime:            3 * time.Hour,
+	AllowUnprotectedTxs: false,
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -601,7 +602,8 @@ func (pool *LegacyPool) local() map[common.Address]types.Transactions {
 // and does not require the pool mutex to be held.
 func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) error {
 	opts := &txpool.ValidationOptions{
-		Config: pool.chainconfig,
+		Config:              pool.chainconfig,
+		AllowUnprotectedTxs: pool.config.AllowUnprotectedTxs,
 		Accept: 0 |
 			1<<types.LegacyTxType |
 			1<<types.AccessListTxType |
@@ -671,6 +673,11 @@ func (pool *LegacyPool) add(tx *types.Transaction, local bool) (replaced bool, e
 		knownTxMeter.Mark(1)
 		return false, txpool.ErrAlreadyKnown
 	}
+
+	if pool.config.AllowUnprotectedTxs {
+		pool.signer = types.NewFakeSigner(tx.ChainId())
+	}
+
 	// Make the local flag. If it's from local source or it's from the network but
 	// the sender is marked as local previously, treat it as the local transaction.
 	isLocal := local || pool.locals.containsTx(tx)
@@ -984,6 +991,11 @@ func (pool *LegacyPool) Add(txs []*types.Transaction, local, sync bool) []error 
 			knownTxMeter.Mark(1)
 			continue
 		}
+
+		if pool.config.AllowUnprotectedTxs {
+			pool.signer = types.NewFakeSigner(tx.ChainId())
+		}
+
 		// Exclude transactions with basic errors, e.g invalid signatures and
 		// insufficient intrinsic gas as soon as possible and cache senders
 		// in transactions before obtaining lock

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -93,7 +93,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 		return core.ErrTipAboveFeeCap
 	}
 	// Make sure the transaction is signed properly
-	if _, err := types.Sender(signer, tx); err != nil || !opts.AllowUnprotectedTxs {
+	if _, err := types.Sender(signer, tx); err != nil && !opts.AllowUnprotectedTxs {
 		return ErrInvalidSender
 	}
 	// Ensure the transaction has more gas than the bare minimum needed to cover

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -35,6 +35,8 @@ import (
 type ValidationOptions struct {
 	Config *params.ChainConfig // Chain configuration to selectively validate based on current fork rules
 
+	AllowUnprotectedTxs bool // Whether to allow unprotected transactions in the pool
+
 	Accept  uint8    // Bitmap of transaction types that should be accepted for the calling pool
 	MaxSize uint64   // Maximum size of a transaction that the caller can meaningfully handle
 	MinTip  *big.Int // Minimum gas tip needed to allow a transaction into the caller pool
@@ -91,7 +93,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 		return core.ErrTipAboveFeeCap
 	}
 	// Make sure the transaction is signed properly
-	if _, err := types.Sender(signer, tx); err != nil {
+	if _, err := types.Sender(signer, tx); err != nil || !opts.AllowUnprotectedTxs {
 		return ErrInvalidSender
 	}
 	// Ensure the transaction has more gas than the bare minimum needed to cover

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -582,3 +582,38 @@ func deriveChainId(v *big.Int) *big.Int {
 	v = new(big.Int).Sub(v, big.NewInt(35))
 	return v.Div(v, big.NewInt(2))
 }
+
+// FakeSigner implements the Signer interface and accepts unprotected transactions
+type FakeSigner struct{ londonSigner }
+
+var _ Signer = FakeSigner{}
+
+func NewFakeSigner(chainId *big.Int) Signer {
+	signer := NewLondonSigner(chainId)
+	ls, _ := signer.(londonSigner)
+	return FakeSigner{londonSigner: ls}
+}
+
+func (f FakeSigner) Sender(tx *Transaction) (common.Address, error) {
+	return f.londonSigner.Sender(tx)
+}
+
+func (f FakeSigner) SignatureValues(tx *Transaction, sig []byte) (r, s, v *big.Int, err error) {
+	return f.londonSigner.SignatureValues(tx, sig)
+}
+
+func (f FakeSigner) ChainID() *big.Int {
+	return f.londonSigner.ChainID()
+}
+
+// Hash returns 'signature hash', i.e. the transaction hash that is signed by the
+// private key. This hash does not uniquely identify the transaction.
+func (f FakeSigner) Hash(tx *Transaction) common.Hash {
+	return f.londonSigner.Hash(tx)
+}
+
+// Equal returns true if the given signer is the same as the receiver.
+func (f FakeSigner) Equal(Signer) bool {
+	// Always return true
+	return true
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -174,6 +174,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 
 	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
+		log.Info("------Unprotected transactions allowed-------")
 		config.TxPool.AllowUnprotectedTxs = true
 	}
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -174,8 +174,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 
 	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
-		log.Debug(" ###########", "Unprotected transactions allowed")
-
 		config.TxPool.AllowUnprotectedTxs = true
 	}
 

--- a/eth/bor_api_backend.go
+++ b/eth/bor_api_backend.go
@@ -83,21 +83,6 @@ func (b *EthAPIBackend) GetVoteOnHash(ctx context.Context, starBlockNr uint64, e
 		return false, fmt.Errorf("Hash mismatch: localChainHash %s, milestoneHash %s", localEndBlockHash, hash)
 	}
 
-	ethHandler := (*ethHandler)(b.eth.handler)
-
-	bor, ok := ethHandler.chain.Engine().(*bor.Bor)
-
-	if !ok {
-		return false, fmt.Errorf("Bor not available")
-	}
-
-	err = bor.HeimdallClient.FetchMilestoneID(ctx, milestoneId)
-
-	if err != nil {
-		downloader.UnlockMutex(false, "", endBlockNr, common.Hash{})
-		return false, fmt.Errorf("Milestone ID doesn't exist in Heimdall")
-	}
-
 	downloader.UnlockMutex(true, milestoneId, endBlockNr, localEndBlock.Hash())
 
 	return true, nil

--- a/internal/cli/server/config_legacy_test.go
+++ b/internal/cli/server/config_legacy_test.go
@@ -42,3 +42,22 @@ func TestConfigLegacy(t *testing.T) {
 		readFile("./testdata/test.toml")
 	})
 }
+
+func TestDefaultConfigLegacy(t *testing.T) {
+	readFile := func(path string) {
+		expectedConfig, err := readLegacyConfig(path)
+		assert.NoError(t, err)
+
+		testConfig := DefaultConfig()
+
+		testConfig.Identity = "Polygon-Devs"
+		testConfig.DataDir = "/var/lib/bor"
+
+		assert.Equal(t, expectedConfig, testConfig)
+	}
+
+	// read file in hcl format
+	t.Run("toml", func(t *testing.T) {
+		readFile("./testdata/default.toml")
+	})
+}

--- a/internal/cli/server/testdata/default.toml
+++ b/internal/cli/server/testdata/default.toml
@@ -1,0 +1,193 @@
+chain = "mainnet"
+identity = "Polygon-Devs"
+verbosity = 3
+log-level = ""
+vmdebug = false
+datadir = "/var/lib/bor"
+ancient = ""
+"db.engine" = "leveldb"
+keystore = ""
+"rpc.batchlimit" = 100
+"rpc.returndatalimit" = 100000
+syncmode = "full"
+gcmode = "full"
+snapshot = true
+"bor.logs" = false
+ethstats = ""
+devfakeauthor = false
+
+["eth.requiredblocks"]
+
+[log]
+  vmodule = ""
+  json = false
+  backtrace = ""
+  debug = false
+
+[p2p]
+  maxpeers = 50
+  maxpendpeers = 50
+  bind = "0.0.0.0"
+  port = 30303
+  nodiscover = false
+  nat = "any"
+  netrestrict = ""
+  nodekey = ""
+  nodekeyhex = ""
+  txarrivalwait = "500ms"
+  [p2p.discovery]
+    v4disc = true
+    v5disc = false
+    bootnodes = []
+    bootnodesv4 = []
+    bootnodesv5 = []
+    static-nodes = []
+    trusted-nodes = []
+    dns = []
+
+[heimdall]
+  url = "http://localhost:1317"
+  "bor.without" = false
+  grpc-address = ""
+  "bor.runheimdall" = false
+  "bor.runheimdallargs" = ""
+  "bor.useheimdallapp" = false
+
+[txpool]
+  locals = []
+  nolocals = false
+  journal = "transactions.rlp"
+  rejournal = "1h0m0s"
+  pricelimit = 1
+  pricebump = 10
+  accountslots = 16
+  globalslots = 32768
+  accountqueue = 16
+  globalqueue = 32768
+  lifetime = "3h0m0s"
+
+[miner]
+  mine = false
+  etherbase = ""
+  extradata = ""
+  gaslimit = 30000000
+  gasprice = "1000000000"
+  recommit = "2m5s"
+  commitinterrupt = true
+
+[jsonrpc]
+  ipcdisable = false
+  ipcpath = ""
+  gascap = 50000000
+  evmtimeout = "5s"
+  txfeecap = 1.0
+  allow-unprotected-txs = false
+  enabledeprecatedpersonal = false
+  [jsonrpc.http]
+    enabled = false
+    port = 8545
+    prefix = ""
+    host = "localhost"
+    api = ["eth", "net", "web3", "txpool", "bor"]
+    vhosts = ["localhost"]
+    corsdomain = ["localhost"]
+    ep-size = 40
+    ep-requesttimeout = "0s"
+  [jsonrpc.ws]
+    enabled = false
+    port = 8546
+    prefix = ""
+    host = "localhost"
+    api = ["net", "web3"]
+    origins = ["localhost"]
+    ep-size = 40
+    ep-requesttimeout = "0s"
+  [jsonrpc.graphql]
+    enabled = false
+    port = 0
+    prefix = ""
+    host = ""
+    vhosts = ["localhost"]
+    corsdomain = ["localhost"]
+    ep-size = 0
+    ep-requesttimeout = ""
+  [jsonrpc.auth]
+    jwtsecret = ""
+    addr = "localhost"
+    port = 8551
+    vhosts = ["localhost"]
+  [jsonrpc.timeouts]
+    read = "10s"
+    write = "30s"
+    idle = "2m0s"
+
+[gpo]
+  blocks = 20
+  percentile = 60
+  maxheaderhistory = 1024
+  maxblockhistory = 1024
+  maxprice = "500000000000"
+  ignoreprice = "2"
+
+[telemetry]
+  metrics = false
+  expensive = false
+  prometheus-addr = "127.0.0.1:7071"
+  opencollector-endpoint = ""
+  [telemetry.influx]
+    influxdb = false
+    endpoint = ""
+    database = ""
+    username = ""
+    password = ""
+    influxdbv2 = false
+    token = ""
+    bucket = ""
+    organization = ""
+    [telemetry.influx.tags]
+
+[cache]
+  cache = 1024
+  gc = 25
+  snapshot = 10
+  database = 50
+  trie = 15
+  noprefetch = false
+  preimages = false
+  txlookuplimit = 2350000
+  triesinmemory = 128
+  blocklogs = 32
+  timeout = "1h0m0s"
+  fdlimit = 0
+
+[leveldb]
+  compactiontablesize = 2
+  compactiontablesizemultiplier = 1.0
+  compactiontotalsize = 10
+  compactiontotalsizemultiplier = 10.0
+
+[accounts]
+  unlock = []
+  password = ""
+  allow-insecure-unlock = false
+  lightkdf = false
+  disable-bor-wallet = true
+
+[grpc]
+  addr = ":3131"
+
+[developer]
+  dev = false
+  period = 0
+  gaslimit = 11500000
+
+[parallelevm]
+  enable = true
+  procs = 8
+
+[pprof]
+  pprof = false
+  port = 6060
+  addr = "127.0.0.1"
+  memprofilerate = 524288
+  blockprofilerate = 0

--- a/params/config.go
+++ b/params/config.go
@@ -960,9 +960,9 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "arrowGlacierBlock", block: c.ArrowGlacierBlock, optional: true},
 		{name: "grayGlacierBlock", block: c.GrayGlacierBlock, optional: true},
 		{name: "mergeNetsplitBlock", block: c.MergeNetsplitBlock, optional: true},
-		{name: "ShanghaiBlock", block: c.ShanghaiBlock},
-		{name: "CancunBlock", block: c.CancunBlock, optional: true},
-		{name: "pragueTime", block: c.PragueBlock, optional: true},
+		{name: "shanghaiBlock", block: c.ShanghaiBlock},
+		{name: "cancunBlock", block: c.CancunBlock, optional: true},
+		{name: "pragueBlock", block: c.PragueBlock, optional: true},
 	} {
 		if lastFork.name != "" {
 			switch {


### PR DESCRIPTION
# Description

Adds changes back from the reverted [PR#1124](https://github.com/maticnetwork/bor/pull/1124/)
Changes:
  - Make hardfork naming consistent across all the blocks @anshalshukla 
  - Enables unprotected txns @temaniarpit27
  - Test default flags added via config @pratikspatil024 
  - Fix balance update via blockalloc at HF @anshalshukla 
  - Fix milestone getVoteOnHash @VAIBHAVJINDAL3012 

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [X] I have added at least 2 reviewer or the whole pos-v1 team
- [X] I have added sufficient documentation in code
- [X] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
