### PR TITLE
fix: nil dereference during handshake packet decoding

### DIFF
--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -538,7 +538,9 @@ func (c *Codec) decodeWhoareyou(head *Header, headerData []byte) (Packet, error)
 func (c *Codec) decodeHandshakeMessage(fromAddr string, head *Header, headerData, msgData []byte) (n *enode.Node, p Packet, err error) {
 	node, auth, session, err := c.decodeHandshake(fromAddr, head)
 	if err != nil {
-		c.sc.deleteHandshake(auth.h.SrcID, fromAddr)
+		if auth != nil {
+			c.sc.deleteHandshake(auth.h.SrcID, fromAddr)
+		}
 		return nil, nil, err
 	}
 
@@ -556,39 +558,40 @@ func (c *Codec) decodeHandshakeMessage(fromAddr string, head *Header, headerData
 	return node, msg, nil
 }
 
-func (c *Codec) decodeHandshake(fromAddr string, head *Header) (n *enode.Node, auth handshakeAuthData, s *session, err error) {
-	if auth, err = c.decodeHandshakeAuthData(head); err != nil {
-		return nil, auth, nil, err
+func (c *Codec) decodeHandshake(fromAddr string, head *Header) (n *enode.Node, auth *handshakeAuthData, s *session, err error) {
+	tempAuth := &handshakeAuthData{}
+	if *tempAuth, err = c.decodeHandshakeAuthData(head); err != nil {
+		return nil, nil, nil, err
 	}
 
 	// Verify against our last WHOAREYOU.
-	challenge := c.sc.getHandshake(auth.h.SrcID, fromAddr)
+	challenge := c.sc.getHandshake(tempAuth.h.SrcID, fromAddr)
 	if challenge == nil {
-		return nil, auth, nil, errUnexpectedHandshake
+		return nil, nil, nil, errUnexpectedHandshake
 	}
 	// Get node record.
-	n, err = c.decodeHandshakeRecord(challenge.Node, auth.h.SrcID, auth.record)
+	n, err = c.decodeHandshakeRecord(challenge.Node, tempAuth.h.SrcID, tempAuth.record)
 	if err != nil {
-		return nil, auth, nil, err
+		return nil, nil, nil, err
 	}
 	// Verify ID nonce signature.
-	sig := auth.signature
+	sig := tempAuth.signature
 	cdata := challenge.ChallengeData
 
-	err = verifyIDSignature(c.sha256, sig, n, cdata, auth.pubkey, c.localnode.ID())
+	err = verifyIDSignature(c.sha256, sig, n, cdata, tempAuth.pubkey, c.localnode.ID())
 	if err != nil {
-		return nil, auth, nil, err
+		return nil, nil, nil, err
 	}
-	// Verify ephemeral key is on curve.
-	ephkey, err := DecodePubkey(c.privkey.Curve, auth.pubkey)
+	// Verify ephemeral key is on curve
+	ephkey, err := DecodePubkey(c.privkey.Curve, tempAuth.pubkey)
 	if err != nil {
-		return nil, auth, nil, errInvalidAuthKey
+		return nil, nil, nil, errInvalidAuthKey
 	}
 	// Derive session keys.
-	session := deriveKeys(sha256.New, c.privkey, ephkey, auth.h.SrcID, c.localnode.ID(), cdata)
+	session := deriveKeys(sha256.New, c.privkey, ephkey, tempAuth.h.SrcID, c.localnode.ID(), cdata)
 	session = session.keysFlipped()
 
-	return n, auth, session, nil
+	return n, tempAuth, session, nil
 }
 
 // decodeHandshakeAuthData reads the authdata section of a handshake packet.

--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -735,7 +735,7 @@ func bytesCopy(r *bytes.Buffer) []byte {
 	return b
 }
 
-// isValid checks if handshakeAuthData is valid
+// isHandshakeAuthDataValid checks if handshakeAuthData is valid
 func (auth *handshakeAuthData) isHandshakeAuthDataValid() bool {
 	// Conditions for the auth to be considered valid
 	return auth != nil && len(auth.signature) > 0 && len(auth.pubkey) > 0 && auth.h.SrcID != (enode.ID{})


### PR DESCRIPTION
# Description

Fix a nil pointer dereference during handshake packet decoding.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli