### PR TITLE
eth/tracers: avoid data race when tracing block with bor tx

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -835,8 +835,10 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 
 				if stateSyncPresent && task.index == len(txs)-1 {
 					if *config.BorTraceEnabled {
-						config.BorTx = newBoolPtr(true)
-						res, err = api.traceTx(ctx, msg, txctx, blockCtx, task.statedb, config)
+						// avoid data race
+						newConfig := *config
+						newConfig.BorTx = newBoolPtr(true)
+						res, err = api.traceTx(ctx, msg, txctx, blockCtx, task.statedb, &newConfig)
 					} else {
 						break
 					}


### PR DESCRIPTION
# Description
`debug_traceBlockByHash` and `debug_traceBlockByNumber` may return incorrect result because there is a data race in code.

Data race may happen when tracing block that contains bor transaction, it may cause that a common transaction is treated as a bor transaction.

This PR tries to fix the issue.


# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

No.

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
