### PR TITLE
Revert "consensus/bor: fetch validator set using parent hash"

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -465,9 +465,8 @@ func (c *Bor) verifyCascadingFields(chain consensus.ChainHeaderReader, header *t
 
 	// Verify the validator list match the local contract
 	if IsSprintStart(number+1, c.config.CalculateSprint(number)) {
-		// Use parent block's hash to make the eth_call to fetch validators so that the state being
-		// used to make the call is of the same fork.
-		newValidators, err := c.spanner.GetCurrentValidatorsByBlockNrOrHash(context.Background(), rpc.BlockNumberOrHashWithHash(header.ParentHash, false), number+1)
+		newValidators, err := c.spanner.GetCurrentValidatorsByBlockNrOrHash(context.Background(), rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), number+1)
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Reverts maticnetwork/bor#1384

The change was done to use state from previous header instead of the last canonical header as that was useful for side chain imports. Seems like even that can cause some issues. 

There were lot of peer drops recently on mainnet which led to this being the root cause. Whenever a chain is being imported, headers are sent to consensus engine for simple verification. 

https://github.com/maticnetwork/bor/blob/51af82cca11b4ccfec9bd967bc2e426eaf1417c0/core/blockchain.go#L2101

In consensus, verification happens in background as below

https://github.com/maticnetwork/bor/blob/51af82cca11b4ccfec9bd967bc2e426eaf1417c0/consensus/bor/bor.go#L317-L327

Header verification is supposed to be state-less (i.e. can be done independently without having any info of previous block in state) and hence this works in most of the cases. But, we modified this behaviour and used `header.ParentHash` to make an `eth_call` against it's state to fetch validator set and compare it with header. Because `engine.VerifyHeaders` is called very early on in `InsertChain` function, there are very less chances that the parent header has been processed till then. This leads to an error `header for hash not found` which goes all the way till downloader and drops the peer. 


E.g. if we're receiving a chain from `[n, n+10]`, we'll verify headers separately (calling it process A) and process blocks one by one (calling it process B). A for `n` passes as `n-1` is canonical and written to disk. We go to perform B for `n`. Meanwhile, we also go to do A for `n+1` as it's parallel. Until `n` doesn't complete B, the eth call for `n+1` will fail as `n` is not written to disk yet. Note that this can happen to any of the block and not in first one. This will cause the whole import to fail and lead to peer drop. 

For now, we're reverting this to what it was previously as it covers pretty much all the cases. Will create a separate PR to handle everything post discussion. 