### PR TITLE
PIP-35: enforce gas related configs for mainnet

### DIFF
--- a/builder/files/config.toml
+++ b/builder/files/config.toml
@@ -56,7 +56,7 @@ syncmode = "full"
 
 [txpool]
   nolocals = true
-  pricelimit = 30000000000 # 25000000000 for amoy
+  pricelimit = 25000000000
   accountslots = 16
   globalslots = 32768
   accountqueue = 16
@@ -69,7 +69,7 @@ syncmode = "full"
 
 [miner]
   gaslimit = 30000000
-  gasprice = "30000000000" # 25000000000 for amoy
+  gasprice = "25000000000"
   # mine = true
   # etherbase = "VALIDATOR ADDRESS"
   # extradata = ""
@@ -127,7 +127,7 @@ syncmode = "full"
   # maxheaderhistory = 1024
   # maxblockhistory = 1024
   # maxprice = "5000000000000"
-  ignoreprice = "30000000000" # 25000000000 for amoy
+  ignoreprice = "25000000000"
 
 [telemetry]
   metrics = true

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -296,9 +296,6 @@ func (c *testChain) State() (*state.StateDB, error) {
 
 // TestTxPoolDefaultPriceLimit ensures the bor default tx pool price limit is set correctly.
 func TestTxPoolDefaultPriceLimit(t *testing.T) {
-	// (PIP-35): Only applicable to amoy
-	t.Skip("Skipped because the price enforcement is only applied to amoy")
-
 	t.Parallel()
 
 	pool, _ := setupPool()

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -61,7 +61,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   nolocals = false              # Disables price exemptions for locally submitted transactions
   journal = "transactions.rlp"  # Disk journal for local transaction to survive node restarts
   rejournal = "1h0m0s"          # Time interval to regenerate the local transaction journal
-  pricelimit = 30000000000      # Minimum gas price limit to enforce for acceptance into the pool. Regardless the value set, it will be enforced to 25000000000 for all networks
+  pricelimit = 25000000000      # Minimum gas price limit to enforce for acceptance into the pool. Regardless the value set, it will be enforced to 25000000000 for all networks
   pricebump = 10                # Price bump percentage to replace an already existing transaction
   accountslots = 16             # Minimum number of executable transaction slots guaranteed per account
   globalslots = 32768           # Maximum number of executable transaction slots for all accounts
@@ -74,7 +74,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   etherbase = ""           # Public address for block mining rewards
   extradata = ""           # Block extra data set by the miner (default = client version)
   gaslimit = 30000000      # Target gas ceiling for mined blocks
-  gasprice = "30000000000"  # Minimum gas price for mining a transaction. Regardless the value set, it will be enforced to 25000000000 for all networks
+  gasprice = "25000000000"  # Minimum gas price for mining a transaction. Regardless the value set, it will be enforced to 25000000000 for all networks
   recommit = "2m5s"        # The time interval for miner to re-create mining work
   commitinterrupt = true   # Interrupt the current mining work when time is exceeded and create partial blocks
 
@@ -128,7 +128,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   maxheaderhistory = 1024     # Maximum header history of gasprice oracle
   maxblockhistory = 1024      # Maximum block history of gasprice oracle
   maxprice = "5000000000000"  # Maximum gas price will be recommended by gpo
-  ignoreprice = "2"           # Gas price below which gpo will ignore transactions. Regardless the value set, it will be enforced to 25000000000 for all networks
+  ignoreprice = "25000000000"           # Gas price below which gpo will ignore transactions. Regardless the value set, it will be enforced to 25000000000 for all networks
 
 [telemetry]
   metrics = false                            # Enable metrics collection and reporting

--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -61,7 +61,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   nolocals = false              # Disables price exemptions for locally submitted transactions
   journal = "transactions.rlp"  # Disk journal for local transaction to survive node restarts
   rejournal = "1h0m0s"          # Time interval to regenerate the local transaction journal
-  pricelimit = 30000000000      # Minimum gas price limit to enforce for acceptance into the pool. Recommended for mainnet = 30000000000 (not enforced). For Amoy network, regardless the value set, it will be enforced to 25000000000 in bor.
+  pricelimit = 30000000000      # Minimum gas price limit to enforce for acceptance into the pool. Regardless the value set, it will be enforced to 25000000000 for all networks
   pricebump = 10                # Price bump percentage to replace an already existing transaction
   accountslots = 16             # Minimum number of executable transaction slots guaranteed per account
   globalslots = 32768           # Maximum number of executable transaction slots for all accounts
@@ -74,7 +74,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   etherbase = ""           # Public address for block mining rewards
   extradata = ""           # Block extra data set by the miner (default = client version)
   gaslimit = 30000000      # Target gas ceiling for mined blocks
-  gasprice = "30000000000"  # Minimum gas price for mining a transaction. Recommended for mainnet = 30000000000 (not enforced). For Amoy network, regardless the value set, it will be enforced to 25000000000 in bor.
+  gasprice = "30000000000"  # Minimum gas price for mining a transaction. Regardless the value set, it will be enforced to 25000000000 for all networks
   recommit = "2m5s"        # The time interval for miner to re-create mining work
   commitinterrupt = true   # Interrupt the current mining work when time is exceeded and create partial blocks
 
@@ -128,7 +128,7 @@ devfakeauthor = false           # Run miner without validator set authorization 
   maxheaderhistory = 1024     # Maximum header history of gasprice oracle
   maxblockhistory = 1024      # Maximum block history of gasprice oracle
   maxprice = "5000000000000"  # Maximum gas price will be recommended by gpo
-  ignoreprice = "2"           # Gas price below which gpo will ignore transactions. Recommended for mainnet = 30000000000 (not enforced). For Amoy network, regardless the value set, it will be enforced to 25000000000 in bor.
+  ignoreprice = "2"           # Gas price below which gpo will ignore transactions. Regardless the value set, it will be enforced to 25000000000 for all networks
 
 [telemetry]
   metrics = false                            # Enable metrics collection and reporting

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -46,7 +46,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```gpo.blocks```: Number of recent blocks to check for gas prices (default: 20)
 
-- ```gpo.ignoreprice```: Gas price below which gpo will ignore transactions (default: 2)
+- ```gpo.ignoreprice```: Gas price below which gpo will ignore transactions (default: 25000000000)
 
 - ```gpo.maxblockhistory```: Maximum block history of gasprice oracle (default: 1024)
 
@@ -250,7 +250,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```miner.gaslimit```: Target gas ceiling (gas limit) for mined blocks (default: 30000000)
 
-- ```miner.gasprice```: Minimum gas price for mining a transaction (default: 1000000000)
+- ```miner.gasprice```: Minimum gas price for mining a transaction (default: 25000000000)
 
 - ```miner.interruptcommit```: Interrupt block commit when block creation time is passed (default: true)
 
@@ -306,6 +306,6 @@ The ```bor server``` command runs the Bor client.
 
 - ```txpool.pricebump```: Price bump percentage to replace an already existing transaction (default: 10)
 
-- ```txpool.pricelimit```: Minimum gas price limit to enforce for acceptance into the pool (default: 1)
+- ```txpool.pricelimit```: Minimum gas price limit to enforce for acceptance into the pool (default: 25000000000)
 
 - ```txpool.rejournal```: Time interval to regenerate the local transaction journal (default: 1h0m0s)

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -84,7 +84,7 @@ func generateMergeChain(n int, merged bool) (*core.Genesis, []*types.Block) {
 	generate := func(i int, g *core.BlockGen) {
 		g.OffsetTime(5)
 		g.SetExtra([]byte("test"))
-		tx, _ := types.SignTx(types.NewTransaction(testNonce, common.HexToAddress("0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a"), big.NewInt(1), params.TxGas, big.NewInt(params.InitialBaseFee*2), nil), types.LatestSigner(&config), testKey)
+		tx, _ := types.SignTx(types.NewTransaction(testNonce, common.HexToAddress("0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a"), big.NewInt(1), params.TxGas, big.NewInt(params.InitialBaseFee*26), nil), types.LatestSigner(&config), testKey)
 		g.AddTx(tx)
 		testNonce++
 	}
@@ -604,7 +604,7 @@ func TestNewPayloadOnInvalidChain(t *testing.T) {
 			Nonce:    statedb.GetNonce(testAddr),
 			Value:    new(big.Int),
 			Gas:      1000000,
-			GasPrice: big.NewInt(2 * params.InitialBaseFee),
+			GasPrice: big.NewInt(26 * params.InitialBaseFee),
 			Data:     logCode,
 		})
 		ethservice.TxPool().Add([]*types.Transaction{tx}, false, true)

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -35,9 +35,8 @@ import (
 const sampleNumber = 3 // Number of transactions sampled in a block
 
 var (
-	DefaultMaxPrice        = big.NewInt(500 * params.GWei)
-	DefaultIgnorePrice     = big.NewInt(2 * params.Wei)
-	DefaultIgnorePriceAmoy *big.Int // (PIP-35): Default ignore price for amoy (to be removed later)
+	DefaultMaxPrice    = big.NewInt(500 * params.GWei)
+	DefaultIgnorePrice = big.NewInt(params.BorDefaultGpoIgnorePrice) // bor's default
 )
 
 type Config struct {
@@ -101,21 +100,14 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 		log.Warn("Sanitizing invalid gasprice oracle price cap", "provided", params.MaxPrice, "updated", maxPrice)
 	}
 
-	// (PIP-35): Enforce the ignore price for amoy. The default value for amoy (which is
-	// an indicator of being on amoy) should be set by the caller.
+	// PIP-35: Enforce the ignore price to 25 gwei
 	ignorePrice := params.IgnorePrice
-	if DefaultIgnorePriceAmoy != nil {
-		if ignorePrice == nil || ignorePrice.Int64() != DefaultIgnorePriceAmoy.Int64() {
-			ignorePrice = DefaultIgnorePriceAmoy
-			log.Warn("Sanitizing invalid gasprice oracle ignore price", "provided", params.IgnorePrice, "updated", ignorePrice)
-		}
-	} else {
-		if ignorePrice == nil || ignorePrice.Int64() <= 0 {
-			ignorePrice = DefaultIgnorePrice
-			log.Warn("Sanitizing invalid gasprice oracle ignore price", "provided", params.IgnorePrice, "updated", ignorePrice)
-		}
+	if ignorePrice == nil || ignorePrice.Int64() != DefaultIgnorePrice.Int64() {
+		ignorePrice = DefaultIgnorePrice
+		log.Warn("Sanitizing invalid gasprice oracle ignore price", "provided", params.IgnorePrice, "updated", ignorePrice)
+	} else if ignorePrice.Int64() > 0 {
+		log.Info("Gasprice oracle is ignoring threshold set", "threshold", ignorePrice)
 	}
-	log.Info("Gasprice oracle is ignoring threshold set", "threshold", ignorePrice)
 
 	maxHeaderHistory := params.MaxHeaderHistory
 	if maxHeaderHistory < 1 {

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -105,7 +105,7 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 	if ignorePrice == nil || ignorePrice.Int64() != DefaultIgnorePrice.Int64() {
 		ignorePrice = DefaultIgnorePrice
 		log.Warn("Sanitizing invalid gasprice oracle ignore price", "provided", params.IgnorePrice, "updated", ignorePrice)
-	} else if ignorePrice.Int64() > 0 {
+	} else {
 		log.Info("Gasprice oracle is ignoring threshold set", "threshold", ignorePrice)
 	}
 

--- a/internal/cli/server/command_test.go
+++ b/internal/cli/server/command_test.go
@@ -86,7 +86,7 @@ func TestFlagsWithConfig(t *testing.T) {
 			"32000000": "0x875500011e5eecc0c554f95d07b31cf59df4ca2505f4dbbfffa7d4e4da917c68",
 		},
 	)
-	require.Equal(t, c.config.Sealer.GasPrice, big.NewInt(30000000000))
+	require.Equal(t, c.config.Sealer.GasPrice, big.NewInt(25000000000))
 	require.Equal(t, c.config.Sealer.Recommit, recommit)
 	require.Equal(t, c.config.JsonRPC.RPCEVMTimeout, evmTimeout)
 	require.Equal(t, c.config.JsonRPC.Http.API, []string{"eth", "bor"})

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -655,7 +655,7 @@ func DefaultConfig() *Config {
 			NoLocals:     false,
 			Journal:      "transactions.rlp",
 			Rejournal:    1 * time.Hour,
-			PriceLimit:   1, // Default for every network except Amoy
+			PriceLimit:   params.BorDefaultTxPoolPriceLimit, // bor's default
 			PriceBump:    10,
 			AccountSlots: 16,
 			GlobalSlots:  32768,
@@ -666,8 +666,8 @@ func DefaultConfig() *Config {
 		Sealer: &SealerConfig{
 			Enabled:             false,
 			Etherbase:           "",
-			GasCeil:             30_000_000,                  // geth's default
-			GasPrice:            big.NewInt(1 * params.GWei), // Default for every network except Amoy
+			GasCeil:             30_000_000,                                 // geth's default
+			GasPrice:            big.NewInt(params.BorDefaultMinerGasPrice), // bor's default
 			ExtraData:           "",
 			Recommit:            125 * time.Second,
 			CommitInterruptFlag: true,
@@ -678,7 +678,7 @@ func DefaultConfig() *Config {
 			MaxHeaderHistory: 1024,
 			MaxBlockHistory:  1024,
 			MaxPrice:         gasprice.DefaultMaxPrice,
-			IgnorePrice:      gasprice.DefaultIgnorePrice,
+			IgnorePrice:      gasprice.DefaultIgnorePrice, // bor's default
 		},
 		JsonRPC: &JsonRPCConfig{
 			IPCDisable:          false,

--- a/internal/cli/server/config_legacy_test.go
+++ b/internal/cli/server/config_legacy_test.go
@@ -26,7 +26,7 @@ func TestConfigLegacy(t *testing.T) {
 			"31000000": "0x2087b9e2b353209c2c21e370c82daa12278efd0fe5f0febe6c29035352cf050e",
 			"32000000": "0x875500011e5eecc0c554f95d07b31cf59df4ca2505f4dbbfffa7d4e4da917c68",
 		}
-		testConfig.Sealer.GasPrice = big.NewInt(30000000000)
+		testConfig.Sealer.GasPrice = big.NewInt(25000000000)
 		testConfig.Sealer.Recommit = 20 * time.Second
 		testConfig.JsonRPC.RPCEVMTimeout = 5 * time.Second
 		testConfig.JsonRPC.TxFeeCap = 6.0

--- a/internal/cli/server/config_test.go
+++ b/internal/cli/server/config_test.go
@@ -26,9 +26,6 @@ func TestConfigDefault(t *testing.T) {
 
 // assertBorDefaultGasPrice asserts the bor default gas price is set correctly.
 func assertBorDefaultGasPrice(t *testing.T, ethConfig *ethconfig.Config) {
-	// (PIP-35): Only applicable to amoy
-	t.Skip("Skipped because the price enforcement is only applied to amoy")
-
 	assert.NotNil(t, ethConfig)
 	assert.Equal(t, ethConfig.Miner.GasPrice, big.NewInt(params.BorDefaultMinerGasPrice))
 }

--- a/internal/cli/server/testdata/default.toml
+++ b/internal/cli/server/testdata/default.toml
@@ -58,7 +58,7 @@ devfakeauthor = false
   nolocals = false
   journal = "transactions.rlp"
   rejournal = "1h0m0s"
-  pricelimit = 1
+  pricelimit = 25000000000
   pricebump = 10
   accountslots = 16
   globalslots = 32768
@@ -71,7 +71,7 @@ devfakeauthor = false
   etherbase = ""
   extradata = ""
   gaslimit = 30000000
-  gasprice = "1000000000"
+  gasprice = "25000000000"
   recommit = "2m5s"
   commitinterrupt = true
 
@@ -127,7 +127,7 @@ devfakeauthor = false
   maxheaderhistory = 1024
   maxblockhistory = 1024
   maxprice = "500000000000"
-  ignoreprice = "2"
+  ignoreprice = "25000000000"
 
 [telemetry]
   metrics = false

--- a/internal/cli/server/testdata/test.toml
+++ b/internal/cli/server/testdata/test.toml
@@ -11,7 +11,7 @@ snapshot = true
 "32000000" = "0x875500011e5eecc0c554f95d07b31cf59df4ca2505f4dbbfffa7d4e4da917c68"
 
 [miner]
-  gasprice = "30000000000"
+  gasprice = "25000000000"
   recommit = "20s"
 
 [jsonrpc]

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -59,11 +59,8 @@ type Config struct {
 
 // DefaultConfig contains default settings for miner.
 var DefaultConfig = Config{
-	GasCeil: 30000000,
-
-	// (PIP-35): Update the gas price to `params.BorDefaultMinerGasPrice` once
-	// the change is applied over all networks.
-	GasPrice: big.NewInt(params.GWei),
+	GasCeil:  30000000,
+	GasPrice: big.NewInt(params.BorDefaultMinerGasPrice), // enforce min gas price to 25 gwei for bor
 
 	// The default recommit time is chosen as two seconds since
 	// consensus-layer usually will wait a half slot of time(6s)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -269,7 +269,7 @@ func (b *testWorkerBackend) PeerCount() int {
 
 func (b *testWorkerBackend) newRandomTx(creation bool) *types.Transaction {
 	var tx *types.Transaction
-	gasPrice := big.NewInt(10 * params.InitialBaseFee)
+	gasPrice := big.NewInt(26 * params.InitialBaseFee)
 	if creation {
 		tx, _ = types.SignTx(types.NewContractCreation(b.txPool.Nonce(testBankAddress), big.NewInt(0), testGas, gasPrice, common.FromHex(testCode)), types.HomesteadSigner{}, testBankKey)
 	} else {

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -297,7 +297,7 @@ func (b *testWorkerBackend) newRandomTxWithNonce(creation bool, nonce uint64) *t
 func (b *testWorkerBackend) newStorageCreateContractTx() (*types.Transaction, common.Address) {
 	var tx *types.Transaction
 
-	gasPrice := big.NewInt(10 * params.InitialBaseFee)
+	gasPrice := big.NewInt(26 * params.InitialBaseFee)
 
 	tx, _ = types.SignTx(types.NewContractCreation(b.txPool.Nonce(TestBankAddress), big.NewInt(0), testGas, gasPrice, common.FromHex(storageContractByteCode)), types.HomesteadSigner{}, testBankKey)
 	contractAddr := crypto.CreateAddress(TestBankAddress, b.txPool.Nonce(TestBankAddress))
@@ -309,7 +309,7 @@ func (b *testWorkerBackend) newStorageCreateContractTx() (*types.Transaction, co
 func (b *testWorkerBackend) newStorageContractCallTx(to common.Address, nonce uint64) *types.Transaction {
 	var tx *types.Transaction
 
-	gasPrice := big.NewInt(10 * params.InitialBaseFee)
+	gasPrice := big.NewInt(26 * params.InitialBaseFee)
 
 	tx, _ = types.SignTx(types.NewTransaction(nonce, to, nil, storageCallTxGas, gasPrice, common.FromHex(storageContractTxCallData)), types.HomesteadSigner{}, testBankKey)
 

--- a/packaging/templates/mainnet-v1/archive/config.toml
+++ b/packaging/templates/mainnet-v1/archive/config.toml
@@ -51,7 +51,7 @@ gcmode = "archive"
 
 [txpool]
     nolocals = true
-    pricelimit = 30000000000
+    pricelimit = 25000000000
     accountslots = 16
     globalslots = 32768
     accountqueue = 16
@@ -64,7 +64,7 @@ gcmode = "archive"
 
 [miner]
     gaslimit = 30000000
-    gasprice = "30000000000"
+    gasprice = "25000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""
@@ -121,7 +121,7 @@ gcmode = "archive"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    ignoreprice = "30000000000"
+    ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
@@ -51,7 +51,7 @@ syncmode = "full"
 
 [txpool]
     nolocals = true
-    pricelimit = 30000000000
+    pricelimit = 25000000000
     accountslots = 16
     globalslots = 32768
     accountqueue = 16
@@ -64,7 +64,7 @@ syncmode = "full"
 
 [miner]
     gaslimit = 30000000
-    gasprice = "30000000000"
+    gasprice = "25000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""
@@ -121,7 +121,7 @@ syncmode = "full"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    ignoreprice = "30000000000"
+    ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
@@ -53,7 +53,7 @@ syncmode = "full"
 
 [txpool]
     nolocals = true
-    pricelimit = 30000000000
+    pricelimit = 25000000000
     accountslots = 16
     globalslots = 32768
     accountqueue = 16
@@ -67,7 +67,7 @@ syncmode = "full"
 [miner]
     mine = true
     gaslimit = 30000000
-    gasprice = "30000000000"
+    gasprice = "25000000000"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
@@ -123,7 +123,7 @@ syncmode = "full"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    ignoreprice = "30000000000"
+    ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
@@ -53,7 +53,7 @@ syncmode = "full"
 
 [txpool]
     nolocals = true
-    pricelimit = 30000000000
+    pricelimit = 25000000000
     accountslots = 16
     globalslots = 32768
     accountqueue = 16
@@ -67,7 +67,7 @@ syncmode = "full"
 [miner]
     mine = true
     gaslimit = 30000000
-    gasprice = "30000000000"
+    gasprice = "25000000000"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
@@ -123,7 +123,7 @@ syncmode = "full"
 #     maxheaderhistory = 1024
 #     maxblockhistory = 1024
 #     maxprice = "5000000000000"
-    ignoreprice = "30000000000"
+      ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-v4/archive/config.toml
+++ b/packaging/templates/testnet-v4/archive/config.toml
@@ -59,12 +59,12 @@ gcmode = "archive"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 25000000000
     # pricebump = 10
 
 [miner]
     gaslimit = 30000000
-    # gasprice = "30000000000"
+    # gasprice = "25000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""
@@ -121,7 +121,7 @@ gcmode = "archive"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "30000000000"
+    # ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/sentry/bor/config.toml
@@ -59,12 +59,12 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 25000000000
     # pricebump = 10
 
 [miner]
     gaslimit = 30000000
-    # gasprice = "30000000000"
+    # gasprice = "25000000000"
     # mine = false
     # etherbase = ""
     # extradata = ""
@@ -121,7 +121,7 @@ syncmode = "full"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "30000000000"
+    # ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-v4/sentry/validator/bor/config.toml
@@ -61,13 +61,13 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 25000000000
     # pricebump = 10
 
 [miner]
     mine = true
     gaslimit = 30000000
-    # gasprice = "30000000000"
+    # gasprice = "25000000000"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
@@ -123,7 +123,7 @@ syncmode = "full"
     # maxheaderhistory = 1024
     # maxblockhistory = 1024
     # maxprice = "5000000000000"
-    # ignoreprice = "30000000000"
+    # ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true

--- a/packaging/templates/testnet-v4/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-v4/without-sentry/bor/config.toml
@@ -61,13 +61,13 @@ syncmode = "full"
     # locals = []
     # journal = ""
     # rejournal = "1h0m0s"
-    # pricelimit = 30000000000
+    # pricelimit = 25000000000
     # pricebump = 10
 
 [miner]
     mine = true
     gaslimit = 30000000
-    # gasprice = "30000000000"
+    # gasprice = "25000000000"
     # etherbase = ""
     # extradata = ""
     # recommit = "2m5s"
@@ -123,7 +123,7 @@ syncmode = "full"
 #     maxheaderhistory = 1024
 #     maxblockhistory = 1024
 #     maxprice = "5000000000000"
-#     ignoreprice = "30000000000"
+#     ignoreprice = "25000000000"
 
 [telemetry]
     metrics = true


### PR DESCRIPTION
# Description

This PR generalises the 25 gwei gas enforcement (based on [PIP-35](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-35.md)) to all networks (i.e. specifically polygon mainnet). Earlier, it was only introduced to amoy. This PR removes those checks such that it's applicable to mainnet as well. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

The values `txpool.pricelimit`, `miner.gasprice` and `gpo.ignoreprice` are now enforced to 25 gwei

# Nodes audience

Applicable to all

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [x] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [x] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
