### PR TITLE
eth: broadcast block to static and trusted peers as well

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -606,6 +606,17 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 			log.Error("Propagating dangling block", "number", block.Number(), "hash", hash)
 			return
 		}
+
+		// These are the static and trusted peers which are not
+		// in `transfer := peers[:int(math.Sqrt(float64(len(peers))))]`
+		staticAndTrustedPeers := []*ethPeer{}
+
+		for _, peer := range peers[int(math.Sqrt(float64(len(peers)))):] {
+			if peer.IsTrusted() || peer.IsStatic() {
+				staticAndTrustedPeers = append(staticAndTrustedPeers, peer)
+			}
+		}
+
 		// Send the block to a subset of our peers
 		transfer := peers[:int(math.Sqrt(float64(len(peers))))]
 		for _, peer := range transfer {
@@ -613,6 +624,14 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		}
 
 		log.Trace("Propagated block", "hash", hash, "recipients", len(transfer), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
+
+		// Send the block to the trusted and static peers
+		for _, peer := range staticAndTrustedPeers {
+			log.Trace("Propagating block to static and trusted peer", "hash", hash, "peerID", peer.ID())
+			peer.AsyncSendNewBlock(block, td)
+		}
+
+		log.Trace("Propagated same block to additional static and trusted peers", "hash", hash, "recipients", len(staticAndTrustedPeers), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
 
 		return
 	}

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -470,6 +470,16 @@ func (p *Peer) RequestTxs(hashes []common.Hash) error {
 	})
 }
 
+// IsTrusted returns whether the peer is a trusted peer or not.
+func (p *Peer) IsTrusted() bool {
+	return p.Info().Network.Trusted
+}
+
+// IsStatic returns whether the peer is a static peer or not.
+func (p *Peer) IsStatic() bool {
+	return p.Info().Network.Static
+}
+
 // knownCache is a cache for known hashes.
 type knownCache struct {
 	hashes mapset.Set[common.Hash]

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2238,7 +2238,8 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber uint64, signer types.Signer, tx *types.Transaction, txIndex int, borTx bool) map[string]interface{} {
 	from, _ := types.Sender(signer, tx)
 
-	txHash := common.Hash{}
+	var txHash common.Hash
+
 	if borTx {
 		txHash = types.GetDerivedBorTxHash(types.BorReceiptKey(blockNumber, blockHash))
 	} else {


### PR DESCRIPTION
# Description

The block is broadcasted to only Sqrt(peers) in geth. We observed that in case of validator-sentry architecture, the validator, sometime, might not receive a block which will force the validator to mine on his own, resulting in a reorg.

In this PR, we are making sure that the block will be broadcasted to all the static and trusted peers of a particular node.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
