### PR TITLE
internal/cli: add prometheus sever timeouts

### DIFF
--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -364,8 +364,8 @@ func (s *Server) setupMetrics(config *TelemetryConfig, serviceName string) error
 		timeouts := rpc.DefaultHTTPTimeouts
 
 		promServer := &http.Server{
-			Addr:    config.PrometheusAddr,
-			Handler: prometheusMux,
+			Addr:              config.PrometheusAddr,
+			Handler:           prometheusMux,
 			ReadTimeout:       timeouts.ReadTimeout,
 			ReadHeaderTimeout: timeouts.ReadHeaderTimeout,
 			WriteTimeout:      timeouts.WriteTimeout,

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ethereum/go-ethereum/metrics/influxdb"
 	"github.com/ethereum/go-ethereum/metrics/prometheus"
 	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	// Force-load the tracer engines to trigger registration
 	_ "github.com/ethereum/go-ethereum/eth/tracers/js"
@@ -360,9 +361,15 @@ func (s *Server) setupMetrics(config *TelemetryConfig, serviceName string) error
 
 		prometheusMux.Handle("/debug/metrics/prometheus", prometheus.Handler(metrics.DefaultRegistry))
 
+		timeouts := rpc.DefaultHTTPTimeouts
+
 		promServer := &http.Server{
 			Addr:    config.PrometheusAddr,
 			Handler: prometheusMux,
+			ReadTimeout:       timeouts.ReadTimeout,
+			ReadHeaderTimeout: timeouts.ReadHeaderTimeout,
+			WriteTimeout:      timeouts.WriteTimeout,
+			IdleTimeout:       timeouts.IdleTimeout,
 		}
 
 		go func() {


### PR DESCRIPTION
# Description

In this PR we add default timeouts to prometheus server.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli