### PR TITLE
Make block execution timer more accurate

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -832,6 +832,7 @@ func (c *Bor) Finalize(chain consensus.ChainHeaderReader, header *types.Header, 
 	}
 
 	if IsSprintStart(headerNumber, c.config.CalculateSprint(headerNumber)) {
+		start := time.Now()
 		ctx := context.Background()
 		cx := statefull.ChainContext{Chain: chain, Bor: c}
 		// check and commit span
@@ -848,6 +849,8 @@ func (c *Bor) Finalize(chain consensus.ChainHeaderReader, header *types.Header, 
 				return
 			}
 		}
+
+		state.BorConsensusTime = time.Since(start)
 	}
 
 	if err = c.changeContractCodeIfNeeded(headerNumber, state); err != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -174,6 +174,9 @@ type StateDB struct {
 	SnapshotCommits      time.Duration
 	TrieDBCommits        time.Duration
 
+	// Bor metrics
+	BorConsensusTime time.Duration
+
 	AccountUpdated int
 	StorageUpdated atomic.Int64
 	AccountDeleted int


### PR DESCRIPTION
Block execution contains the time it takes to fetch state sync data from heimdall, which sometimes returns data with long latency (> 1s). When the latency is significant, the chain execution time will be affected and become inaccurate. This PR isolate the time of heimdall requests from block execution.

# Description

Please provide a detailed description of what was done in this PR

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
