### PR TITLE
Fix incorrect balance when CreateContract is used in block-stm

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1107,6 +1107,9 @@ func (s *StateDB) CreateAccount(addr common.Address) {
 // correctly handle EIP-6780 'delete-in-same-transaction' logic.
 func (s *StateDB) CreateContract(addr common.Address) {
 	obj := s.getStateObject(addr)
+	if obj != nil {
+		obj = s.mvRecordWritten(obj)
+	}
 	if !obj.newContract {
 		obj.newContract = true
 		s.journal.append(createContractChange{account: addr})

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -418,7 +418,6 @@ func (s *StateDB) ApplyMVWriteSet(writes []blockstm.WriteDescriptor) {
 
 			switch path.GetSubpath() {
 			case BalancePath:
-				// todo: @anshalshukla || @cffls - check balance change reason
 				s.SetBalance(addr, sr.GetBalance(addr), tracing.BalanceChangeUnspecified)
 			case NoncePath:
 				s.SetNonce(addr, sr.GetNonce(addr))
@@ -1095,9 +1094,6 @@ func (s *StateDB) createObject(addr common.Address) *stateObject {
 // consensus bug eventually.
 func (s *StateDB) CreateAccount(addr common.Address) {
 	s.createObject(addr)
-	// todo: @anshalshukla || @cffls
-	// Check the below MV Write, balance path change have been removed
-	MVWrite(s, blockstm.NewAddressKey(addr))
 }
 
 // CreateContract is used whenever a contract is created. This may be preceded
@@ -1115,8 +1111,6 @@ func (s *StateDB) CreateContract(addr common.Address) {
 		s.journal.append(createContractChange{account: addr})
 	}
 
-	// todo: @anshalshukla || @cffls
-	// Check the below MV Write, balance path change have been removed
 	MVWrite(s, blockstm.NewAddressKey(addr))
 }
 

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -813,6 +813,33 @@ func TestMVHashMapReadWriteDelete(t *testing.T) {
 	assert.Equal(t, uint256.NewInt(0), b)
 }
 
+func TestMVHashMapCreateContract(t *testing.T) {
+	t.Parallel()
+
+	db := NewDatabase(rawdb.NewMemoryDatabase())
+	mvhm := blockstm.MakeMVHashMap()
+	s, _ := NewWithMVHashmap(common.Hash{}, db, nil, mvhm)
+
+	states := []*StateDB{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	states[0].SetBalance(addr, uint256.NewInt(100), tracing.BalanceChangeTransfer)
+	states[0].FlushMVWriteSet()
+
+	states[1].CreateContract(addr)
+	states[1].FlushMVWriteSet()
+
+	b := states[1].GetBalance(addr)
+	assert.Equal(t, uint256.NewInt(100), b)
+}
+
 func TestMVHashMapRevert(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Description

`CreateContract` was a new function introduced from upstream merge after v1.5.0. When `CreateContract` is called, it should also call `mvRecordWritten` to ensure the state object is in the live set of statedb. Otherwise, some information, e.g. balance of the account, might get lost in the rest of opcodes in that txn.


# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
