### PR TITLE
Check block number and timestamp options when filtering conditional transactions

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1655,7 +1655,7 @@ func (pool *LegacyPool) truncateQueue() {
 // to trigger a re-heap is this function
 func (pool *LegacyPool) demoteUnexecutables() {
 	// Iterate over all accounts and demote any non-executable transactions
-	gasLimit := pool.currentHead.Load().GasLimit
+	currentHeader := pool.currentHead.Load()
 	for addr, list := range pool.pending {
 		nonce := pool.currentState.GetNonce(addr)
 
@@ -1667,7 +1667,7 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			log.Trace("Removed old pending transaction", "hash", hash)
 		}
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
-		drops, invalids := list.Filter(pool.currentState.GetBalance(addr), gasLimit)
+		drops, invalids := list.Filter(pool.currentState.GetBalance(addr), currentHeader.GasLimit)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			log.Trace("Removed unpayable pending transaction", "hash", hash)
@@ -1683,7 +1683,7 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			pool.enqueueTx(hash, tx, false, false)
 		}
 		// Drop all transactions that no longer have valid TxOptions
-		txConditionalsRemoved := list.FilterTxConditional(pool.currentState)
+		txConditionalsRemoved := list.FilterTxConditional(pool.currentState, currentHeader)
 
 		for _, tx := range txConditionalsRemoved {
 			hash := tx.Hash()

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -523,14 +523,26 @@ func (l *list) Filter(costLimit *big.Int, gasLimit uint64) (types.Transactions, 
 	return removed, invalids
 }
 
-// FilterTxConditional returns the conditional transactions with invalid KnownAccounts
-// TODO - We will also have to check block range and time stamp range!
-func (l *list) FilterTxConditional(state *state.StateDB) types.Transactions {
+// FilterTxConditional returns the conditional transactions with invalid PIP15 options
+func (l *list) FilterTxConditional(state *state.StateDB, header *types.Header) types.Transactions {
+	if state == nil || header == nil {
+		return nil
+	}
+
 	removed := l.txs.filter(func(tx *types.Transaction) bool {
 		if options := tx.GetOptions(); options != nil {
-			err := state.ValidateKnownAccounts(options.KnownAccounts)
-			if err != nil {
-				log.Error("Error while Filtering Tx Conditional", "err", err)
+			if err := state.ValidateKnownAccounts(options.KnownAccounts); err != nil {
+				log.Debug("Error while Filtering Tx Conditional's known accounts", "err", err)
+				return true
+			}
+
+			if err := header.ValidateBlockNumberOptionsPIP15(options.BlockNumberMin, options.BlockNumberMax); err != nil {
+				log.Debug("Error while Filtering Tx Conditional's block number options", "err", err)
+				return true
+			}
+
+			if err := header.ValidateTimestampOptionsPIP15(options.TimestampMin, options.TimestampMax); err != nil {
+				log.Debug("Error while Filtering Tx Conditional's timestamp options", "err", err)
 				return true
 			}
 

--- a/core/txpool/legacypool/list_test.go
+++ b/core/txpool/legacypool/list_test.go
@@ -79,13 +79,17 @@ func BenchmarkListAdd(b *testing.B) {
 	}
 }
 
-func TestFilterTxConditional(t *testing.T) {
+func TestFilterTxConditionalKnownAccounts(t *testing.T) {
 	t.Parallel()
 
 	// Create an in memory state db to test against.
 	memDb := rawdb.NewMemoryDatabase()
 	db := state.NewDatabase(memDb)
 	state, _ := state.New(common.Hash{}, db, nil)
+
+	header := &types.Header{
+		Number: big.NewInt(0),
+	}
 
 	// Create a private key to sign transactions.
 	key, _ := crypto.GenerateKey()
@@ -100,7 +104,7 @@ func TestFilterTxConditional(t *testing.T) {
 
 	// There should be no drops at this point.
 	// No state has been modified.
-	drops := list.FilterTxConditional(state)
+	drops := list.FilterTxConditional(state, header)
 
 	count := len(drops)
 	require.Equal(t, 0, count, "got %d filtered by TxOptions when there should not be any", count)
@@ -122,7 +126,7 @@ func TestFilterTxConditional(t *testing.T) {
 	list.Add(tx2, DefaultConfig.PriceBump)
 
 	// There should still be no drops as no state has been modified.
-	drops = list.FilterTxConditional(state)
+	drops = list.FilterTxConditional(state, header)
 
 	count = len(drops)
 	require.Equal(t, 0, count, "got %d filtered by TxOptions when there should not be any", count)
@@ -131,7 +135,129 @@ func TestFilterTxConditional(t *testing.T) {
 	state.SetState(common.Address{19: 1}, common.Hash{}, common.Hash{31: 1})
 
 	// tx2 should be the single transaction filtered out
-	drops = list.FilterTxConditional(state)
+	drops = list.FilterTxConditional(state, header)
+
+	count = len(drops)
+	require.Equal(t, 1, count, "got %d filtered by TxOptions when there should be a single one", count)
+
+	require.Equal(t, tx2, drops[0], "Got %x, expected %x", drops[0].Hash(), tx2.Hash())
+}
+
+func TestFilterTxConditionalBlockNumber(t *testing.T) {
+	t.Parallel()
+
+	// Create an in memory state db to test against.
+	memDb := rawdb.NewMemoryDatabase()
+	db := state.NewDatabase(memDb)
+	state, _ := state.New(common.Hash{}, db, nil)
+
+	header := &types.Header{
+		Number: big.NewInt(100),
+	}
+
+	// Create a private key to sign transactions.
+	key, _ := crypto.GenerateKey()
+
+	// Create a list.
+	list := newList(true)
+
+	// Create a transaction with no defined tx options
+	// and add to the list.
+	tx := transaction(0, 1000, key)
+	list.Add(tx, DefaultConfig.PriceBump)
+
+	// There should be no drops at this point.
+	// No state has been modified.
+	drops := list.FilterTxConditional(state, header)
+
+	count := len(drops)
+	require.Equal(t, 0, count, "got %d filtered by TxOptions when there should not be any", count)
+
+	// Create another transaction with a block number option and add to the list.
+	tx2 := transaction(1, 1000, key)
+
+	var options types.OptionsPIP15
+
+	options.BlockNumberMin = big.NewInt(90)
+	options.BlockNumberMax = big.NewInt(110)
+
+	tx2.PutOptions(&options)
+	list.Add(tx2, DefaultConfig.PriceBump)
+
+	// There should still be no drops as no state has been modified.
+	drops = list.FilterTxConditional(state, header)
+
+	count = len(drops)
+	require.Equal(t, 0, count, "got %d filtered by TxOptions when there should not be any", count)
+
+	// Set block number that conflicts with tx2's policy
+	header.Number = big.NewInt(120)
+
+	// tx2 should be the single transaction filtered out
+	drops = list.FilterTxConditional(state, header)
+
+	count = len(drops)
+	require.Equal(t, 1, count, "got %d filtered by TxOptions when there should be a single one", count)
+
+	require.Equal(t, tx2, drops[0], "Got %x, expected %x", drops[0].Hash(), tx2.Hash())
+}
+
+func TestFilterTxConditionalTimestamp(t *testing.T) {
+	t.Parallel()
+
+	// Create an in memory state db to test against.
+	memDb := rawdb.NewMemoryDatabase()
+	db := state.NewDatabase(memDb)
+	state, _ := state.New(common.Hash{}, db, nil)
+
+	header := &types.Header{
+		Number: big.NewInt(0),
+		Time:   100,
+	}
+
+	// Create a private key to sign transactions.
+	key, _ := crypto.GenerateKey()
+
+	// Create a list.
+	list := newList(true)
+
+	// Create a transaction with no defined tx options
+	// and add to the list.
+	tx := transaction(0, 1000, key)
+	list.Add(tx, DefaultConfig.PriceBump)
+
+	// There should be no drops at this point.
+	// No state has been modified.
+	drops := list.FilterTxConditional(state, header)
+
+	count := len(drops)
+	require.Equal(t, 0, count, "got %d filtered by TxOptions when there should not be any", count)
+
+	// Create another transaction with a timestamp option and add to the list.
+	tx2 := transaction(1, 1000, key)
+
+	var options types.OptionsPIP15
+
+	minTimestamp := uint64(90)
+	maxTimestamp := uint64(110)
+
+	options.TimestampMin = &minTimestamp
+	options.TimestampMax = &maxTimestamp
+
+	tx2.PutOptions(&options)
+	list.Add(tx2, DefaultConfig.PriceBump)
+
+	// There should still be no drops as no state has been modified.
+	drops = list.FilterTxConditional(state, header)
+
+	count = len(drops)
+	require.Equal(t, 0, count, "got %d filtered by TxOptions when there should not be any", count)
+
+	// Set timestamp that conflicts with tx2's policy
+	header.Time = 120
+
+	// tx2 should be the single transaction filtered out
+	drops = list.FilterTxConditional(state, header)
 
 	count = len(drops)
 	require.Equal(t, 1, count, "got %d filtered by TxOptions when there should be a single one", count)


### PR DESCRIPTION
# Description

Added checks for block number and timestamp PIP15 options in the `FilterTxConditional` function. Without those, transactions with invalid block number/timestamp options are never demoted.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli
