### PR TITLE
Fix typos and improve documentation across several files

### DIFF
--- a/cmd/clef/intapi_changelog.md
+++ b/cmd/clef/intapi_changelog.md
@@ -14,7 +14,7 @@ Additional labels for pre-release and build metadata are available as extensions
 
 Added `clef_New` to the internal API callable from a UI.
 
-> `New` creates a new password protected Account. The private key is protected with
+> `New` creates a new password-protected Account. The private key is protected with
 > the given password. Users are responsible to backup the private key that is stored
 > in the keystore location that was specified when this API was created.
 > This method is the same as New on the external API, the difference being that

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -148,7 +148,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```graphql```: Enable GraphQL on the HTTP-RPC server. Note that GraphQL can only be started if an HTTP server is started as well. (default: false)
 
-- ```graphql.corsdomain```: Comma separated list of domains from which to accept cross origin requests (browser enforced) (default: localhost)
+- ```graphql.corsdomain```: Comma separated list of domains from which to accept cross-origin requests (browser enforced) (default: localhost)
 
 - ```graphql.vhosts```: Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. (default: localhost)
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -158,7 +158,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```http.api```: API's offered over the HTTP-RPC interface (default: eth,net,web3,txpool,bor)
 
-- ```http.corsdomain```: Comma separated list of domains from which to accept cross origin requests (browser enforced) (default: localhost)
+- ```http.corsdomain```: Comma separated list of domains from which to accept cross-origin requests (browser enforced) (default: localhost)
 
 - ```http.ep-requesttimeout```: Request Timeout for rpc execution pool for HTTP requests (default: 0s)
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -40,7 +40,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```eth.requiredblocks```: Comma separated block number-to-hash mappings to require for peering (<number>=<hash>)
 
-- ```ethstats```: Reporting URL of a ethstats service (nodename:secret@host:port)
+- ```ethstats```: Reporting URL of an ethstats service (nodename:secret@host:port)
 
 - ```gcmode```: Blockchain garbage collection mode ("full", "archive") (default: full)
 

--- a/p2p/simulations/README.md
+++ b/p2p/simulations/README.md
@@ -116,7 +116,7 @@ the expectation and what network events were emitted during the step run.
 
 ## HTTP API
 
-The simulation framework includes a HTTP API that can be used to control the
+The simulation framework includes an HTTP API that can be used to control the
 simulation.
 
 The API is initialised with a particular node adapter and has the following


### PR DESCRIPTION
This PR addresses several typographical issues across multiple documentation files. The changes include fixing hyphenation errors, correcting article usage, and updating duplicated phrases. 

### Changes
- Fixed the spelling of "password-protected" in `intapi_changelog.md`.
- Corrected the use of "an" vs. "a" in `server.md` and `README.md` for consistency and clarity.
- Added missing hyphen in "cross-origin" in `server.md`.
- Removed duplicated phrase "to have" in `rules.md`.

### Checklist
- [ ] I have added at least 2 reviewers or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

### Testing
- [ ] I have manually tested the changes in my local environment.
- [ ] I have tested the functionality in the remote devnet.

### Additional comments
No additional comments.
