### PR TITLE
internal/cli: trim trailing / from ancient path

### DIFF
--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -473,7 +473,7 @@ func checkDeletePermissions(path string) (bool, error) {
 func (c *PruneBlockCommand) pruneBlock(stack *node.Node, fdHandles int) error {
 	name := "chaindata"
 
-	oldAncientPath := c.datadirAncient
+	oldAncientPath := strings.TrimSuffix(c.datadirAncient, "/")
 
 	switch {
 	case oldAncientPath == "":


### PR DESCRIPTION
# Description

Fix a bug that leads to node corruption when `--datadir.ancient` has a trailing `/`.

To reproduce:

```
/usr/bin/bor snapshot prune-block --datadir=/var/lib/polygon/bor/ --datadir.ancient=/var/lib/polygon/bor/bor/chaindata/ancient/
```

Behaviour:
* `bor` saves `ancient_back` to `/var/lib/polygon/bor/bor/chaindata/ancient/ancient_back` because of `filepath.Split` at line 485
* folder `ancient` is deleted after pruning, removing `ancient_back`
* -> node is corrupted

Fix: use `TrimSuffix` to remove the trailing `/` is present.

# Changes

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
