### PR TITLE
Fix panic on nil block in ethstats

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -729,6 +729,10 @@ func (s *Service) assembleBlockStats(block *types.Block) *blockStats {
 			}
 		}
 
+		if block == nil {
+			return nil
+		}
+
 		header = block.Header()
 		td = fullBackend.GetTd(context.Background(), header.Hash())
 

--- a/ethstats/ethstats_test.go
+++ b/ethstats/ethstats_test.go
@@ -17,8 +17,17 @@
 package ethstats
 
 import (
+	"context"
+	"math/big"
 	"strconv"
 	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 func TestParseEthstatsURL(t *testing.T) {
@@ -81,5 +90,65 @@ func TestParseEthstatsURL(t *testing.T) {
 		if host != c.host {
 			t.Errorf("case=%d mismatch host value, got: %v ,want: %v", i, host, c.host)
 		}
+	}
+}
+
+// MockBackend is a mock implementation of the backend interface
+type MockFullNodeBackend struct{}
+
+func (m *MockFullNodeBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {
+	return nil
+}
+
+func (m *MockFullNodeBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
+	return nil
+}
+
+func (m *MockFullNodeBackend) CurrentHeader() *types.Header {
+	return &types.Header{}
+}
+
+func (m *MockFullNodeBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
+	return nil, nil
+}
+
+func (m *MockFullNodeBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {
+	return big.NewInt(0)
+}
+
+func (m *MockFullNodeBackend) Stats() (pending int, queued int) {
+	return 0, 0
+}
+
+func (m *MockFullNodeBackend) SyncProgress() ethereum.SyncProgress {
+	return ethereum.SyncProgress{}
+}
+
+func (m *MockFullNodeBackend) SubscribeChain2HeadEvent(ch chan<- core.Chain2HeadEvent) event.Subscription {
+	return nil
+}
+
+func (m *MockFullNodeBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {
+	return nil, nil
+}
+
+func (m *MockFullNodeBackend) CurrentBlock() *types.Header {
+	return &types.Header{Number: big.NewInt(1)}
+}
+
+func (m *MockFullNodeBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+
+func TestAssembleBlockStats_NilBlock(t *testing.T) {
+	mockBackend := &MockFullNodeBackend{}
+	service := &Service{
+		backend: mockBackend,
+	}
+
+	result := service.assembleBlockStats(nil)
+
+	if result != nil {
+		t.Errorf("Expected nil, got %v", result)
 	}
 }


### PR DESCRIPTION
# Description

This change addresses the panic issue when the block is nil in ethstats. Also added test that will catch this case in CI. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
