### PR TITLE
core/rawdb: handle ancient pruner offset in indexing

### DIFF
--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -108,10 +108,6 @@ func iterateTransactions(db ethdb.Database, from uint64, to uint64, reverse bool
 		rlp    rlp.RawValue
 	}
 
-	if offset := db.AncientOffSet(); offset > from {
-		from = offset
-	}
-
 	if to <= from {
 		return nil
 	}
@@ -206,6 +202,11 @@ func iterateTransactions(db ethdb.Database, from uint64, to uint64, reverse bool
 // There is a passed channel, the whole procedure will be interrupted if any
 // signal received.
 func indexTransactions(db ethdb.Database, from uint64, to uint64, interrupt chan struct{}, hook func(uint64) bool, report bool) {
+	// Bor: If ancient data was pruned, adjust range accordingly.
+	if offset := db.AncientOffSet(); offset > from {
+		from = offset
+	}
+
 	// short circuit for invalid range
 	if from >= to {
 		return
@@ -309,6 +310,11 @@ func indexTransactionsForTesting(db ethdb.Database, from uint64, to uint64, inte
 // There is a passed channel, the whole procedure will be interrupted if any
 // signal received.
 func unindexTransactions(db ethdb.Database, from uint64, to uint64, interrupt chan struct{}, hook func(uint64) bool, report bool) {
+	// Bor: If ancient data was pruned, adjust range accordingly.
+	if offset := db.AncientOffSet(); offset > from {
+		from = offset
+	}
+
 	// short circuit for invalid range
 	if from >= to {
 		return


### PR DESCRIPTION
# Description

Fixes https://github.com/maticnetwork/bor/issues/1387

When ancient data was pruned, the `iterateTransactions` function returned a nil channel causing the outer functions to not proceed leading to ungraceful shutdown. This PR handles the check for ancient pruner offset in outer functions. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
