### PR TITLE
fix: eth/protocol: bunduled transactions are not broadcasted to the peers

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -56,6 +56,7 @@ type Transaction struct {
 	inner TxData    // Consensus contents of a transaction
 	time  time.Time // Time first seen locally (spam avoidance)
 
+	// BOR specific - DO NOT REMOVE
 	// knownAccounts (EIP-4337)
 	optionsAA4337 *OptionsAA4337
 

--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -80,7 +80,11 @@ func (p *Peer) broadcastTransactions() {
 				size        common.StorageSize
 			)
 			for i := 0; i < len(queue) && size < maxTxPacketSize; i++ {
-				if tx := p.txpool.Get(queue[i]); tx != nil {
+				tx := p.txpool.Get(queue[i])
+
+				// BOR specific - DO NOT REMOVE
+				// Skip EIP-4337 bundled transactions
+				if tx != nil && tx.GetOptions() == nil {
 					txs = append(txs, tx)
 					size += common.StorageSize(tx.Size())
 				}
@@ -151,6 +155,7 @@ func (p *Peer) announceTransactions() {
 			)
 			for count = 0; count < len(queue) && size < maxTxPacketSize; count++ {
 				tx := p.txpool.Get(queue[count])
+				// BOR specific - DO NOT REMOVE
 				// Skip EIP-4337 bundled transactions
 				if tx != nil && tx.GetOptions() == nil {
 					pending = append(pending, queue[count])


### PR DESCRIPTION
# Description

The check to not broadcast the bundled transactions (EIP-4337/PIP-15) to the peers was removed in this [PR#1106](https://github.com/maticnetwork/bor/pull/1106).
Fastlane reported this issue and this PR adds the check back.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
