### PR TITLE
Allow Custom Gas Price Configurations Greater Than Default Limits

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -166,7 +166,7 @@ func (config *Config) sanitize() Config {
 		conf.Rejournal = time.Second
 	}
 	// PIP-35: Enforce min price limit to 25 gwei
-	if conf.PriceLimit != params.BorDefaultTxPoolPriceLimit {
+	if conf.PriceLimit < params.BorDefaultTxPoolPriceLimit {
 		log.Warn("Sanitizing invalid txpool price limit", "provided", conf.PriceLimit, "updated", DefaultConfig.PriceLimit)
 		conf.PriceLimit = DefaultConfig.PriceLimit
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -122,7 +122,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 
 	// PIP-35: Enforce min gas price to 25 gwei
-	if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(big.NewInt(params.BorDefaultMinerGasPrice)) != 0 {
+	if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(big.NewInt(params.BorDefaultMinerGasPrice)) < 0 {
 		log.Warn("Sanitizing invalid miner gas price", "provided", config.Miner.GasPrice, "updated", ethconfig.Defaults.Miner.GasPrice)
 		config.Miner.GasPrice = ethconfig.Defaults.Miner.GasPrice
 	}

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -102,7 +102,7 @@ func NewOracle(backend OracleBackend, params Config, startPrice *big.Int) *Oracl
 
 	// PIP-35: Enforce the ignore price to 25 gwei
 	ignorePrice := params.IgnorePrice
-	if ignorePrice == nil || ignorePrice.Int64() != DefaultIgnorePrice.Int64() {
+	if ignorePrice == nil || ignorePrice.Int64() < DefaultIgnorePrice.Int64() {
 		ignorePrice = DefaultIgnorePrice
 		log.Warn("Sanitizing invalid gasprice oracle ignore price", "provided", params.IgnorePrice, "updated", ignorePrice)
 	} else {


### PR DESCRIPTION
**PR Description:**

This PR introduces a change that allows custom gas price configurations to be set to values greater than the default price limits :

1. **Core/Txpool/Legacypool (`legacypool.go`)**
2. **Eth/Backend (`backend.go`)**
3. **Eth/GasPrice (`gasprice.go`)**

### Problem Addressed:
Previously, when setting a gas price limit or price threshold, values greater than the default price would be overridden by the default. This PR removes that restriction, enabling users to configure values greater than the default limit.

### Example:
If the default price limit is set to **25 Gwei** and you want to configure the price to **30 Gwei**, the updated code will now respect your configuration:

```json
"PriceLimit": 30
```

In the previous behavior, this would have been automatically reset to 25 Gwei. With this update, you can now use 30 Gwei without it being overridden by the default value.

### Code Changes:

#### 1. **Core/Txpool/Legacypool (`legacypool.go`)**
```go
// PIP-35: Enforce min price limit to 25 gwei
if conf.PriceLimit < params.BorDefaultTxPoolPriceLimit {
    log.Warn("Sanitizing invalid txpool price limit", "provided", conf.PriceLimit, "updated", DefaultConfig.PriceLimit)
    conf.PriceLimit = DefaultConfig.PriceLimit
}
```

#### 2. **Eth/Backend (`backend.go`)**
```go
// PIP-35: Enforce min gas price to 25 gwei
if config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(big.NewInt(params.BorDefaultMinerGasPrice)) < 0 {
    log.Warn("Sanitizing invalid miner gas price", "provided", config.Miner.GasPrice, "updated", ethconfig.Defaults.Miner.GasPrice)
    config.Miner.GasPrice = ethconfig.Defaults.Miner.GasPrice
}
```

#### 3. **Eth/GasPrice (`gasprice.go`)**
```go
// PIP-35: Enforce the ignore price to 25 gwei
ignorePrice := params.IgnorePrice
if ignorePrice == nil || ignorePrice.Int64() < DefaultIgnorePrice.Int64() {
    ignorePrice = DefaultIgnorePrice
    log.Warn("Sanitizing invalid gasprice oracle ignore price", "provided", params.IgnorePrice, "updated", ignorePrice)
} else {
    log.Info("Gasprice oracle is ignoring threshold set", "threshold", ignorePrice)
}
```


### Summary:
This update ensures that gas price configurations are no longer restricted to default values when set higher, allowing greater flexibility for users who need to adjust their gas price limits and thresholds.