### PR TITLE
Fix panic in eth_getLogs

### DIFF
--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -352,7 +352,7 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*type
 		return nil, errExceedMaxTopics
 	}
 
-	borConfig := api.chainConfig.Bor
+	borConfig := api.sys.backend.ChainConfig().Bor
 
 	var filter *Filter
 
@@ -435,7 +435,7 @@ func (api *FilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*types.Lo
 		return nil, errFilterNotFound
 	}
 
-	borConfig := api.chainConfig.Bor
+	borConfig := api.sys.backend.ChainConfig().Bor
 
 	var filter *Filter
 


### PR DESCRIPTION
# Description

Fixes nil pointer dereference bug in filter.

Sample error:
```
ERROR[10-04|04:21:13.680] RPC method eth_getLogs crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 19346 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
  /home/ubuntu/bor/rpc/service.go:216 +0x85
panic({0x26d2fa0?, 0x4f70000?})
  /home/ubuntu/.go/src/runtime/panic.go:770 +0x132
github.com/ethereum/go-ethereum/eth/filters.(*FilterAPI).GetLogs(0xc006412f80, {0x3a5b4e8, 0xc0008e3720}, {0x0, 0xc009a33000, 0xc009a33020, {0x54b4880, 0x0, 0x0}, {0x0, ...}})
  /home/ubuntu/bor/eth/filters/api.go:355 +0x5b
reflect.Value.call({0xc00e2795c0?, 0xc00e402c68?, 0x50?}, {0x2af2779, 0x4}, {0xc0008e3a40, 0x3, 0xc0008e3a40?})
  /home/ubuntu/.go/src/reflect/value.go:596 +0xca6
reflect.Value.Call({0xc00e2795c0?, 0xc00e402c68?, 0x1?}, {0xc0008e3a40?, 0x16?, 0x16?})
  /home/ubuntu/.go/src/reflect/value.go:380 +0xb9
github.com/ethereum/go-ethereum/rpc.(*callback).call(0xc00e430960, {0x3a5b4e8, 0xc0008e3720}, {0xc0597dfc00, 0xb}, {0xc0102ebc38, 0x1, 0x4a22af?})
  /home/ubuntu/bor/rpc/service.go:223 +0x36d
github.com/ethereum/go-ethereum/rpc.(*handler).runMethod(0xc00059d2f0?, {0x3a5b4e8?, 0xc0008e3720?}, 0xc00b07ae00, 0x1?, {0xc0102ebc38?, 0xc011ff0da0?, 0x41e738?})
  /home/ubuntu/bor/rpc/handler.go:607 +0x3c
github.com/ethereum/go-ethereum/rpc.(*handler).handleCall(0xc05dfd5a40, 0xc02cf57bc0, 0xc00b07ae00)
  /home/ubuntu/bor/rpc/handler.go:548 +0x22f
``` 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
