### PR TITLE
miner: add commit interrupt tests for non-validator mode

### DIFF
--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -844,7 +844,7 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 		chainConfig *params.ChainConfig
 		db          = rawdb.NewMemoryDatabase()
 		ctrl        *gomock.Controller
-		txs         = make([]*types.Transaction, 0, 1)
+		// txs         = make([]*types.Transaction, 0, 1)
 	)
 
 	chainConfig = params.BorUnittestChainConfig
@@ -865,7 +865,6 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 	tx1, addr := b.newStorageCreateContractTx()
 	tx2 := b.newStorageContractCallTx(addr, 1)
 	tx3 := b.newStorageContractCallTx(addr, 2)
-	txs = append(txs, tx1)
 
 	// Create a chain head subscription for tests
 	chainHeadCh := make(chan core.ChainHeadEvent, 10)
@@ -882,7 +881,7 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 				w.stop()
 
 				// Add the first transaction to be mined normally via `txsCh`
-				b.TxPool().Add(txs, false, false)
+				b.TxPool().Add([]*types.Transaction{tx1}, false, false)
 
 				// Set it to syncing mode so that it doesn't mine via the `commitWork` flow
 				w.syncing.Store(true)
@@ -900,9 +899,7 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 				w.setInterruptCtx(vm.InterruptCtxOpcodeDelayKey, uint(500))
 
 				// Send the second transaction
-				txs = make([]*types.Transaction, 0, 1)
-				txs = append(txs, tx2)
-				b.TxPool().Add(txs, false, false)
+				b.TxPool().Add([]*types.Transaction{tx2}, false, false)
 
 				// Reset the delay again. By this time, we're sure that it has timed out.
 				delay = time.Until(time.Unix(int64(w.current.header.Time), 0))
@@ -915,9 +912,7 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 				w.setInterruptCtx(vm.InterruptCtxOpcodeDelayKey, uint(0))
 
 				// Send the third transaction
-				txs = make([]*types.Transaction, 0, 1)
-				txs = append(txs, tx3)
-				b.TxPool().Add(txs, false, false)
+				b.TxPool().Add([]*types.Transaction{tx3}, false, false)
 			}
 		}
 	}()

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -844,7 +844,6 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 		chainConfig *params.ChainConfig
 		db          = rawdb.NewMemoryDatabase()
 		ctrl        *gomock.Controller
-		// txs         = make([]*types.Transaction, 0, 1)
 	)
 
 	chainConfig = params.BorUnittestChainConfig

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -895,8 +895,8 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 
 				// Case 1: This transaction should not be included due to commit interrupt
 				// at opcode level. It will start the EVM execution but will end in between.
-				// select {
 				<-time.After(delay)
+
 				// Set an artificial delay at opcode level
 				w.setInterruptCtx(vm.InterruptCtxOpcodeDelayKey, uint(500))
 
@@ -904,15 +904,14 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 				txs = make([]*types.Transaction, 0, 1)
 				txs = append(txs, tx2)
 				b.TxPool().Add(txs, false, false)
-				// }
 
 				// Reset the delay again. By this time, we're sure that it has timed out.
 				delay = time.Until(time.Unix(int64(w.current.header.Time), 0))
 
 				// Case 2: This transaction should not be included because the miner loop
 				// won't accept any transactions post the deadline (i.e. header.Timestamp).
-				// select {
 				<-time.After(delay)
+
 				// Reset the artificial opcode delay just to be sure of the exclusion of tx
 				w.setInterruptCtx(vm.InterruptCtxOpcodeDelayKey, uint(0))
 
@@ -920,7 +919,6 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 				txs = make([]*types.Transaction, 0, 1)
 				txs = append(txs, tx3)
 				b.TxPool().Add(txs, false, false)
-				// }
 			}
 		}
 	}()

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/ethereum/go-ethereum/triedb"
 	"github.com/golang/mock/gomock"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 )
 
@@ -707,9 +708,10 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 	}
 }
 
-// nolint : paralleltest
-// TestCommitInterruptExperimentBor tests the commit interrupt experiment for bor consensus by inducing an artificial delay at transaction level.
-func TestCommitInterruptExperimentBor(t *testing.T) {
+// nolint: paralleltest
+// TestCommitInterruptExperimentBor_NormalFlow tests the commit interrupt experiment for bor consensus by inducing
+// an artificial delay at transaction level. It runs the normal mining flow triggered via new head.
+func TestCommitInterruptExperimentBor_NormalFlow(t *testing.T) {
 	// with 1 sec block time and 200 millisec tx delay we should get 5 txs per block
 	testCommitInterruptExperimentBor(t, 200, 5, 0)
 
@@ -832,6 +834,106 @@ func testCommitInterruptExperimentBor(t *testing.T, delay uint, txCount int, opc
 	currentBlockNumber := w.current.header.Number.Uint64()
 	assert.Check(t, txCount >= w.chain.GetBlockByNumber(currentBlockNumber-1).Transactions().Len())
 	assert.Check(t, 0 < w.chain.GetBlockByNumber(currentBlockNumber-1).Transactions().Len())
+}
+
+// TestCommitInterruptExperimentBor_NewTxFlow tests the commit interrupt experiment for bor consensus by inducing
+// an artificial delay at transaction level. It runs the mining flow triggered via new transactions channel. The tests
+// are a bit unconventional compared to normal flow as the situations are only possible in non-validator mode.
+func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
+	var (
+		engine      consensus.Engine
+		chainConfig *params.ChainConfig
+		db          = rawdb.NewMemoryDatabase()
+		ctrl        *gomock.Controller
+		txs         = make([]*types.Transaction, 0, 1)
+	)
+
+	chainConfig = params.BorUnittestChainConfig
+
+	log.SetDefault(log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelInfo, true)))
+
+	engine, ctrl = getFakeBorFromConfig(t, chainConfig)
+
+	w, b, _ := newTestWorker(t, chainConfig, engine, rawdb.NewMemoryDatabase(), true, uint(0), uint(0))
+	defer func() {
+		w.close()
+		engine.Close()
+		db.Close()
+		ctrl.Finish()
+	}()
+
+	// Create random transactions (contract interaction)
+	tx1, addr := b.newStorageCreateContractTx()
+	tx2 := b.newStorageContractCallTx(addr, 1)
+	tx3 := b.newStorageContractCallTx(addr, 2)
+	txs = append(txs, tx1)
+
+	// Create a chain head subscription for tests
+	chainHeadCh := make(chan core.ChainHeadEvent, 10)
+	w.chain.SubscribeChainHeadEvent(chainHeadCh)
+
+	// Start mining!
+	w.start()
+	go func() {
+		for {
+			select {
+			case head := <-chainHeadCh:
+				// We skip the initial 2 blocks as the mining timings are a bit skewed up
+				if head.Block.NumberU64() == 2 {
+					// Stop the miner so that worker assumes it's a sentry and not a validator
+					w.stop()
+
+					// Add the first transaction to be mined normally via `txsCh`
+					b.TxPool().Add(txs, false, false)
+
+					// Set it to syncing mode so that it doesn't mine via the `commitWork` flow
+					w.syncing.Store(true)
+
+					// Wait until the mining window (2s) is almost about to reach leaving
+					// a very small time (~10ms) to try to commit transaction before timing out.
+					delay := time.Until(time.Unix(int64(w.current.header.Time), 0))
+					delay -= 10 * time.Millisecond
+
+					// Case 1: This transaction should not be included due to commit interrupt
+					// at opcode level. It will start the EVM execution but will end in between.
+					select {
+					case <-time.After(delay):
+						// Set an artificial delay at opcode level
+						w.setInterruptCtx(vm.InterruptCtxOpcodeDelayKey, uint(500))
+
+						// Send the second transaction
+						txs = make([]*types.Transaction, 0, 1)
+						txs = append(txs, tx2)
+						b.TxPool().Add(txs, false, false)
+					}
+
+					// Reset the delay again. By this time, we're sure that it has timed out.
+					delay = time.Until(time.Unix(int64(w.current.header.Time), 0))
+
+					// Case 2: This transaction should not be included because the miner loop
+					// won't accept any transactions post the deadline (i.e. header.Timestamp).
+					select {
+					case <-time.After(delay):
+						// Reset the artificial opcode delay just to be sure of the exclusion of tx
+						w.setInterruptCtx(vm.InterruptCtxOpcodeDelayKey, uint(0))
+
+						// Send the third transaction
+						txs = make([]*types.Transaction, 0, 1)
+						txs = append(txs, tx3)
+						b.TxPool().Add(txs, false, false)
+					}
+				}
+			}
+		}
+	}()
+
+	// Wait for enough time to mine 3 blocks
+	time.Sleep(6 * time.Second)
+
+	// Ensure that the last block was 3 and only 1 transactions out of 3 were included
+	assert.Equal(t, w.current.header.Number.Uint64(), uint64(3))
+	require.Equal(t, w.current.tcount, 1)
+	require.Equal(t, len(w.current.txs), 1)
 }
 
 func BenchmarkBorMining(b *testing.B) {

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -46,7 +46,6 @@ import (
 	"github.com/ethereum/go-ethereum/triedb"
 	"github.com/golang/mock/gomock"
 	"github.com/holiman/uint256"
-	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 )
 
@@ -928,8 +927,8 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 
 	// Ensure that the last block was 3 and only 1 transactions out of 3 were included
 	assert.Equal(t, w.current.header.Number.Uint64(), uint64(3))
-	require.Equal(t, w.current.tcount, 1)
-	require.Equal(t, len(w.current.txs), 1)
+	assert.Equal(t, w.current.tcount, 1)
+	assert.Equal(t, len(w.current.txs), 1)
 }
 
 func BenchmarkBorMining(b *testing.B) {


### PR DESCRIPTION
# Description

Follow up to https://github.com/maticnetwork/bor/pull/1434

This PR adds a test which verifies the working of miner module when running on a sentry (non-validator) node. It tries to disable the normal mining flow and trigger it via the new transactions subscription channel and asserts mainly 2 things
- Interrupt commit works and breaks execution when the time crosses deadline (i.e. header.Timestamp)
- Mining is not triggered when we've already crossed the deadline 

It uses a bit unconventional / hacky way to do things (as we've to let the worker know midway that it's a sentry and explicitly disable normal commit work route to mine new blocks)

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
