### PR TITLE
ethclient: handle single state-sync tx in get block calls

### DIFF
--- a/ethclient/bor_ethclient.go
+++ b/ethclient/bor_ethclient.go
@@ -8,6 +8,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+const (
+	zeroAddress = "0x0000000000000000000000000000000000000000"
+)
+
 // GetRootHash returns the merkle root of the block headers
 func (ec *Client) GetRootHash(ctx context.Context, startBlockNumber uint64, endBlockNumber uint64) (string, error) {
 	var rootHash string


### PR DESCRIPTION
Refer to previous PR: https://github.com/maticnetwork/bor/pull/1409

# Description

This PR resolves an issue where blocks containing system transactions could not be retrieved properly using `getBlock`.  
For such blocks, the `transactionsRoot` is set to `EmptyTxsHash`, but the `Transactions` list contains one transaction, which leads to a mismatch and prevents block information from being retrieved.  
The validation logic has been updated to handle these cases correctly.
Example block with system transaction: https://amoy.polygonscan.com/block/16653120

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

No breaking changes have been introduced in this PR.

# Nodes audience

This PR affects all nodes and does not include changes limited to a subset of nodes.

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

1. Retrieved a block with system transactions (`transactionsRoot` as `EmptyTxsHash` but including `Transactions`).
2. Verified that block information is now retrieved correctly without validation errors.
3. Confirmed that other blocks without system transactions remain unaffected.

# Additional comments

See the example block for context:  
https://amoy.polygonscan.com/block/16653120
