### PR TITLE
eth/downloader: bypass peer validation if remote peer is far away

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -922,13 +922,15 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 			return 0, err
 		}
 
-		// Don't validate the peer against whitelisted milestones until the different of
-		// our local height and remote peer's height is less than `maxValidationThreshold`
-		if errors.Is(err, whitelist.ErrNoRemote) && localHeight >= remoteHeight-d.maxValidationThreshold {
-			log.Info("Remote peer didn't respond", "id", p.id, "local", localHeight, "remote", remoteHeight, "err", err)
-			return 0, err
-		} else if errors.Is(err, whitelist.ErrNoRemote) {
-			log.Info("Remote peer didn't respond but is far ahead, skipping validation", "id", p.id, "local", localHeight, "remote", remoteHeight, "err", err)
+		if errors.Is(err, whitelist.ErrNoRemote) {
+			// Don't validate the peer against whitelisted milestones until the different of
+			// our local height and remote peer's height is less than `maxValidationThreshold`
+			if localHeight >= remoteHeight-d.maxValidationThreshold {
+				log.Info("Remote peer didn't respond", "id", p.id, "local", localHeight, "remote", remoteHeight, "err", err)
+				return 0, err
+			} else {
+				log.Info("Remote peer didn't respond but is far ahead, skipping validation", "id", p.id, "local", localHeight, "remote", remoteHeight, "err", err)
+			}
 		}
 	}
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -57,6 +57,8 @@ var (
 	fsHeaderSafetyNet = 2048            // Number of headers to discard in case a chain violation is detected
 	fsHeaderContCheck = 3 * time.Second // Time interval to check for header continuations during state download
 	fsMinFullBlocks   = 64              // Number of blocks to retrieve fully even in snap sync
+
+	maxValidationThreshold = uint64(1024) // Number of block difference from remote peer to start validation
 )
 
 var (
@@ -243,7 +245,7 @@ func New(stateDb ethdb.Database, mux *event.TypeMux, chain BlockChain, lightchai
 		stateSyncStart:         make(chan *stateSync),
 		syncStartBlock:         chain.CurrentSnapBlock().Number.Uint64(),
 		ChainValidator:         whitelistService,
-		maxValidationThreshold: 1024,
+		maxValidationThreshold: maxValidationThreshold,
 	}
 	// Create the post-merge skeleton syncer and start the process
 	dl.skeleton = newSkeleton(stateDb, dl.peers, dropPeer, newBeaconBackfiller(dl, success))

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -928,9 +928,9 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 			if localHeight >= remoteHeight-d.maxValidationThreshold {
 				log.Info("Remote peer didn't respond", "id", p.id, "local", localHeight, "remote", remoteHeight, "err", err)
 				return 0, err
-			} else {
-				log.Info("Remote peer didn't respond but is far ahead, skipping validation", "id", p.id, "local", localHeight, "remote", remoteHeight, "err", err)
 			}
+
+			log.Info("Remote peer didn't respond but is far ahead, skipping validation", "id", p.id, "local", localHeight, "remote", remoteHeight, "err", err)
 		}
 	}
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -893,13 +893,6 @@ func (d *Downloader) getFetchHeadersByNumber(p *peerConnection) func(number uint
 // In the rare scenario when we ended up on a long reorganisation (i.e. none of
 // the head links match), we do a binary search to find the common ancestor.
 func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header) (uint64, error) {
-	// Check the validity of peer from which the chain is to be downloaded
-	if d.ChainValidator != nil {
-		if _, err := d.IsValidPeer(d.getFetchHeadersByNumber(p)); err != nil {
-			return 0, err
-		}
-	}
-
 	// Figure out the valid ancestor range to prevent rewrite attacks
 	var (
 		floor        = int64(-1)
@@ -915,6 +908,23 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 		localHeight = d.blockchain.CurrentSnapBlock().Number.Uint64()
 	default:
 		localHeight = d.lightchain.CurrentHeader().Number.Uint64()
+	}
+
+	// Check the validity of peer from which the chain is to be downloaded
+	if d.ChainValidator != nil {
+		_, err := d.IsValidPeer(d.getFetchHeadersByNumber(p))
+		if errors.Is(err, whitelist.ErrMismatch) {
+			return 0, err
+		}
+
+		// Assuming that `remoteHeight` is always greater than `localHeight`, we won't
+		// check peer validity if the remote header is far ahead of us.
+		if errors.Is(err, whitelist.ErrNoRemote) && localHeight > remoteHeight-1024 {
+			log.Info("Remote peer didn't respond but is far ahead, skipping validation", "id", p.id, "local", localHeight, "remote", remoteHeight, "err", err)
+		} else if errors.Is(err, whitelist.ErrNoRemote) {
+			log.Info("Remote peer didn't respond", "id", p.id, "local", localHeight, "remote", remoteHeight, "err", err)
+			return 0, err
+		}
 	}
 
 	p.log.Debug("Looking for common ancestor", "local", localHeight, "remote", remoteHeight)


### PR DESCRIPTION
# Description

Adds modified version of https://github.com/maticnetwork/bor/pull/1167. While syncing if the remote peer is far away (1024 blocks), bypass the validation. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli