### PR TITLE
core: implement AUTH and AUTHCALL opcodes (EIP: 3074)

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -5184,8 +5184,7 @@ func TestEIP3074(t *testing.T) {
 	gspec.Config.TerminalTotalDifficultyPassed = true
 	gspec.Config.ShanghaiBlock = common.Big0
 	gspec.Config.CancunBlock = common.Big0
-	// TODO(manav2401): Add HF name whenever decided
-	// gspec.Config.PragueTime = u64(0)
+	gspec.Config.PragueBlock = common.Big0
 	signer := types.LatestSigner(gspec.Config)
 
 	_, blocks, _ := GenerateChainWithGenesis(gspec, engine, 1, func(i int, b *BlockGen) {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math/big"
@@ -5098,5 +5099,132 @@ func TestEIP3651(t *testing.T) {
 
 	if actual.Cmp(expected) != 0 {
 		t.Fatalf("sender balance incorrect: expected %d, got %d", expected, actual)
+	}
+}
+
+func TestEIP3074(t *testing.T) {
+	var (
+		aa     = common.HexToAddress("0x000000000000000000000000000000000000aaaa")
+		bb     = common.HexToAddress("0x000000000000000000000000000000000000bbbb")
+		engine = beacon.NewFaker()
+
+		// A sender who makes transactions, has some funds
+		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		addr   = crypto.PubkeyToAddress(key.PublicKey)
+		funds  = new(big.Int).Mul(common.Big1, big.NewInt(params.Ether))
+		config = *params.AllEthashProtocolChanges
+		gspec  = &Genesis{
+			Config: &config,
+			Alloc: GenesisAlloc{
+				addr: {Balance: funds},
+				// The address 0xAAAA sloads 0x00 and 0x01
+				aa: {
+					Code:    nil, // added below
+					Nonce:   0,
+					Balance: big.NewInt(0),
+				},
+				// The address 0xBBBB calls 0xAAAA
+				bb: {
+					Code: []byte{
+						byte(vm.CALLER),
+						byte(vm.PUSH0),
+						byte(vm.SSTORE),
+						byte(vm.STOP),
+					},
+					Nonce:   0,
+					Balance: big.NewInt(0),
+				},
+			},
+		}
+	)
+
+	invoker := []byte{
+		// copy sig to memory
+		byte(vm.CALLDATASIZE),
+		byte(vm.PUSH0),
+		byte(vm.PUSH0),
+		byte(vm.CALLDATACOPY),
+
+		// set up auth
+		byte(vm.CALLDATASIZE),
+		byte(vm.PUSH0),
+	}
+	// push authority to stack
+	invoker = append(invoker, append([]byte{byte(vm.PUSH20)}, addr.Bytes()...)...)
+	invoker = append(invoker, []byte{
+
+		byte(vm.AUTH),
+		byte(vm.POP),
+
+		// execute authcall
+		byte(vm.PUSH0), // out size
+		byte(vm.DUP1),  // out offset
+		byte(vm.DUP1),  // out insize
+		byte(vm.DUP1),  // in offset
+		byte(vm.DUP1),  // valueExt
+		byte(vm.DUP1),  // value
+		byte(vm.PUSH2), // address
+		byte(0xbb),
+		byte(0xbb),
+		byte(vm.GAS), // gas
+		byte(vm.AUTHCALL),
+		byte(vm.STOP),
+	}...,
+	)
+
+	// Set the invoker's code.
+	if entry, _ := gspec.Alloc[aa]; true {
+		entry.Code = invoker
+		gspec.Alloc[aa] = entry
+	}
+
+	gspec.Config.BerlinBlock = common.Big0
+	gspec.Config.LondonBlock = common.Big0
+	gspec.Config.TerminalTotalDifficulty = common.Big0
+	gspec.Config.TerminalTotalDifficultyPassed = true
+	gspec.Config.ShanghaiTime = u64(0)
+	gspec.Config.CancunTime = u64(0)
+	gspec.Config.PragueTime = u64(0)
+	signer := types.LatestSigner(gspec.Config)
+
+	_, blocks, _ := GenerateChainWithGenesis(gspec, engine, 1, func(i int, b *BlockGen) {
+		commit := common.Hash{0x42}
+		msg := []byte{params.AuthMagic}
+		msg = append(msg, common.LeftPadBytes(gspec.Config.ChainID.Bytes(), 32)...)
+		msg = append(msg, common.LeftPadBytes(aa.Bytes(), 32)...)
+		msg = append(msg, commit.Bytes()...)
+		msg = crypto.Keccak256(msg)
+
+		sig, _ := crypto.Sign(msg, key)
+		sig = append([]byte{sig[len(sig)-1]}, sig[0:len(sig)-1]...)
+		txdata := &types.DynamicFeeTx{
+			ChainID:    gspec.Config.ChainID,
+			Nonce:      0,
+			To:         &aa,
+			Gas:        500000,
+			GasFeeCap:  newGwei(5),
+			GasTipCap:  big.NewInt(2),
+			AccessList: nil,
+			Data:       append(sig, commit.Bytes()...),
+		}
+		tx := types.NewTx(txdata)
+		tx, _ = types.SignTx(tx, signer, key)
+
+		b.AddTx(tx)
+	})
+	chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), nil, gspec, nil, engine, vm.Config{Tracer: logger.NewMarkdownLogger(&logger.Config{}, os.Stderr)}, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	defer chain.Stop()
+	if n, err := chain.InsertChain(blocks); err != nil {
+		t.Fatalf("block %d: failed to insert into chain: %v", n, err)
+	}
+
+	// Verify authcall worked correctly.
+	state, _ := chain.State()
+	got := state.GetState(bb, common.Hash{})
+	if want := common.LeftPadBytes(addr.Bytes(), 32); !bytes.Equal(got.Bytes(), want) {
+		t.Fatalf("incorrect sender in authcall: got %s, want %s", got.Hex(), common.Bytes2Hex(want))
 	}
 }

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -5173,7 +5173,7 @@ func TestEIP3074(t *testing.T) {
 	)
 
 	// Set the invoker's code.
-	if entry, _ := gspec.Alloc[aa]; true {
+	if entry := gspec.Alloc[aa]; true {
 		entry.Code = invoker
 		gspec.Alloc[aa] = entry
 	}
@@ -5191,6 +5191,7 @@ func TestEIP3074(t *testing.T) {
 		commit := common.Hash{0x42}
 		msg := []byte{params.AuthMagic}
 		msg = append(msg, common.LeftPadBytes(gspec.Config.ChainID.Bytes(), 32)...)
+		msg = append(msg, common.LeftPadBytes(big.NewInt(1).Bytes(), 32)...) // nonce: 1
 		msg = append(msg, common.LeftPadBytes(aa.Bytes(), 32)...)
 		msg = append(msg, commit.Bytes()...)
 		msg = crypto.Keccak256(msg)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -5182,9 +5182,10 @@ func TestEIP3074(t *testing.T) {
 	gspec.Config.LondonBlock = common.Big0
 	gspec.Config.TerminalTotalDifficulty = common.Big0
 	gspec.Config.TerminalTotalDifficultyPassed = true
-	gspec.Config.ShanghaiTime = u64(0)
-	gspec.Config.CancunTime = u64(0)
-	gspec.Config.PragueTime = u64(0)
+	gspec.Config.ShanghaiBlock = common.Big0
+	gspec.Config.CancunBlock = common.Big0
+	// TODO(manav2401): Add HF name whenever decided
+	// gspec.Config.PragueTime = u64(0)
 	signer := types.LatestSigner(gspec.Config)
 
 	_, blocks, _ := GenerateChainWithGenesis(gspec, engine, 1, func(i int, b *BlockGen) {
@@ -5212,7 +5213,7 @@ func TestEIP3074(t *testing.T) {
 
 		b.AddTx(tx)
 	})
-	chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), nil, gspec, nil, engine, vm.Config{Tracer: logger.NewMarkdownLogger(&logger.Config{}, os.Stderr)}, nil, nil)
+	chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), nil, gspec, nil, engine, vm.Config{Tracer: logger.NewMarkdownLogger(&logger.Config{}, os.Stderr)}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create tester chain: %v", err)
 	}

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
@@ -332,4 +333,105 @@ func enable6780(jt *JumpTable) {
 		minStack:    minStack(1, 0),
 		maxStack:    maxStack(1, 0),
 	}
+}
+
+func enable3074(jt *JumpTable) {
+	jt[AUTH] = &operation{
+		execute:     opAuth,
+		constantGas: 3100,
+		dynamicGas:  gasReturn,
+		minStack:    minStack(3, 1),
+		maxStack:    maxStack(3, 1),
+		memorySize:  memoryAuth,
+	}
+	jt[AUTHCALL] = &operation{
+		execute:     opAuthCall,
+		constantGas: params.CallGasEIP150,
+		dynamicGas:  gasCallEIP2929,
+		minStack:    minStack(8, 1),
+		maxStack:    maxStack(8, 1),
+		memorySize:  memoryCall,
+	}
+}
+
+func opAuth(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	var (
+		tmp       = scope.Stack.pop()
+		authority = common.Address(tmp.Bytes20())
+		offset    = scope.Stack.pop()
+		length    = scope.Stack.pop()
+		data      = scope.Memory.GetPtr(int64(offset.Uint64()), int64(length.Uint64()))
+		sig       = make([]byte, 65)
+		commit    common.Hash
+	)
+	copy(sig, data)
+	if len(data) > 65 {
+		copy(commit[:], data[65:])
+	}
+
+	// Build original auth message.
+	msg := []byte{params.AuthMagic}
+	msg = append(msg, common.LeftPadBytes(interpreter.evm.chainConfig.ChainID.Bytes(), 32)...)
+	msg = append(msg, common.LeftPadBytes(scope.Contract.Address().Bytes(), 32)...)
+	msg = append(msg, commit.Bytes()...)
+	msg = crypto.Keccak256(msg)
+
+	// Verify signature against provided address.
+	sig = append(sig[1:], sig[0])
+	pub, err := crypto.Ecrecover(msg, sig)
+	var recovered common.Address
+	copy(recovered[:], crypto.Keccak256(pub[1:])[12:])
+
+	fmt.Println(recovered)
+	fmt.Println(authority)
+
+	if err != nil || recovered != authority {
+		scope.Stack.push(uint256.NewInt(0))
+		return nil, err
+	}
+
+	scope.Stack.push(uint256.NewInt(1))
+	scope.Authorized = &authority
+	return nil, nil
+}
+
+func opAuthCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	if scope.Authorized == nil {
+		return nil, ErrAuthorizedNotSet
+	}
+	var (
+		stack                                                = scope.Stack
+		temp                                                 = stack.pop()
+		gas                                                  = interpreter.evm.callGasTemp
+		addr, value, _, inOffset, inSize, retOffset, retSize = stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
+		toAddr                                               = common.Address(addr.Bytes20())
+		args                                                 = scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
+	)
+
+	if interpreter.readOnly && !value.IsZero() {
+		return nil, ErrWriteProtection
+	}
+
+	var bigVal = big0
+	if !value.IsZero() {
+		gas += params.CallStipend
+		bigVal = value.ToBig()
+	}
+
+	ret, returnGas, err := interpreter.evm.AuthCall(scope.Contract, *scope.Authorized, toAddr, args, gas, bigVal)
+
+	if err != nil {
+		temp.Clear()
+	} else {
+		temp.SetOne()
+	}
+	stack.push(&temp)
+	if err == nil || err == ErrExecutionReverted {
+		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+	}
+	scope.Contract.Gas += returnGas
+
+	interpreter.returnData = ret
+	return ret, nil
+
 }

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -414,7 +414,6 @@ func opAuthCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 
 	var bigVal = big0
 	if !value.IsZero() {
-		gas += params.CallStipend
 		bigVal = value.ToBig()
 	}
 

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -349,8 +349,8 @@ func enable3074(jt *JumpTable) {
 		execute:     opAuthCall,
 		constantGas: params.CallGasEIP150,
 		dynamicGas:  gasCallEIP2929,
-		minStack:    minStack(8, 1),
-		maxStack:    maxStack(8, 1),
+		minStack:    minStack(7, 1),
+		maxStack:    maxStack(7, 1),
 		memorySize:  memoryCall,
 	}
 }
@@ -417,12 +417,12 @@ func opAuthCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 		return nil, ErrAuthorizedNotSet
 	}
 	var (
-		stack                                                = scope.Stack
-		temp                                                 = stack.pop()
-		gas                                                  = interpreter.evm.callGasTemp
-		addr, value, _, inOffset, inSize, retOffset, retSize = stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
-		toAddr                                               = common.Address(addr.Bytes20())
-		args                                                 = scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
+		stack                                             = scope.Stack
+		temp                                              = stack.pop()
+		gas                                               = interpreter.evm.callGasTemp
+		addr, value, inOffset, inSize, retOffset, retSize = stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
+		toAddr                                            = common.Address(addr.Bytes20())
+		args                                              = scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
 	)
 
 	if interpreter.readOnly && !value.IsZero() {

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -389,15 +389,22 @@ func opAuth(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	// Verify signature against provided address.
 	sig = append(sig[1:], sig[0])
 	pub, err := crypto.Ecrecover(msg, sig)
+	if err != nil {
+		scope.Authorized = nil
+		scope.Stack.push(uint256.NewInt(0))
+		return nil, err
+	}
+
 	var recovered common.Address
 	copy(recovered[:], crypto.Keccak256(pub[1:])[12:])
 
 	fmt.Println(recovered)
 	fmt.Println(authority)
 
-	if err != nil || recovered != authority {
+	if recovered != authority {
+		scope.Authorized = nil
 		scope.Stack.push(uint256.NewInt(0))
-		return nil, err
+		return nil, ErrInvalidAuthSignature
 	}
 
 	scope.Stack.push(uint256.NewInt(1))

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -417,7 +417,7 @@ func opAuthCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 		bigVal = value.ToBig()
 	}
 
-	ret, returnGas, err := interpreter.evm.AuthCall(scope.Contract, *scope.Authorized, toAddr, args, gas, bigVal)
+	ret, returnGas, err := interpreter.evm.AuthCall(scope.Contract, *scope.Authorized, toAddr, args, gas, bigVal, nil)
 
 	if err != nil {
 		temp.Clear()

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -371,6 +371,12 @@ func opAuth(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 		copy(commit[:], data[65:])
 	}
 
+	// Verify if the provided authority address isn't a contract
+	if code := interpreter.evm.StateDB.GetCode(authority); len(code) != 0 {
+		scope.Stack.push(uint256.NewInt(0))
+		return nil, ErrAuthorizedIsContract
+	}
+
 	// Build original auth message.
 	msg := []byte{params.AuthMagic}
 	msg = append(msg, common.LeftPadBytes(interpreter.evm.chainConfig.ChainID.Bytes(), 32)...)

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -373,6 +373,7 @@ func opAuth(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 
 	// Verify if the provided authority address isn't a contract
 	if code := interpreter.evm.StateDB.GetCode(authority); len(code) != 0 {
+		scope.Authorized = nil
 		scope.Stack.push(uint256.NewInt(0))
 		return nil, ErrAuthorizedIsContract
 	}

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -37,6 +37,7 @@ var (
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
+	ErrAuthorizedIsContract     = errors.New("authcall with authorized as a contract address")
 	ErrAuthorizedNotSet         = errors.New("authcall without setting authorized")
 
 	// errStopToken is an internal token indicating interpreter loop termination,

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -37,8 +37,6 @@ var (
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
-	ErrInvalidAuthSignature     = errors.New("invalid auth signature")
-	ErrAuthorizedIsContract     = errors.New("authcall with authorized as a contract address")
 	ErrAuthorizedNotSet         = errors.New("authcall without setting authorized")
 
 	// errStopToken is an internal token indicating interpreter loop termination,

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -37,6 +37,7 @@ var (
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
+	ErrInvalidAuthSignature     = errors.New("invalid auth signature")
 	ErrAuthorizedIsContract     = errors.New("authcall with authorized as a contract address")
 	ErrAuthorizedNotSet         = errors.New("authcall without setting authorized")
 

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -37,6 +37,7 @@ var (
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
+	ErrAuthorizedNotSet         = errors.New("authcall without setting authorized")
 
 	// errStopToken is an internal token indicating interpreter loop termination,
 	// never returned to outside callers.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -429,7 +429,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 }
 
 // AuthCall mimic Call except it sets the caller to the Authorized addres$ in Scope.
-func (evm *EVM) AuthCall(invoker ContractRef, caller, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
+func (evm *EVM) AuthCall(invoker ContractRef, caller, addr common.Address, input []byte, gas uint64, value *big.Int, interruptCtx context.Context) (ret []byte, leftOverGas uint64, err error) {
 	// Fail if we're trying to execute above the call depth limit
 	if evm.depth > int(params.CallCreateDepth) {
 		return nil, gas, ErrDepth
@@ -491,7 +491,7 @@ func (evm *EVM) AuthCall(invoker ContractRef, caller, addr common.Address, input
 			// The depth-check is already done, and precompiles handled above
 			contract := NewContract(AccountRef(callerCopy), AccountRef(addrCopy), value, gas)
 			contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), code)
-			ret, err = evm.interpreter.Run(contract, input, false)
+			ret, err = evm.interpreter.PreRun(contract, input, false, interruptCtx)
 			gas = contract.Gas
 		}
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -428,7 +428,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	return ret, gas, err
 }
 
-// AuthCall mimic Call except it sets the caller to the Authorized addres$ in Scope.
+// AuthCall mimic Call except it sets the caller to the Authorized address in Scope.
 func (evm *EVM) AuthCall(invoker ContractRef, caller, addr common.Address, input []byte, gas uint64, value *big.Int, interruptCtx context.Context) (ret []byte, leftOverGas uint64, err error) {
 	// Fail if we're trying to execute above the call depth limit
 	if evm.depth > int(params.CallCreateDepth) {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -428,7 +428,9 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	return ret, gas, err
 }
 
-// AuthCall mimic Call except it sets the caller to the Authorized address in Scope.
+// AuthCall mimic Call except it sets the caller to the Authorized address in Scope
+// and invoker and addr represents the invoker contract and destination contract
+// being called respectively.
 func (evm *EVM) AuthCall(invoker ContractRef, caller, addr common.Address, input []byte, gas uint64, value *big.Int, interruptCtx context.Context) (ret []byte, leftOverGas uint64, err error) {
 	// Fail if we're trying to execute above the call depth limit
 	if evm.depth > int(params.CallCreateDepth) {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -437,7 +437,7 @@ func (evm *EVM) AuthCall(invoker ContractRef, caller, addr common.Address, input
 		return nil, gas, ErrDepth
 	}
 	// Fail if we're trying to transfer more than the available balance
-	if value.Sign() != 0 && !evm.Context.CanTransfer(evm.StateDB, invoker.Address(), value) {
+	if value.Sign() != 0 && !evm.Context.CanTransfer(evm.StateDB, caller, value) {
 		return nil, gas, ErrInsufficientBalance
 	}
 	snapshot := evm.StateDB.Snapshot()
@@ -460,7 +460,7 @@ func (evm *EVM) AuthCall(invoker ContractRef, caller, addr common.Address, input
 		}
 		evm.StateDB.CreateAccount(addr)
 	}
-	evm.Context.Transfer(evm.StateDB, invoker.Address(), addr, value)
+	evm.Context.Transfer(evm.StateDB, caller, addr, value)
 
 	// Capture the tracer start/end events in debug mode
 	if debug {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -428,6 +428,88 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	return ret, gas, err
 }
 
+// AuthCall mimic Call except it sets the caller to the Authorized addres$ in Scope.
+func (evm *EVM) AuthCall(invoker ContractRef, caller, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
+	// Fail if we're trying to execute above the call depth limit
+	if evm.depth > int(params.CallCreateDepth) {
+		return nil, gas, ErrDepth
+	}
+	// Fail if we're trying to transfer more than the available balance
+	if value.Sign() != 0 && !evm.Context.CanTransfer(evm.StateDB, invoker.Address(), value) {
+		return nil, gas, ErrInsufficientBalance
+	}
+	snapshot := evm.StateDB.Snapshot()
+	p, isPrecompile := evm.precompile(addr)
+	debug := evm.Config.Tracer != nil
+
+	if !evm.StateDB.Exist(addr) {
+		if !isPrecompile && evm.chainRules.IsEIP158 && value.Sign() == 0 {
+			// Calling a non existing account, don't do anything, but ping the tracer
+			if debug {
+				if evm.depth == 0 {
+					evm.Config.Tracer.CaptureStart(evm, invoker.Address(), addr, false, input, gas, value)
+					evm.Config.Tracer.CaptureEnd(ret, 0, nil)
+				} else {
+					evm.Config.Tracer.CaptureEnter(AUTHCALL, invoker.Address(), addr, input, gas, value)
+					evm.Config.Tracer.CaptureExit(ret, 0, nil)
+				}
+			}
+			return nil, gas, nil
+		}
+		evm.StateDB.CreateAccount(addr)
+	}
+	evm.Context.Transfer(evm.StateDB, invoker.Address(), addr, value)
+
+	// Capture the tracer start/end events in debug mode
+	if debug {
+		if evm.depth == 0 {
+			evm.Config.Tracer.CaptureStart(evm, invoker.Address(), addr, false, input, gas, value)
+			defer func(startGas uint64) { // Lazy evaluation of the parameters
+				evm.Config.Tracer.CaptureEnd(ret, startGas-gas, err)
+			}(gas)
+		} else {
+			// Handle tracer events for entering and exiting a call frame
+			evm.Config.Tracer.CaptureEnter(AUTHCALL, invoker.Address(), addr, input, gas, value)
+			defer func(startGas uint64) {
+				evm.Config.Tracer.CaptureExit(ret, startGas-gas, err)
+			}(gas)
+		}
+	}
+
+	if isPrecompile {
+		ret, gas, err = RunPrecompiledContract(p, input, gas)
+	} else {
+		// Initialise a new contract and set the code that is to be used by the EVM.
+		// The contract is a scoped environment for this execution context only.
+		code := evm.StateDB.GetCode(addr)
+		if len(code) == 0 {
+			ret, err = nil, nil // gas is unchanged
+		} else {
+			addrCopy := addr
+			callerCopy := caller
+			// If the account has no code, we can abort here
+			// The depth-check is already done, and precompiles handled above
+			contract := NewContract(AccountRef(callerCopy), AccountRef(addrCopy), value, gas)
+			contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), code)
+			ret, err = evm.interpreter.Run(contract, input, false)
+			gas = contract.Gas
+		}
+	}
+	// When an error was returned by the EVM or when setting the creation code
+	// above we revert to the snapshot and consume any gas remaining. Additionally
+	// when we're in homestead this also counts for code storage gas errors.
+	if err != nil {
+		evm.StateDB.RevertToSnapshot(snapshot)
+		if err != ErrExecutionReverted {
+			gas = 0
+		}
+		// TODO: consider clearing up unused snapshots:
+		//} else {
+		//	evm.StateDB.DiscardSnapshot(snapshot)
+	}
+	return ret, gas, err
+}
+
 type codeAndHash struct {
 	code []byte
 	hash common.Hash

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -1079,9 +1079,9 @@ func TestOpAuth(t *testing.T) {
 	}
 	for _, tt := range []testcase{
 		{name: "happy case", key: key, addcode: false, changeSignature: false, expectedResult: 0, expectedError: nil, expectedStack: 1, expectedAuthorized: &addr},
-		{name: "invalid key", key: key2, addcode: false, changeSignature: false, expectedResult: 0, expectedError: ErrInvalidAuthSignature, expectedStack: 0, expectedAuthorized: nil},
+		{name: "invalid key", key: key2, addcode: false, changeSignature: false, expectedResult: 0, expectedError: nil, expectedStack: 0, expectedAuthorized: nil},
 		{name: "invalid signature", key: key, addcode: false, changeSignature: true, expectedResult: 0, expectedError: errors.New("recovery failed"), expectedStack: 0, expectedAuthorized: nil},
-		{name: "invalid authority", key: key, addcode: true, changeSignature: false, expectedResult: 0, expectedError: ErrAuthorizedIsContract, expectedStack: 0, expectedAuthorized: nil},
+		{name: "invalid authority", key: key, addcode: true, changeSignature: false, expectedResult: 0, expectedError: nil, expectedStack: 0, expectedAuthorized: nil},
 	} {
 		pc := uint64(0)
 

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -1101,12 +1101,12 @@ func TestOpAuth(t *testing.T) {
 
 		// Call AUTH
 		res, err := opAuth(&pc, evm.interpreter, scope)
-		require.Equal(t, tt.expectedError, err, "unexpected error executing AUTH")
-		require.Equal(t, tt.expectedResult, len(res), "unexpected return value")
+		require.Equal(t, tt.expectedError, err, tt.name, "unexpected error executing AUTH")
+		require.Equal(t, tt.expectedResult, len(res), tt.name, "unexpected return value")
 
 		// Check the stack for response and scope for authorized
 		actual := stack.pop()
-		require.Equal(t, tt.expectedStack, actual.Uint64(), "unexpected value in stack")
-		require.Equal(t, tt.expectedAuthorized, scope.Authorized, "unexpected authorized address in scope")
+		require.Equal(t, tt.expectedStack, actual.Uint64(), tt.name, "unexpected value in stack")
+		require.Equal(t, tt.expectedAuthorized, scope.Authorized, tt.name, "unexpected authorized address in scope")
 	}
 }

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -120,7 +120,7 @@ func testTwoOperandOp(t *testing.T, tests []TwoOperandTestcase, opFn executionFu
 
 		stack.push(x)
 		stack.push(y)
-		opFn(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opFn(&pc, evmInterpreter, &ScopeContext{nil, stack, nil, nil})
 
 		if len(stack.data) != 1 {
 			t.Errorf("Expected one item on stack after %v, got %d: ", name, len(stack.data))
@@ -239,7 +239,7 @@ func TestAddMod(t *testing.T) {
 		stack.push(z)
 		stack.push(y)
 		stack.push(x)
-		opAddmod(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opAddmod(&pc, evmInterpreter, &ScopeContext{nil, stack, nil, nil})
 
 		actual := stack.pop()
 		if actual.Cmp(expected) != 0 {
@@ -271,7 +271,7 @@ func TestWriteExpectedValues(t *testing.T) {
 			stack.push(x)
 			stack.push(y)
 
-			_, _ = opFn(&pc, interpreter, &ScopeContext{nil, stack, nil})
+			_, _ = opFn(&pc, interpreter, &ScopeContext{nil, stack, nil, nil})
 			actual := stack.pop()
 			result[i] = TwoOperandTestcase{param.x, param.y, fmt.Sprintf("%064x", actual)}
 		}
@@ -312,7 +312,7 @@ func opBenchmark(bench *testing.B, op executionFunc, args ...string) {
 	var (
 		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
-		scope          = &ScopeContext{nil, stack, nil}
+		scope          = &ScopeContext{nil, stack, nil, nil}
 		evmInterpreter = NewEVMInterpreter(env)
 	)
 
@@ -570,7 +570,7 @@ func TestOpMstore(t *testing.T) {
 	v := "abcdef00000000000000abba000000000deaf000000c0de00100000000133700"
 	stack.push(new(uint256.Int).SetBytes(common.Hex2Bytes(v)))
 	stack.push(new(uint256.Int))
-	opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+	opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil, nil})
 
 	if got := common.Bytes2Hex(mem.GetCopy(0, 32)); got != v {
 		t.Fatalf("Mstore fail, got %v, expected %v", got, v)
@@ -578,7 +578,7 @@ func TestOpMstore(t *testing.T) {
 
 	stack.push(new(uint256.Int).SetUint64(0x1))
 	stack.push(new(uint256.Int))
-	opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+	opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil, nil})
 
 	if common.Bytes2Hex(mem.GetCopy(0, 32)) != "0000000000000000000000000000000000000000000000000000000000000001" {
 		t.Fatalf("Mstore failed to overwrite previous value")
@@ -606,7 +606,7 @@ func BenchmarkOpMstore(bench *testing.B) {
 	for i := 0; i < bench.N; i++ {
 		stack.push(value)
 		stack.push(memStart)
-		opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+		opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil, nil})
 	}
 }
 
@@ -623,7 +623,7 @@ func TestOpTstore(t *testing.T) {
 		to             = common.Address{1}
 		contractRef    = contractRef{caller}
 		contract       = NewContract(contractRef, AccountRef(to), new(big.Int), 0)
-		scopeContext   = ScopeContext{mem, stack, contract}
+		scopeContext   = ScopeContext{mem, stack, contract, nil}
 		value          = common.Hex2Bytes("abcdef00000000000000abba000000000deaf000000c0de00100000000133700")
 	)
 
@@ -679,7 +679,7 @@ func BenchmarkOpKeccak256(bench *testing.B) {
 	for i := 0; i < bench.N; i++ {
 		stack.push(uint256.NewInt(32))
 		stack.push(start)
-		opKeccak256(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+		opKeccak256(&pc, evmInterpreter, &ScopeContext{mem, stack, nil, nil})
 	}
 }
 
@@ -775,7 +775,7 @@ func TestRandom(t *testing.T) {
 			evmInterpreter = env.interpreter
 		)
 
-		opRandom(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opRandom(&pc, evmInterpreter, &ScopeContext{nil, stack, nil, nil})
 
 		if len(stack.data) != 1 {
 			t.Errorf("Expected one item on stack after %v, got %d: ", tt.name, len(stack.data))
@@ -821,7 +821,7 @@ func TestBlobHash(t *testing.T) {
 			evmInterpreter = env.interpreter
 		)
 		stack.push(uint256.NewInt(tt.idx))
-		opBlobHash(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opBlobHash(&pc, evmInterpreter, &ScopeContext{nil, stack, nil, nil})
 		if len(stack.data) != 1 {
 			t.Errorf("Expected one item on stack after %v, got %d: ", tt.name, len(stack.data))
 		}
@@ -962,7 +962,7 @@ func TestOpMCopy(t *testing.T) {
 			mem.Resize(memorySize)
 		}
 		// Do the copy
-		opMcopy(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+		opMcopy(&pc, evmInterpreter, &ScopeContext{mem, stack, nil, nil})
 		want := common.FromHex(strings.ReplaceAll(tc.want, " ", ""))
 		if have := mem.store; !bytes.Equal(want, have) {
 			t.Errorf("case %d: \nwant: %#x\nhave: %#x\n", i, want, have)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -57,9 +57,10 @@ type Config struct {
 // ScopeContext contains the things that are per-call, such as stack and memory,
 // but not transients like pc and gas
 type ScopeContext struct {
-	Memory   *Memory
-	Stack    *Stack
-	Contract *Contract
+	Memory     *Memory
+	Stack      *Stack
+	Contract   *Contract
+	Authorized *common.Address
 }
 
 // EVMInterpreter represents an EVM interpreter
@@ -128,6 +129,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	var table *JumpTable
 
 	switch {
+	case evm.chainRules.IsPrague:
+		table = &pragueInstructionSet
 	case evm.chainRules.IsCancun:
 		table = &cancunInstructionSet
 	case evm.chainRules.IsShanghai:

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -178,7 +178,7 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	return &EVMInterpreter{evm: evm, table: table}
 }
 
-// PreRun is a wrapper around Run that allows for a delay to be injected before each opcode when induced by tests else it calls the lagace Run() method
+// PreRun is a wrapper around Run that allows for a delay to be injected before each opcode when induced by tests else it calls the legacy Run() method
 func (in *EVMInterpreter) PreRun(contract *Contract, input []byte, readOnly bool, interruptCtx context.Context) (ret []byte, err error) {
 	var opcodeDelay interface{}
 

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -57,6 +57,7 @@ var (
 	mergeInstructionSet            = newMergeInstructionSet()
 	shanghaiInstructionSet         = newShanghaiInstructionSet()
 	cancunInstructionSet           = newCancunInstructionSet()
+	pragueInstructionSet           = newPraugeInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -79,6 +80,12 @@ func validate(jt JumpTable) JumpTable {
 	}
 
 	return jt
+}
+
+func newPraugeInstructionSet() JumpTable {
+	instructionSet := newCancunInstructionSet()
+	enable3074(&instructionSet) // EIP-3074 AUTH & AUTHCALL
+	return validate(instructionSet)
 }
 
 func newCancunInstructionSet() JumpTable {

--- a/core/vm/memory_table.go
+++ b/core/vm/memory_table.go
@@ -56,6 +56,10 @@ func memoryMcopy(stack *Stack) (uint64, bool) {
 	return calcMemSize64(mStart, stack.Back(2)) // stack[2]: length
 }
 
+func memoryAuth(stack *Stack) (uint64, bool) {
+	return calcMemSize64(stack.Back(1), stack.Back(2))
+}
+
 func memoryCreate(stack *Stack) (uint64, bool) {
 	return calcMemSize64(stack.Back(1), stack.Back(2))
 }

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -218,6 +218,9 @@ const (
 	DELEGATECALL OpCode = 0xf4
 	CREATE2      OpCode = 0xf5
 
+	AUTH     OpCode = 0xf6
+	AUTHCALL OpCode = 0xf7
+
 	STATICCALL   OpCode = 0xfa
 	REVERT       OpCode = 0xfd
 	INVALID      OpCode = 0xfe
@@ -391,6 +394,8 @@ var opCodeToString = [256]string{
 	CALLCODE:     "CALLCODE",
 	DELEGATECALL: "DELEGATECALL",
 	CREATE2:      "CREATE2",
+	AUTH:         "AUTH",
+	AUTHCALL:     "AUTHCALL",
 	STATICCALL:   "STATICCALL",
 	REVERT:       "REVERT",
 	INVALID:      "INVALID",
@@ -548,6 +553,8 @@ var stringToOp = map[string]OpCode{
 	"LOG4":           LOG4,
 	"CREATE":         CREATE,
 	"CREATE2":        CREATE2,
+	"AUTH":           AUTH,
+	"AUTHCALL":       AUTHCALL,
 	"CALL":           CALL,
 	"RETURN":         RETURN,
 	"CALLCODE":       CALLCODE,

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -18,6 +18,7 @@ package vm
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -47,7 +48,8 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 				// Once we're done with YOLOv2 and schedule this for mainnet, might
 				// be good to remove this panic here, which is just really a
 				// canary to have during testing
-				panic("impossible case: address was not present in access list during sstore op")
+
+				panic(fmt.Sprintf("impossible case: address was not present in access list during sstore op %s", contract.Address()))
 			}
 		}
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -196,6 +196,8 @@ var (
 	BeaconRootsStorageAddress = common.HexToAddress("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02")
 	// SystemAddress is where the system-transaction is sent from as per EIP-4788
 	SystemAddress common.Address = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
+
+	AuthMagic = byte(0x03)
 )
 
 func BaseFeeChangeDenominator(borConfig *BorConfig, number *big.Int) uint64 {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -197,7 +197,8 @@ var (
 	// SystemAddress is where the system-transaction is sent from as per EIP-4788
 	SystemAddress common.Address = common.HexToAddress("0xfffffffffffffffffffffffffffffffffffffffe")
 
-	AuthMagic = byte(0x03)
+	// AuthMagic is used for signing EIP-3074 signatures to prevent signature collisions with other signing formats.
+	AuthMagic = byte(0x04)
 )
 
 func BaseFeeChangeDenominator(borConfig *BorConfig, number *big.Int) uint64 {


### PR DESCRIPTION
# Description

This PR implements EIP 3074, as defined and specified [here](https://eips.ethereum.org/EIPS/eip-3074). It adds 2 new opcodes AUTH and AUTHCALL to the EVM. 

The base implementation is borrowed from upstream go-ethereum repo ([PR](https://github.com/ethereum/go-ethereum/pull/28615)).

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
