### PR TITLE
Add `debug.peerStats` for stats related to all connected peers

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -474,3 +474,7 @@ func (b *EthAPIBackend) GetWhitelistedMilestone() (bool, uint64, common.Hash) {
 func (b *EthAPIBackend) PurgeWhitelistedMilestone() {
 	b.eth.Downloader().ChainValidator.PurgeWhitelistedMilestone()
 }
+
+func (b *EthAPIBackend) PeerStats() interface{} {
+	return b.eth.handler.GetPeerStats()
+}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -724,3 +724,33 @@ func (h *handler) enableSyncedFeatures() {
 		h.chain.TrieDB().SetBufferSize(pathdb.DefaultBufferSize)
 	}
 }
+
+// PeerStats represents a short summary of the information known about a connected
+// peer. Specifically, it contains details about the head hash and total difficulty
+// of a peer which makes it a bit different from the PeerInfo.
+type PeerStats struct {
+	Enode string `json:"enode"` // Node URL
+	ID    string `json:"id"`    // Unique node identifier
+	Name  string `json:"name"`  // Name of the node, including client type, version, OS, custom data
+	Hash  string `json:"hash"`  // Head hash of the peer
+	Td    uint64 `json:"td"`    // Total difficulty of the peer
+}
+
+// PeerStats returns the current head height and td of all the connected peers
+// along with few additional identifiers.
+func (h *handler) GetPeerStats() []*PeerStats {
+	info := make([]*PeerStats, 0, len(h.peers.peers))
+
+	for _, peer := range h.peers.peers {
+		hash, td := peer.Head()
+		info = append(info, &PeerStats{
+			Enode: peer.Node().URLv4(),
+			ID:    peer.ID(),
+			Name:  peer.Name(),
+			Hash:  hash.String(),
+			Td:    td.Uint64(),
+		})
+	}
+
+	return info
+}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2729,6 +2729,12 @@ func (api *DebugAPI) GetTraceStack() string {
 	}
 }
 
+// PeerStats returns the current head height and td of all the connected peers
+// along with few additional identifiers.
+func (api *DebugAPI) PeerStats() interface{} {
+	return api.b.PeerStats()
+}
+
 // NetAPI offers network related RPC methods
 type NetAPI struct {
 	net            *p2p.Server

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -644,6 +644,10 @@ func (b testBackend) SubscribeStateSyncEvent(ch chan<- core.StateSyncEvent) even
 	panic("implement me")
 }
 
+func (b testBackend) PeerStats() interface{} {
+	panic("implement me")
+}
+
 func (b testBackend) GetBorBlockLogs(ctx context.Context, hash common.Hash) ([]*types.Log, error) {
 	receipt, err := b.GetBorBlockReceipt(ctx, hash)
 	if err != nil || receipt == nil {

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -112,6 +112,9 @@ type Backend interface {
 	PurgeWhitelistedCheckpoint()
 	GetWhitelistedMilestone() (bool, uint64, common.Hash)
 	PurgeWhitelistedMilestone()
+
+	// Networking related APIs
+	PeerStats() interface{}
 }
 
 func GetAPIs(apiBackend Backend) []rpc.API {

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -412,3 +412,7 @@ func (b *backendMock) GetWhitelistedMilestone() (bool, uint64, common.Hash) {
 func (b *backendMock) PurgeWhitelistedCheckpoint() {}
 
 func (b *backendMock) PurgeWhitelistedMilestone() {}
+
+func (b backendMock) PeerStats() interface{} {
+	return nil
+}

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -376,3 +376,7 @@ func (b *LesApiBackend) GetWhitelistedMilestone() (bool, uint64, common.Hash) {
 
 func (b *LesApiBackend) PurgeWhitelistedMilestone() {
 }
+
+func (b *LesApiBackend) PeerStats() interface{} {
+	return nil
+}


### PR DESCRIPTION
# Description

This PR implements a new RPC/IPC call named `debug.peerStats` which can be used to get additional block related information from all the connected peers. 

More specifically, it emits `hash` and `td` (total difficulty) of the head block of all the peers along with some metadata and identifiers. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [x] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [x] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it