### PR TITLE
Add test for concurrent revert in MVHashmap

### DIFF
--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -1037,6 +1037,57 @@ func TestApplyMVWriteSet(t *testing.T) {
 	assert.Equal(t, sSingleProcess.IntermediateRoot(true), sClean.IntermediateRoot(true))
 }
 
+func TestMVHashMapRevertConcurrent(t *testing.T) {
+	t.Parallel()
+
+	db := NewDatabase(rawdb.NewMemoryDatabase())
+	mvhm := blockstm.MakeMVHashMap()
+	s, _ := NewWithMVHashmap(common.Hash{}, db, nil, mvhm)
+
+	states := []*StateDB{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 2; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	balance := new(big.Int).SetUint64(uint64(100))
+
+	// Tx0 touches the account. Amount doesn't matter.
+	// This is to make sure that Tx1 and Tx2 will use the same state object from Tx0.
+	states[0].AddBalance(addr, common.Big0)
+	states[0].Finalise(false)
+	states[0].FlushMVWriteSet()
+
+	// Tx1 creates the account and add balance
+	snapshot1 := states[1].Snapshot()
+	states[1].CreateAccount(addr)
+	states[1].AddBalance(addr, balance)
+
+	// Tx2 creates the account, reverts.
+	snapshot2 := states[2].Snapshot()
+	states[2].CreateAccount(addr)
+	states[2].RevertToSnapshot(snapshot2)
+
+	// Tx2 adds balance
+	states[2].AddBalance(addr, balance)
+
+	// Tx1 now reverts
+	states[1].RevertToSnapshot(snapshot1)
+	states[1].Finalise(false)
+
+	// Balance after executing Tx0 should be 0 because it shouldn't be affected by Tx1 or Tx2
+	b := states[0].GetBalance(addr)
+	assert.Equal(t, common.Big0, b)
+
+	// Balance after executing Tx1 should be 0 because Tx1 got reverted
+	b = states[1].GetBalance(addr)
+	assert.Equal(t, common.Big0, b)
+}
+
 // TestCopyOfCopy tests that modified objects are carried over to the copy, and the copy of the copy.
 // See https://github.com/ethereum/go-ethereum/pull/15225#issuecomment-380191512
 func TestCopyOfCopy(t *testing.T) {

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -1071,6 +1071,7 @@ func TestMVHashMapRevertConcurrent(t *testing.T) {
 	snapshot2 := states[2].Snapshot()
 	states[2].CreateAccount(addr)
 	states[2].RevertToSnapshot(snapshot2)
+	states[2].Finalise(false)
 
 	// Tx2 adds balance
 	states[2].AddBalance(addr, balance)
@@ -1086,6 +1087,10 @@ func TestMVHashMapRevertConcurrent(t *testing.T) {
 	// Balance after executing Tx1 should be 0 because Tx1 got reverted
 	b = states[1].GetBalance(addr)
 	assert.Equal(t, common.Big0, b)
+
+	// Balance after executing Tx2 should be 100 because its snapshot is taken before Tx1 got reverted
+	b = states[2].GetBalance(addr)
+	assert.Equal(t, balance, b)
 }
 
 // TestCopyOfCopy tests that modified objects are carried over to the copy, and the copy of the copy.


### PR DESCRIPTION
# Description

This change test a case when multiple reverts happen concurrently.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
