### PR TITLE
miner: wait for next block before running commit interrupt tests

### DIFF
--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -876,6 +876,9 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 			head := <-chainHeadCh
 			// We skip the initial 2 blocks as the mining timings are a bit skewed up
 			if head.Block.NumberU64() == 2 {
+				// Wait until `w.current` is updated for next block (3)
+				time.Sleep(100 * time.Millisecond)
+
 				// Stop the miner so that worker assumes it's a sentry and not a validator
 				w.stop()
 


### PR DESCRIPTION
# Description

Fixes https://github.com/maticnetwork/bor/issues/1447

https://github.com/maticnetwork/bor/pull/1441 added new test for commit interrupt via new transactions channel. 

The results were non-deterministic and used to fail sometimes. This was because we use `w.current` to calculate the `delay` which needs to be correct for the test to work as expected. It takes a while before `w.current` is updated to the next block (block 3 in this case). This PR adds a small delay so that we have the new block and delays are accurately calculated for the test to work.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [x] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [x] Includes RPC methods changes, and the Notion documentation has been updated