### PR TITLE
eth/fetcher: modify queue limits for improving sync near chain tip

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -40,10 +40,15 @@ const (
 )
 
 const (
-	maxUncleDist = 7   // Maximum allowed backward distance from the chain head
-	maxQueueDist = 32  // Maximum allowed distance from the chain head to queue
-	hashLimit    = 256 // Maximum number of unique blocks or headers a peer may have announced
-	blockLimit   = 64  // Maximum number of unique blocks a peer may have delivered
+	maxUncleDist = 7 // Maximum allowed backward distance from the chain head
+
+	// maxQueueDist is increased for bor to allow storing more block announcements
+	// near chain tip
+	maxQueueDist = 32 * 6 // Maximum allowed distance from the chain head to queue
+	hashLimit    = 256    // Maximum number of unique blocks or headers a peer may have announced
+
+	// blockLimit is increased for bor to allow storing more unique blocks near chain tip
+	blockLimit = 64 * 3 // Maximum number of unique blocks a peer may have delivered
 )
 
 var (


### PR DESCRIPTION
# Description

This PR updates few constants used in block fetcher to suit PoS block timings i.e. 2s as compared to ethereum which is 12s. 

## Rationale

Block fetcher handles downloading of block headers and bodies near the chain tip as it acts upon the block and block hash announcements. A constant `maxQueueDist` is used to queue the block announcements and it's value was initially set to 32. This means that it only stores the block announcements of last 32 blocks from the chain tip. 

While debugging the sync issues observed recently, we identified that old block announcements were dropped while newer ones were included. This used to stall the import as we would have some missing blocks in this case. It can only proceed in 2 cases. 
- Missing blocks are queried again -- as we've dropped the announcement way earlier, it's difficult to do so in fetcher (may require some rework but there are easy options)
- Downloader kicks in to find gaps and download blocks -- there's a timer to this and one has to wait until it triggers

The simplest option for now is to increase the queue limit to store more block announcements and not drop them. The ideal solution is to use a value which is 6x the original value because of the 6x block time. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [x] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

### Manual tests

Tested sync on an internal mainnet node