### PR TITLE
PIP-35 for amoy: enforce gas related configs

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -56,7 +56,7 @@ syncmode = "full"
 
 [txpool]
   nolocals = true
-  pricelimit = 30000000000
+  pricelimit = 30000000000 # 25000000000 for amoy
   accountslots = 16
   globalslots = 32768
   accountqueue = 16
@@ -69,7 +69,7 @@ syncmode = "full"
 
 [miner]
   gaslimit = 30000000
-  gasprice = "30000000000"
+  gasprice = "30000000000" # 25000000000 for amoy
   # mine = true
   # etherbase = "VALIDATOR ADDRESS"
   # extradata = ""
@@ -127,7 +127,7 @@ syncmode = "full"
   # maxheaderhistory = 1024
   # maxblockhistory = 1024
   # maxprice = "5000000000000"
-  ignoreprice = "30000000000"
+  ignoreprice = "30000000000" # 25000000000 for amoy
 
 [telemetry]
   metrics = true

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -62,7 +62,7 @@ func init() {
 	testTxPoolConfig = DefaultConfig
 	testTxPoolConfig.Journal = ""
 	/*
-		Given the introduction of `BorDefaultTxPoolPriceLimit=30gwei`,
+		Given the introduction of `BorDefaultTxPoolPriceLimit=25gwei`,
 		we set `testTxPoolConfig.PriceLimit = 1` to avoid rewriting all `legacypool_test.go` tests,
 		causing code divergence from geth, as this has been widely tested on different networks.
 		Also, `worker_test.go` has been adapted to reflect such changes.
@@ -296,6 +296,9 @@ func (c *testChain) State() (*state.StateDB, error) {
 
 // TestTxPoolDefaultPriceLimit ensures the bor default tx pool price limit is set correctly.
 func TestTxPoolDefaultPriceLimit(t *testing.T) {
+	// (PIP-35): Only applicable to amoy
+	t.Skip("Skipped because the price enforcement is only applied to amoy")
+
 	t.Parallel()
 
 	pool, _ := setupPool()

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -61,7 +61,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   nolocals = false              # Disables price exemptions for locally submitted transactions
   journal = "transactions.rlp"  # Disk journal for local transaction to survive node restarts
   rejournal = "1h0m0s"          # Time interval to regenerate the local transaction journal
-  pricelimit = 30000000000      # Minimum gas price limit to enforce for acceptance into the pool. Regardless the value set, it will be enforced to 30000000000 in bor.
+  pricelimit = 30000000000      # Minimum gas price limit to enforce for acceptance into the pool. Recommended for mainnet = 30000000000 (not enforced). For Amoy network, regardless the value set, it will be enforced to 25000000000 in bor.
   pricebump = 10                # Price bump percentage to replace an already existing transaction
   accountslots = 16             # Minimum number of executable transaction slots guaranteed per account
   globalslots = 32768           # Maximum number of executable transaction slots for all accounts
@@ -74,7 +74,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   etherbase = ""           # Public address for block mining rewards
   extradata = ""           # Block extra data set by the miner (default = client version)
   gaslimit = 30000000      # Target gas ceiling for mined blocks
-  gasprice = "30000000000"  # Minimum gas price for mining a transaction. Regardless the value set, it will be enforced to 30000000000 in bor, default suitable for amoy/mumbai/devnet.
+  gasprice = "30000000000"  # Minimum gas price for mining a transaction. Recommended for mainnet = 30000000000 (not enforced). For Amoy network, regardless the value set, it will be enforced to 25000000000 in bor.
   recommit = "2m5s"        # The time interval for miner to re-create mining work
   commitinterrupt = true   # Interrupt the current mining work when time is exceeded and create partial blocks
 
@@ -128,7 +128,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   maxheaderhistory = 1024     # Maximum header history of gasprice oracle
   maxblockhistory = 1024      # Maximum block history of gasprice oracle
   maxprice = "5000000000000"  # Maximum gas price will be recommended by gpo
-  ignoreprice = "2"           # Gas price below which gpo will ignore transactions (recommended for mainnet = 30000000000, default suitable for amoy/mumbai/devnet)
+  ignoreprice = "2"           # Gas price below which gpo will ignore transactions. Recommended for mainnet = 30000000000 (not enforced). For Amoy network, regardless the value set, it will be enforced to 25000000000 in bor.
 
 [telemetry]
   metrics = false                            # Enable metrics collection and reporting

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -46,7 +46,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```gpo.blocks```: Number of recent blocks to check for gas prices (default: 20)
 
-- ```gpo.ignoreprice```: Gas price below which gpo will ignore transactions (default: 30000000000). It's set to 30gwei in bor
+- ```gpo.ignoreprice```: Gas price below which gpo will ignore transactions (default: 2)
 
 - ```gpo.maxblockhistory```: Maximum block history of gasprice oracle (default: 1024)
 
@@ -250,7 +250,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```miner.gaslimit```: Target gas ceiling (gas limit) for mined blocks (default: 30000000)
 
-- ```miner.gasprice```: Minimum gas price for mining a transaction (default: 30000000000). It's set to 30gwei in bor
+- ```miner.gasprice```: Minimum gas price for mining a transaction (default: 1000000000)
 
 - ```miner.interruptcommit```: Interrupt block commit when block creation time is passed (default: true)
 
@@ -306,6 +306,6 @@ The ```bor server``` command runs the Bor client.
 
 - ```txpool.pricebump```: Price bump percentage to replace an already existing transaction (default: 10)
 
-- ```txpool.pricelimit```: Minimum gas price limit to enforce the acceptance of txs into the pool (default: 30000000000). It's set to 30gwei in bor
+- ```txpool.pricelimit```: Minimum gas price limit to enforce for acceptance into the pool (default: 1)
 
 - ```txpool.rejournal```: Time interval to regenerate the local transaction journal (default: 1h0m0s)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -122,10 +122,17 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if !config.SyncMode.IsValid() {
 		return nil, fmt.Errorf("invalid sync mode %d", config.SyncMode)
 	}
-	// enforce minimum gas price of 30 gwei in bor
-	if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(big.NewInt(params.BorDefaultMinerGasPrice)) != 0 {
-		log.Warn("Sanitizing invalid miner gas price", "provided", config.Miner.GasPrice, "updated", ethconfig.Defaults.Miner.GasPrice)
-		config.Miner.GasPrice = new(big.Int).Set(ethconfig.Defaults.Miner.GasPrice)
+	// (PIP-35): Only enforce the minimum gas price of 25 gwei for amoy
+	if config.Genesis.Config.ChainID.Cmp(params.AmoyChainConfig.ChainID) == 0 {
+		if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(big.NewInt(params.BorDefaultMinerGasPrice)) != 0 {
+			log.Warn("Sanitizing invalid miner gas price", "provided", config.Miner.GasPrice, "updated", params.BorDefaultMinerGasPrice)
+			config.Miner.GasPrice = new(big.Int).SetUint64(params.BorDefaultMinerGasPrice)
+		}
+	} else {
+		if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(common.Big0) <= 0 {
+			log.Warn("Sanitizing invalid miner gas price", "provided", config.Miner.GasPrice, "updated", ethconfig.Defaults.Miner.GasPrice)
+			config.Miner.GasPrice = new(big.Int).Set(ethconfig.Defaults.Miner.GasPrice)
+		}
 	}
 	if config.NoPruning && config.TrieDirtyCache > 0 {
 		if config.SnapshotCache > 0 {
@@ -251,6 +258,10 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TxLookupLimit, checker)
 	}
 
+	// (PIP-35): Update the default ignore price for amoy
+	if chainConfig.ChainID.Cmp(params.AmoyChainConfig.ChainID) == 0 {
+		gasprice.DefaultIgnorePriceAmoy = new(big.Int).SetUint64(params.BorDefaultGpoIgnorePrice)
+	}
 	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams)
 	if err != nil {
 		return nil, err
@@ -277,6 +288,14 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// The `config.TxPool.PriceLimit` used above doesn't reflect the sanitized/enforced changes
+	// made in the txpool. Update the `gasTip` explicitly to reflect the enforced value.
+	// (PIP-35): This change is only applied for Amoy network. Remove the checks once it's applied for all networks.
+	if chainConfig.ChainID.Cmp(params.AmoyChainConfig.ChainID) == 0 {
+		eth.txPool.SetGasTip(new(big.Int).SetUint64(params.BorDefaultTxPoolPriceLimit))
+	}
+
 	// Permit the downloader to use the trie cache allowance during fast sync
 	cacheLimit := cacheConfig.TrieCleanLimit + cacheConfig.TrieDirtyLimit + cacheConfig.SnapshotLimit
 	if eth.handler, err = newHandler(&handlerConfig{

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -123,7 +123,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		return nil, fmt.Errorf("invalid sync mode %d", config.SyncMode)
 	}
 	// (PIP-35): Only enforce the minimum gas price of 25 gwei for amoy
-	if config.Genesis.Config.ChainID.Cmp(params.AmoyChainConfig.ChainID) == 0 {
+	if config.Genesis != nil && config.Genesis.Config.ChainID.Cmp(params.AmoyChainConfig.ChainID) == 0 {
 		if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(big.NewInt(params.BorDefaultMinerGasPrice)) != 0 {
 			log.Warn("Sanitizing invalid miner gas price", "provided", config.Miner.GasPrice, "updated", params.BorDefaultMinerGasPrice)
 			config.Miner.GasPrice = new(big.Int).SetUint64(params.BorDefaultMinerGasPrice)

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -84,7 +84,7 @@ func generateMergeChain(n int, merged bool) (*core.Genesis, []*types.Block) {
 	generate := func(i int, g *core.BlockGen) {
 		g.OffsetTime(5)
 		g.SetExtra([]byte("test"))
-		tx, _ := types.SignTx(types.NewTransaction(testNonce, common.HexToAddress("0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a"), big.NewInt(1), params.TxGas, big.NewInt(params.InitialBaseFee*32), nil), types.LatestSigner(&config), testKey)
+		tx, _ := types.SignTx(types.NewTransaction(testNonce, common.HexToAddress("0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a"), big.NewInt(1), params.TxGas, big.NewInt(params.InitialBaseFee*2), nil), types.LatestSigner(&config), testKey)
 		g.AddTx(tx)
 		testNonce++
 	}
@@ -604,7 +604,7 @@ func TestNewPayloadOnInvalidChain(t *testing.T) {
 			Nonce:    statedb.GetNonce(testAddr),
 			Value:    new(big.Int),
 			Gas:      1000000,
-			GasPrice: big.NewInt(32 * params.InitialBaseFee),
+			GasPrice: big.NewInt(2 * params.InitialBaseFee),
 			Data:     logCode,
 		})
 		ethservice.TxPool().Add([]*types.Transaction{tx}, false, true)

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -655,7 +655,7 @@ func DefaultConfig() *Config {
 			NoLocals:     false,
 			Journal:      "transactions.rlp",
 			Rejournal:    1 * time.Hour,
-			PriceLimit:   params.BorDefaultTxPoolPriceLimit, // bor's default
+			PriceLimit:   1, // Default for every network except Amoy
 			PriceBump:    10,
 			AccountSlots: 16,
 			GlobalSlots:  32768,
@@ -666,8 +666,8 @@ func DefaultConfig() *Config {
 		Sealer: &SealerConfig{
 			Enabled:             false,
 			Etherbase:           "",
-			GasCeil:             30_000_000,                                 // geth's default
-			GasPrice:            big.NewInt(params.BorDefaultMinerGasPrice), // bor's default
+			GasCeil:             30_000_000,                  // geth's default
+			GasPrice:            big.NewInt(1 * params.GWei), // Default for every network except Amoy
 			ExtraData:           "",
 			Recommit:            125 * time.Second,
 			CommitInterruptFlag: true,

--- a/internal/cli/server/config_test.go
+++ b/internal/cli/server/config_test.go
@@ -26,6 +26,9 @@ func TestConfigDefault(t *testing.T) {
 
 // assertBorDefaultGasPrice asserts the bor default gas price is set correctly.
 func assertBorDefaultGasPrice(t *testing.T, ethConfig *ethconfig.Config) {
+	// (PIP-35): Only applicable to amoy
+	t.Skip("Skipped because the price enforcement is only applied to amoy")
+
 	assert.NotNil(t, ethConfig)
 	assert.Equal(t, ethConfig.Miner.GasPrice, big.NewInt(params.BorDefaultMinerGasPrice))
 }

--- a/internal/cli/server/testdata/default.toml
+++ b/internal/cli/server/testdata/default.toml
@@ -58,7 +58,7 @@ devfakeauthor = false
   nolocals = false
   journal = "transactions.rlp"
   rejournal = "1h0m0s"
-  pricelimit = 30000000000
+  pricelimit = 1
   pricebump = 10
   accountslots = 16
   globalslots = 32768
@@ -71,7 +71,7 @@ devfakeauthor = false
   etherbase = ""
   extradata = ""
   gaslimit = 30000000
-  gasprice = "30000000000"
+  gasprice = "1000000000"
   recommit = "2m5s"
   commitinterrupt = true
 
@@ -127,7 +127,7 @@ devfakeauthor = false
   maxheaderhistory = 1024
   maxblockhistory = 1024
   maxprice = "500000000000"
-  ignoreprice = "30000000000"
+  ignoreprice = "2"
 
 [telemetry]
   metrics = false

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -59,8 +59,11 @@ type Config struct {
 
 // DefaultConfig contains default settings for miner.
 var DefaultConfig = Config{
-	GasCeil:  30000000,
-	GasPrice: big.NewInt(params.BorDefaultMinerGasPrice), // enforces minimum gas price of 30 gwei in bor
+	GasCeil: 30000000,
+
+	// (PIP-35): Update the gas price to `params.BorDefaultMinerGasPrice` once
+	// the change is applied over all networks.
+	GasPrice: big.NewInt(params.GWei),
 
 	// The default recommit time is chosen as two seconds since
 	// consensus-layer usually will wait a half slot of time(6s)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -297,7 +297,7 @@ func (b *testWorkerBackend) newRandomTxWithNonce(creation bool, nonce uint64) *t
 func (b *testWorkerBackend) newStorageCreateContractTx() (*types.Transaction, common.Address) {
 	var tx *types.Transaction
 
-	gasPrice := big.NewInt(30 * params.InitialBaseFee)
+	gasPrice := big.NewInt(10 * params.InitialBaseFee)
 
 	tx, _ = types.SignTx(types.NewContractCreation(b.txPool.Nonce(TestBankAddress), big.NewInt(0), testGas, gasPrice, common.FromHex(storageContractByteCode)), types.HomesteadSigner{}, testBankKey)
 	contractAddr := crypto.CreateAddress(TestBankAddress, b.txPool.Nonce(TestBankAddress))

--- a/packaging/templates/testnet-amoy/archive/config.toml
+++ b/packaging/templates/testnet-amoy/archive/config.toml
@@ -57,12 +57,12 @@ gcmode = "archive"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 25000000000
     # pricebump = 10
 
 [miner]
     gaslimit = 30000000
-    # gasprice = "30000000000"
+    # gasprice = "25000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""
@@ -119,7 +119,7 @@ gcmode = "archive"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "30000000000"
+    # ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-amoy/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-amoy/sentry/sentry/bor/config.toml
@@ -57,12 +57,12 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 25000000000
     # pricebump = 10
 
 [miner]
     gaslimit = 30000000
-    # gasprice = "30000000000"
+    # gasprice = "25000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""
@@ -119,7 +119,7 @@ syncmode = "full"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "30000000000"
+    # ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-amoy/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-amoy/sentry/validator/bor/config.toml
@@ -59,13 +59,13 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 25000000000
     # pricebump = 10
 
 [miner]
     mine = true
     gaslimit = 30000000
-    # gasprice = "30000000000"
+    # gasprice = "25000000000"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
@@ -121,7 +121,7 @@ syncmode = "full"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "30000000000"
+    # ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-amoy/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-amoy/without-sentry/bor/config.toml
@@ -59,13 +59,13 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 25000000000
     # pricebump = 10
 
 [miner]
     mine = true
     gaslimit = 30000000
-    # gasprice = "30000000000"
+    # gasprice = "25000000000"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
@@ -121,7 +121,7 @@ syncmode = "full"
 #     maxheaderhistory = 1024
 #     maxblockhistory = 1024
 #     maxprice = "5000000000000"
-#     ignoreprice = "30000000000"
+#     ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -183,13 +183,13 @@ const (
 	MaxBlobGasPerBlock          = 6 * BlobTxBlobGasPerBlob // Maximum consumable blob gas for data blobs per block
 
 	// BorDefaultMinerGasPrice defines the minimum gas price for bor validators to mine a transaction.
-	BorDefaultMinerGasPrice = 30 * GWei
+	BorDefaultMinerGasPrice = 25 * GWei
 
 	// BorDefaultTxPoolPriceLimit defines the minimum gas price limit for bor to enforce txs acceptance into the pool.
-	BorDefaultTxPoolPriceLimit = 30 * GWei
+	BorDefaultTxPoolPriceLimit = 25 * GWei
 
 	// BorDefaultGpoIgnorePrice defines the minimum gas price below which bor gpo will ignore transactions.
-	BorDefaultGpoIgnorePrice = 30 * GWei
+	BorDefaultGpoIgnorePrice = 25 * GWei
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations


### PR DESCRIPTION
# Description

This PR extends on https://github.com/maticnetwork/bor/pull/1264 and makes the following changes:
1. The gas config enforcement value is modified to 25gwei (instead of 30gwei before)
2. The gas config enforcements are only made for Amoy network
3. Fixes a bug in TxPool gas tip enforcement where it wasn't honouring the enforced limit on non-validator nodes

Due to (2), the checks look a bit complicated but upon mainnet release, they'll be again simplified and generalised. PIP-35 for mainnet will be released later with prior announcements. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
