### PR TITLE
miner: log last tx hash before commit interrupt

### DIFF
--- a/miner/test_backend.go
+++ b/miner/test_backend.go
@@ -540,6 +540,8 @@ func (w *worker) commitTransactionsWithDelay(env *environment, txs *transactions
 		}(chDeps)
 	}
 
+	var lastTxHash common.Hash
+
 mainloop:
 	for {
 		if interruptCtx != nil {
@@ -551,7 +553,7 @@ mainloop:
 			select {
 			case <-interruptCtx.Done():
 				txCommitInterruptCounter.Inc(1)
-				log.Warn("Tx Level Interrupt")
+				log.Warn("Tx Level Interrupt", "hash", lastTxHash)
 				break mainloop
 			default:
 			}
@@ -573,6 +575,7 @@ mainloop:
 		if ltx == nil {
 			break
 		}
+		lastTxHash = ltx.Hash
 		// If we don't have enough space for the next transaction, skip the account.
 		if env.gasPool.Gas() < ltx.Gas {
 			log.Trace("Not enough gas left for transaction", "hash", ltx.Hash, "left", env.gasPool.Gas(), "needed", ltx.Gas)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -956,6 +956,8 @@ func (w *worker) commitTransactions(env *environment, txs *transactionsByPriceAn
 		}(chDeps)
 	}
 
+	var lastTxHash common.Hash
+
 mainloop:
 	for {
 		// Check interruption signal and abort building if it's fired.
@@ -974,7 +976,7 @@ mainloop:
 			select {
 			case <-interruptCtx.Done():
 				txCommitInterruptCounter.Inc(1)
-				log.Warn("Tx Level Interrupt")
+				log.Warn("Tx Level Interrupt", "hash", lastTxHash)
 				break mainloop
 			default:
 			}
@@ -990,6 +992,7 @@ mainloop:
 		if ltx == nil {
 			break
 		}
+		lastTxHash = ltx.Hash
 		// If we don't have enough space for the next transaction, skip the account.
 		if env.gasPool.Gas() < ltx.Gas {
 			log.Trace("Not enough gas left for transaction", "hash", ltx.Hash, "left", env.gasPool.Gas(), "needed", ltx.Gas)


### PR DESCRIPTION
This PR logs the last transaction miner was processing before commit interrupt was called. This may be helpful in analysing the kind of transactions which might be taking longer time to process. 