### PR TITLE
core, eth, internal, miner, params: enforce 30gwei for gas related configs in bor

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -147,7 +147,7 @@ var DefaultConfig = Config{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 1,
+	PriceLimit: params.BorDefaultTxPoolPriceLimit,
 	PriceBump:  10,
 
 	AccountSlots: 16,
@@ -167,7 +167,8 @@ func (config *Config) sanitize() Config {
 		log.Warn("Sanitizing invalid txpool journal time", "provided", conf.Rejournal, "updated", time.Second)
 		conf.Rejournal = time.Second
 	}
-	if conf.PriceLimit < 1 {
+	// enforce txpool price limit to 30gwei in bor
+	if conf.PriceLimit != params.BorDefaultTxPoolPriceLimit {
 		log.Warn("Sanitizing invalid txpool price limit", "provided", conf.PriceLimit, "updated", DefaultConfig.PriceLimit)
 		conf.PriceLimit = DefaultConfig.PriceLimit
 	}

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -61,6 +61,14 @@ const (
 func init() {
 	testTxPoolConfig = DefaultConfig
 	testTxPoolConfig.Journal = ""
+	/*
+	Given the introduction of `BorDefaultTxPoolPriceLimit=30gwei`,
+	we set `testTxPoolConfig.PriceLimit = 1` to avoid rewriting all `legacypool_test.go` tests,
+	causing code divergence from geth, as this has been widely tested on different networks.
+	Also, `worker_test.go` has been adapted to reflect such changes.
+	Furthermore, config test can be found in `TestTxPoolDefaultPriceLimit`
+	*/
+	testTxPoolConfig.PriceLimit = 1
 
 	cpy := *params.TestChainConfig
 	eip1559Config = &cpy
@@ -284,6 +292,18 @@ func (c *testChain) State() (*state.StateDB, error) {
 	}
 
 	return stdb, nil
+}
+
+// TestTxPoolDefaultPriceLimit ensures the bor default tx pool price limit is set correctly.
+func TestTxPoolDefaultPriceLimit(t *testing.T) {
+	t.Parallel()
+
+	pool, _ := setupPool()
+	defer pool.Close()
+
+	if have, want := pool.config.PriceLimit, uint64(params.BorDefaultTxPoolPriceLimit); have != want {
+		t.Fatalf("txpool price limit incorrect: have %d, want %d", have, want)
+	}
 }
 
 // This test simulates a scenario where a new block is imported during a

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -61,7 +61,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   nolocals = false              # Disables price exemptions for locally submitted transactions
   journal = "transactions.rlp"  # Disk journal for local transaction to survive node restarts
   rejournal = "1h0m0s"          # Time interval to regenerate the local transaction journal
-  pricelimit = 1                # Minimum gas price limit to enforce for acceptance into the pool (mainnet = 30000000000)
+  pricelimit = 30000000000      # Minimum gas price limit to enforce for acceptance into the pool. Regardless the value set, it will be enforced to 30000000000 in bor.
   pricebump = 10                # Price bump percentage to replace an already existing transaction
   accountslots = 16             # Minimum number of executable transaction slots guaranteed per account
   globalslots = 32768           # Maximum number of executable transaction slots for all accounts
@@ -74,7 +74,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   etherbase = ""           # Public address for block mining rewards
   extradata = ""           # Block extra data set by the miner (default = client version)
   gaslimit = 30000000      # Target gas ceiling for mined blocks
-  gasprice = "1000000000"  # Minimum gas price for mining a transaction (recommended for mainnet = 30000000000, default suitable for amoy/mumbai/devnet)
+  gasprice = "30000000000"  # Minimum gas price for mining a transaction. Regardless the value set, it will be enforced to 30000000000 in bor, default suitable for amoy/mumbai/devnet.
   recommit = "2m5s"        # The time interval for miner to re-create mining work
   commitinterrupt = true   # Interrupt the current mining work when time is exceeded and create partial blocks
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -46,7 +46,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```gpo.blocks```: Number of recent blocks to check for gas prices (default: 20)
 
-- ```gpo.ignoreprice```: Gas price below which gpo will ignore transactions (default: 2)
+- ```gpo.ignoreprice```: Gas price below which gpo will ignore transactions (default: 30000000000). It's set to 30gwei in bor
 
 - ```gpo.maxblockhistory```: Maximum block history of gasprice oracle (default: 1024)
 
@@ -248,7 +248,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```miner.gaslimit```: Target gas ceiling (gas limit) for mined blocks (default: 30000000)
 
-- ```miner.gasprice```: Minimum gas price for mining a transaction (default: 1000000000)
+- ```miner.gasprice```: Minimum gas price for mining a transaction (default: 30000000000). It's set to 30gwei in bor
 
 - ```miner.interruptcommit```: Interrupt block commit when block creation time is passed (default: true)
 
@@ -304,6 +304,6 @@ The ```bor server``` command runs the Bor client.
 
 - ```txpool.pricebump```: Price bump percentage to replace an already existing transaction (default: 10)
 
-- ```txpool.pricelimit```: Minimum gas price limit to enforce for acceptance into the pool (default: 1)
+- ```txpool.pricelimit```: Minimum gas price limit to enforce the acceptance of txs into the pool (default: 30000000000). It's set to 30gwei in bor
 
 - ```txpool.rejournal```: Time interval to regenerate the local transaction journal (default: 1h0m0s)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -122,7 +122,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if !config.SyncMode.IsValid() {
 		return nil, fmt.Errorf("invalid sync mode %d", config.SyncMode)
 	}
-	if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(common.Big0) <= 0 {
+	// enforce minimum gas price of 30 gwei in bor
+	if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(big.NewInt(params.BorDefaultMinerGasPrice)) != 0 {
 		log.Warn("Sanitizing invalid miner gas price", "provided", config.Miner.GasPrice, "updated", ethconfig.Defaults.Miner.GasPrice)
 		config.Miner.GasPrice = new(big.Int).Set(ethconfig.Defaults.Miner.GasPrice)
 	}

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -84,7 +84,7 @@ func generateMergeChain(n int, merged bool) (*core.Genesis, []*types.Block) {
 	generate := func(i int, g *core.BlockGen) {
 		g.OffsetTime(5)
 		g.SetExtra([]byte("test"))
-		tx, _ := types.SignTx(types.NewTransaction(testNonce, common.HexToAddress("0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a"), big.NewInt(1), params.TxGas, big.NewInt(params.InitialBaseFee*2), nil), types.LatestSigner(&config), testKey)
+		tx, _ := types.SignTx(types.NewTransaction(testNonce, common.HexToAddress("0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a"), big.NewInt(1), params.TxGas, big.NewInt(params.InitialBaseFee*32), nil), types.LatestSigner(&config), testKey)
 		g.AddTx(tx)
 		testNonce++
 	}
@@ -604,7 +604,7 @@ func TestNewPayloadOnInvalidChain(t *testing.T) {
 			Nonce:    statedb.GetNonce(testAddr),
 			Value:    new(big.Int),
 			Gas:      1000000,
-			GasPrice: big.NewInt(2 * params.InitialBaseFee),
+			GasPrice: big.NewInt(32 * params.InitialBaseFee),
 			Data:     logCode,
 		})
 		ethservice.TxPool().Add([]*types.Transaction{tx}, false, true)

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -36,7 +36,7 @@ const sampleNumber = 3 // Number of transactions sampled in a block
 
 var (
 	DefaultMaxPrice    = big.NewInt(500 * params.GWei)
-	DefaultIgnorePrice = big.NewInt(2 * params.Wei)
+	DefaultIgnorePrice = big.NewInt(params.BorDefaultGpoIgnorePrice)
 )
 
 type Config struct {
@@ -101,7 +101,7 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 	}
 
 	ignorePrice := params.IgnorePrice
-	if ignorePrice == nil || ignorePrice.Int64() <= 0 {
+	if ignorePrice == nil || ignorePrice.Int64() != DefaultIgnorePrice.Int64() {
 		ignorePrice = DefaultIgnorePrice
 		log.Warn("Sanitizing invalid gasprice oracle ignore price", "provided", params.IgnorePrice, "updated", ignorePrice)
 	} else if ignorePrice.Int64() > 0 {

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -655,7 +655,7 @@ func DefaultConfig() *Config {
 			NoLocals:     false,
 			Journal:      "transactions.rlp",
 			Rejournal:    1 * time.Hour,
-			PriceLimit:   1, // geth's default
+			PriceLimit:   params.BorDefaultTxPoolPriceLimit, // bor's default
 			PriceBump:    10,
 			AccountSlots: 16,
 			GlobalSlots:  32768,
@@ -666,8 +666,8 @@ func DefaultConfig() *Config {
 		Sealer: &SealerConfig{
 			Enabled:             false,
 			Etherbase:           "",
-			GasCeil:             30_000_000,                  // geth's default
-			GasPrice:            big.NewInt(1 * params.GWei), // geth's default
+			GasCeil:             30_000_000,                                 // geth's default
+			GasPrice:            big.NewInt(params.BorDefaultMinerGasPrice), // bor's default
 			ExtraData:           "",
 			Recommit:            125 * time.Second,
 			CommitInterruptFlag: true,

--- a/internal/cli/server/config_test.go
+++ b/internal/cli/server/config_test.go
@@ -1,10 +1,14 @@
 package server
 
 import (
+	"math/big"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestConfigDefault(t *testing.T) {
@@ -15,8 +19,15 @@ func TestConfigDefault(t *testing.T) {
 	_, err := config.buildNode()
 	assert.NoError(t, err)
 
-	_, err = config.buildEth(nil, nil)
+	ethConfig, err := config.buildEth(nil, nil)
 	assert.NoError(t, err)
+	assertBorDefaultGasPrice(t, ethConfig)
+}
+
+// assertBorDefaultGasPrice asserts the bor default gas price is set correctly.
+func assertBorDefaultGasPrice(t *testing.T, ethConfig *ethconfig.Config) {
+	assert.NotNil(t, ethConfig)
+	assert.Equal(t, ethConfig.Miner.GasPrice, big.NewInt(params.BorDefaultMinerGasPrice))
 }
 
 func TestConfigMerge(t *testing.T) {

--- a/internal/cli/server/testdata/default.toml
+++ b/internal/cli/server/testdata/default.toml
@@ -58,7 +58,7 @@ devfakeauthor = false
   nolocals = false
   journal = "transactions.rlp"
   rejournal = "1h0m0s"
-  pricelimit = 1
+  pricelimit = 30000000000
   pricebump = 10
   accountslots = 16
   globalslots = 32768
@@ -71,7 +71,7 @@ devfakeauthor = false
   etherbase = ""
   extradata = ""
   gaslimit = 30000000
-  gasprice = "1000000000"
+  gasprice = "30000000000"
   recommit = "2m5s"
   commitinterrupt = true
 
@@ -127,7 +127,7 @@ devfakeauthor = false
   maxheaderhistory = 1024
   maxblockhistory = 1024
   maxprice = "500000000000"
-  ignoreprice = "2"
+  ignoreprice = "30000000000"
 
 [telemetry]
   metrics = false

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -60,7 +60,7 @@ type Config struct {
 // DefaultConfig contains default settings for miner.
 var DefaultConfig = Config{
 	GasCeil:  30000000,
-	GasPrice: big.NewInt(params.GWei),
+	GasPrice: big.NewInt(params.BorDefaultMinerGasPrice), // enforces minimum gas price of 30 gwei in bor
 
 	// The default recommit time is chosen as two seconds since
 	// consensus-layer usually will wait a half slot of time(6s)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -297,7 +297,7 @@ func (b *testWorkerBackend) newRandomTxWithNonce(creation bool, nonce uint64) *t
 func (b *testWorkerBackend) newStorageCreateContractTx() (*types.Transaction, common.Address) {
 	var tx *types.Transaction
 
-	gasPrice := big.NewInt(10 * params.InitialBaseFee)
+	gasPrice := big.NewInt(30 * params.InitialBaseFee)
 
 	tx, _ = types.SignTx(types.NewContractCreation(b.txPool.Nonce(TestBankAddress), big.NewInt(0), testGas, gasPrice, common.FromHex(storageContractByteCode)), types.HomesteadSigner{}, testBankKey)
 	contractAddr := crypto.CreateAddress(TestBankAddress, b.txPool.Nonce(TestBankAddress))

--- a/packaging/templates/testnet-amoy/archive/config.toml
+++ b/packaging/templates/testnet-amoy/archive/config.toml
@@ -57,12 +57,12 @@ gcmode = "archive"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 1
+    # pricelimit = 30000000000
     # pricebump = 10
 
 [miner]
     gaslimit = 30000000
-    # gasprice = "1000000000"
+    # gasprice = "30000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""
@@ -119,7 +119,7 @@ gcmode = "archive"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "2"
+    # ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-amoy/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-amoy/sentry/sentry/bor/config.toml
@@ -57,12 +57,12 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 1
+    # pricelimit = 30000000000
     # pricebump = 10
 
 [miner]
     gaslimit = 30000000
-    # gasprice = "1000000000"
+    # gasprice = "30000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""
@@ -119,7 +119,7 @@ syncmode = "full"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "2"
+    # ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-amoy/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-amoy/sentry/validator/bor/config.toml
@@ -59,13 +59,13 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 1
+    # pricelimit = 30000000000
     # pricebump = 10
 
 [miner]
     mine = true
     gaslimit = 30000000
-    # gasprice = "1000000000"
+    # gasprice = "30000000000"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
@@ -121,7 +121,7 @@ syncmode = "full"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "2"
+    # ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-amoy/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-amoy/without-sentry/bor/config.toml
@@ -59,13 +59,13 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 1
+    # pricelimit = 30000000000
     # pricebump = 10
 
 [miner]
     mine = true
     gaslimit = 30000000
-    # gasprice = "1000000000"
+    # gasprice = "30000000000"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
@@ -121,7 +121,7 @@ syncmode = "full"
 #     maxheaderhistory = 1024
 #     maxblockhistory = 1024
 #     maxprice = "5000000000000"
-#     ignoreprice = "2"
+#     ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-v4/archive/config.toml
+++ b/packaging/templates/testnet-v4/archive/config.toml
@@ -59,12 +59,12 @@ gcmode = "archive"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 1
+    # pricelimit = 30000000000
     # pricebump = 10
 
 [miner]
     gaslimit = 30000000
-    # gasprice = "1000000000"
+    # gasprice = "30000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""
@@ -121,7 +121,7 @@ gcmode = "archive"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "2"
+    # ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
@@ -59,12 +59,12 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 1
+    # pricelimit = 30000000000
     # pricebump = 10
 
 [miner]
     gaslimit = 30000000
-    # gasprice = "1000000000"
+    # gasprice = "30000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""
@@ -121,7 +121,7 @@ syncmode = "full"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "2"
+    # ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
@@ -61,13 +61,13 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 1
+    # pricelimit = 30000000000
     # pricebump = 10
 
 [miner]
     mine = true
     gaslimit = 30000000
-    # gasprice = "1000000000"
+    # gasprice = "30000000000"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
@@ -123,7 +123,7 @@ syncmode = "full"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "2"
+    # ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-v4/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/without-sentry/bor/config.toml
@@ -61,13 +61,13 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 1
+    # pricelimit = 30000000000
     # pricebump = 10
 
 [miner]
     mine = true
     gaslimit = 30000000
-    # gasprice = "1000000000"
+    # gasprice = "30000000000"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
@@ -123,7 +123,7 @@ syncmode = "full"
 #     maxheaderhistory = 1024
 #     maxblockhistory = 1024
 #     maxprice = "5000000000000"
-#     ignoreprice = "2"
+#     ignoreprice = "30000000000"
 
 [telemetry]
     metrics = true

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -181,6 +181,15 @@ const (
 
 	BlobTxTargetBlobGasPerBlock = 3 * BlobTxBlobGasPerBlob // Target consumable blob gas for data blobs per block (for 1559-like pricing)
 	MaxBlobGasPerBlock          = 6 * BlobTxBlobGasPerBlob // Maximum consumable blob gas for data blobs per block
+
+	// BorDefaultMinerGasPrice defines the minimum gas price for bor validators to mine a transaction.
+	BorDefaultMinerGasPrice = 30 * GWei
+
+	// BorDefaultTxPoolPriceLimit defines the minimum gas price limit for bor to enforce txs acceptance into the pool.
+	BorDefaultTxPoolPriceLimit = 30 * GWei
+
+	// BorDefaultGpoIgnorePrice defines the minimum gas price below which bor gpo will ignore transactions.
+	BorDefaultGpoIgnorePrice = 30 * GWei
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations


### PR DESCRIPTION
# Description

This PR enforces the params `txpool.pricelimit`, `miner.gasprice` and `gpo.ignoreprice` to be set to 30 gwei.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- Related erigon PR: https://github.com/ledgerwatch/erigon/pull/10119 

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli