### PR TITLE
Fix hasher

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -988,7 +988,7 @@ func (s *StateDB) getStateObject(addr common.Address) *stateObject {
 		var data *types.StateAccount
 		if s.snap != nil {
 			start := time.Now()
-			acc, err := s.snap.Account(crypto.HashData(s.hasher, addr.Bytes()))
+			acc, err := s.snap.Account(crypto.HashData(crypto.NewKeccakState(), addr.Bytes()))
 			s.SnapshotAccountReads += time.Since(start)
 			if err == nil {
 				if acc == nil {


### PR DESCRIPTION
# Description

This will fix a hasher bug that was introduced in https://github.com/maticnetwork/bor/commit/a23701f2d4b824ff30885d2061f6f71a11710dfc

The error can occur when the hasher is used by more than one goroutine at the same time:

```
panic: runtime error: slice bounds out of range [:-5]
goroutine 41937862 [running]:
golang.org/x/crypto/sha3.(*state).Write(0xc0ae67eb60, {0xc0e01441e0?, 0x14, 0x2a42620?})
/root/go/pkg/mod/golang.org/x/crypto@v0.24.0/sha3/sha3.go:135 +0x255
github.com/ethereum/go-ethereum/crypto.HashData({0x7fb51c2a9a58, 0xc0ae67eb60}, {0xc0e01441e0, 0x14, 0x14})
/go/src/github.com/maticnetwork/bor/crypto/crypto.go:79 +0x6b
github.com/ethereum/go-ethereum/core/state.(*StateDB).getStateObject.func1(0xc17b255680)
/go/src/github.com/maticnetwork/bor/core/state/statedb.go:992 +0xfa
github.com/ethereum/go-ethereum/core/state.MVRead[...](0xc17b255680?, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...}, ...)
/go/src/github.com/maticnetwork/bor/core/state/statedb.go:314 +0x4ea
github.com/ethereum/go-ethereum/core/state.(*StateDB).getStateObject(0xc17b255680, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...})
/go/src/github.com/maticnetwork/bor/core/state/statedb.go:979 +0x1de
github.com/ethereum/go-ethereum/core/state.(*StateDB).GetBalance.func1(0x274dd60?)
/go/src/github.com/maticnetwork/bor/core/state/statedb.go:647 +0x25
github.com/ethereum/go-ethereum/core/state.MVRead[...](0xc17b255680?, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...}, ...)
/go/src/github.com/maticnetwork/bor/core/state/statedb.go:314 +0x4ea
github.com/ethereum/go-ethereum/core/state.(*StateDB).GetBalance(0xc17b255680, {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...})
/go/src/github.com/maticnetwork/bor/core/state/statedb.go:646 +0x1d8
github.com/ethereum/go-ethereum/core/state.(*StateDB).ApplyMVWriteSet(0xc12958ab40, {0xc0df8c0008, 0x4f, 0xc12958ab40?})
/go/src/github.com/maticnetwork/bor/core/state/statedb.go:422 +0x2c5
github.com/ethereum/go-ethereum/core.(*ExecutionTask).Settle(0xc0d52b5d48)
/go/src/github.com/maticnetwork/bor/core/parallel_state_processor.go:183 +0x305
github.com/ethereum/go-ethereum/core/blockstm.(*ParallelExecutor).Prepare.func2()
/go/src/github.com/maticnetwork/bor/core/blockstm/executor.go:383 +0x3c
created by github.com/ethereum/go-ethereum/core/blockstm.(*ParallelExecutor).Prepare in goroutine 41937844
/go/src/github.com/maticnetwork/bor/core/blockstm/executor.go:381 +0x3c7
```

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
