### PR TITLE
Remove redundant locks from txpool

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -100,12 +100,8 @@ var (
 	localGauge   = metrics.NewRegisteredGauge("txpool/local", nil)
 	slotsGauge   = metrics.NewRegisteredGauge("txpool/slots", nil)
 
-	resetCacheGauge  = metrics.NewRegisteredGauge("txpool/resetcache", nil)
-	reinitCacheGauge = metrics.NewRegisteredGauge("txpool/reinittcache", nil)
-	hitCacheCounter  = metrics.NewRegisteredCounter("txpool/cachehit", nil)
-	missCacheCounter = metrics.NewRegisteredCounter("txpool/cachemiss", nil)
-
-	reheapTimer = metrics.NewRegisteredTimer("txpool/reheap", nil)
+	resetCacheGauge = metrics.NewRegisteredGauge("txpool/resetcache", nil)
+	reheapTimer     = metrics.NewRegisteredTimer("txpool/reheap", nil)
 )
 
 // BlockChain defines the minimal set of methods needed to back a tx pool with


### PR DESCRIPTION
# Description

Improve txpool performance by removing redundant locks.

Most changes were from https://github.com/maticnetwork/bor/pull/604, which added the locks for deeper level of control when debugging.

### pprof before
runReorg used ~45% of CPU cycles. 
<img width="1793" alt="Screenshot 2025-01-27 at 1 25 07 PM" src="https://github.com/user-attachments/assets/15eacaee-2762-4537-aeac-5cad8268a4cf" />


### pprof after
Usage of runReorg dropped to 12%.
<img width="1785" alt="Screenshot 2025-01-27 at 1 22 49 PM" src="https://github.com/user-attachments/assets/8ff04888-916f-4848-a7b7-75fad339c131" />


# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

