### PR TITLE
consensus/bor: fetch validator set using parent hash

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -468,8 +468,9 @@ func (c *Bor) verifyCascadingFields(chain consensus.ChainHeaderReader, header *t
 
 	// Verify the validator list match the local contract
 	if IsSprintStart(number+1, c.config.CalculateSprint(number)) {
-		newValidators, err := c.spanner.GetCurrentValidatorsByBlockNrOrHash(context.Background(), rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), number+1)
-
+		// Use parent block's hash to make the eth_call to fetch validators so that the state being
+		// used to make the call is of the same fork.
+		newValidators, err := c.spanner.GetCurrentValidatorsByBlockNrOrHash(context.Background(), rpc.BlockNumberOrHashWithHash(header.ParentHash, false), number+1)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When fetch validators from child chain contract, `rpc.LatestNumber` was used to make the `eth_call` request. This PR replaces it with using `header.ParentHash` so that the state being used while making the call belongs to the same fork as the block being imported and checked for. 