### PR TITLE
param: transactions announced only

### DIFF
--- a/docs/cli/example_config.toml
+++ b/docs/cli/example_config.toml
@@ -32,16 +32,17 @@ devfakeauthor = false           # Run miner without validator set authorization 
   enable-block-tracking = false   # Enables additional logging of information collected while tracking block lifecycle
 
 [p2p]
-  maxpeers = 50           # Maximum number of network peers (network disabled if set to 0)
-  maxpendpeers = 50       # Maximum number of pending connection attempts
-  bind = "0.0.0.0"        # Network binding address
-  port = 30303            # Network listening port
-  nodiscover = false      # Disables the peer discovery mechanism (manual peer addition)
-  nat = "any"             # NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>)
-  netrestrict = ""        # Restricts network communication to the given IP networks (CIDR masks)
-  nodekey = ""            # P2P node key file
-  nodekeyhex = ""         # P2P node key as hex
-  txarrivalwait = "500ms" # Maximum duration to wait before requesting an announced transaction
+  maxpeers = 50               # Maximum number of network peers (network disabled if set to 0)
+  maxpendpeers = 50           # Maximum number of pending connection attempts
+  bind = "0.0.0.0"            # Network binding address
+  port = 30303                # Network listening port
+  nodiscover = false          # Disables the peer discovery mechanism (manual peer addition)
+  nat = "any"                 # NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>)
+  netrestrict = ""            # Restricts network communication to the given IP networks (CIDR masks)
+  nodekey = ""                # P2P node key file
+  nodekeyhex = ""             # P2P node key as hex
+  txarrivalwait = "500ms"     # Maximum duration to wait before requesting an announced transaction
+  txannouncementonly = false  # Whether to only announce transactions to peers
   [p2p.discovery]
     v4disc = true       # Enables the V4 discovery mechanism
     v5disc = false      # Enables the experimental RLPx V5 (Topic Discovery) mechanism

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -242,6 +242,8 @@ The ```bor server``` command runs the Bor client.
 
 - ```txarrivalwait```: Maximum duration to wait for a transaction before explicitly requesting it (default: 500ms)
 
+- ```txannouncementonly```: Whether to only announce transactions to peers (default: false)
+
 - ```v4disc```: Enables the V4 discovery mechanism (default: true)
 
 - ```v5disc```: Enables the experimental RLPx V5 (Topic Discovery) mechanism (default: false)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -306,6 +306,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		EthAPI:              blockChainAPI,
 		checker:             checker,
 		enableBlockTracking: eth.config.EnableBlockTracking,
+		txAnnouncementOnly:  eth.p2pServer.TxAnnouncementOnly,
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -222,6 +222,9 @@ type P2PConfig struct {
 	// an announced transaction to arrive before explicitly requesting it
 	TxArrivalWait    time.Duration `hcl:"-,optional" toml:"-"`
 	TxArrivalWaitRaw string        `hcl:"txarrivalwait,optional" toml:"txarrivalwait,optional"`
+
+	// TxAnnouncementOnly is used to only announce transactions to peers
+	TxAnnouncementOnly bool `hcl:"txannouncementonly,optional" toml:"txannouncementonly,optional"`
 }
 
 type P2PDiscovery struct {
@@ -625,14 +628,15 @@ func DefaultConfig() *Config {
 		RPCBatchLimit:      100,
 		RPCReturnDataLimit: 100000,
 		P2P: &P2PConfig{
-			MaxPeers:      50,
-			MaxPendPeers:  50,
-			Bind:          "0.0.0.0",
-			Port:          30303,
-			NoDiscover:    false,
-			NAT:           "any",
-			NetRestrict:   "",
-			TxArrivalWait: 500 * time.Millisecond,
+			MaxPeers:           50,
+			MaxPendPeers:       50,
+			Bind:               "0.0.0.0",
+			Port:               30303,
+			NoDiscover:         false,
+			NAT:                "any",
+			NetRestrict:        "",
+			TxArrivalWait:      500 * time.Millisecond,
+			TxAnnouncementOnly: false,
 			Discovery: &P2PDiscovery{
 				DiscoveryV4:  true,
 				V5Enabled:    false,
@@ -1343,12 +1347,13 @@ func (c *Config) buildNode() (*node.Config, error) {
 		AllowUnprotectedTxs:   c.JsonRPC.AllowUnprotectedTxs,
 		EnablePersonal:        c.JsonRPC.EnablePersonal,
 		P2P: p2p.Config{
-			MaxPeers:        int(c.P2P.MaxPeers),
-			MaxPendingPeers: int(c.P2P.MaxPendPeers),
-			ListenAddr:      c.P2P.Bind + ":" + strconv.Itoa(int(c.P2P.Port)),
-			DiscoveryV4:     c.P2P.Discovery.DiscoveryV4,
-			DiscoveryV5:     c.P2P.Discovery.V5Enabled,
-			TxArrivalWait:   c.P2P.TxArrivalWait,
+			MaxPeers:           int(c.P2P.MaxPeers),
+			MaxPendingPeers:    int(c.P2P.MaxPendPeers),
+			ListenAddr:         c.P2P.Bind + ":" + strconv.Itoa(int(c.P2P.Port)),
+			DiscoveryV4:        c.P2P.Discovery.DiscoveryV4,
+			DiscoveryV5:        c.P2P.Discovery.V5Enabled,
+			TxArrivalWait:      c.P2P.TxArrivalWait,
+			TxAnnouncementOnly: c.P2P.TxAnnouncementOnly,
 		},
 		HTTPModules:         c.JsonRPC.Http.API,
 		HTTPCors:            c.JsonRPC.Http.Cors,

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -812,6 +812,13 @@ func (c *Command) Flags(config *Config) *flagset.Flagset {
 		Default: c.cliConfig.P2P.TxArrivalWait,
 		Group:   "P2P",
 	})
+	f.BoolFlag(&flagset.BoolFlag{
+		Name:    "txannouncementonly",
+		Usage:   "Whether to only announce transactions to peers",
+		Value:   &c.cliConfig.P2P.TxAnnouncementOnly,
+		Default: c.cliConfig.P2P.TxAnnouncementOnly,
+		Group:   "P2P",
+	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
 		Name:    "discovery.dns",
 		Usage:   "Comma separated list of enrtree:// URLs which will be queried for nodes to connect to",

--- a/internal/cli/server/testdata/default.toml
+++ b/internal/cli/server/testdata/default.toml
@@ -36,6 +36,7 @@ devfakeauthor = false
   nodekey = ""
   nodekeyhex = ""
   txarrivalwait = "500ms"
+  txannouncementonly = false
   [p2p.discovery]
     v4disc = true
     v5disc = false

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -172,6 +172,9 @@ type Config struct {
 	// TxArrivalWait is the duration (ms) that the node will wait after seeing
 	// an announced transaction before explicitly requesting it
 	TxArrivalWait time.Duration
+
+	// TxAnnouncementOnly is used to only announce transactions to peers
+	TxAnnouncementOnly bool
 }
 
 // Server manages all peer connections.

--- a/packaging/templates/mainnet-v1/archive/config.toml
+++ b/packaging/templates/mainnet-v1/archive/config.toml
@@ -35,6 +35,7 @@ gcmode = "archive"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     # [p2p.discovery]
         # v4disc = true
         # v5disc = false

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/config.toml
@@ -34,6 +34,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v4disc = true
         # v5disc = false

--- a/packaging/templates/mainnet-v1/sentry/sentry/bor/pbss_config.toml
+++ b/packaging/templates/mainnet-v1/sentry/sentry/bor/pbss_config.toml
@@ -36,6 +36,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v4disc = true
         # v5disc = false

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/config.toml
@@ -36,6 +36,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v4disc = true
         # v5disc = false

--- a/packaging/templates/mainnet-v1/sentry/validator/bor/pbss_config.toml
+++ b/packaging/templates/mainnet-v1/sentry/validator/bor/pbss_config.toml
@@ -38,6 +38,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v4disc = true
         # v5disc = false

--- a/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/config.toml
@@ -36,6 +36,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v4disc = true
         # v5disc = false

--- a/packaging/templates/mainnet-v1/without-sentry/bor/pbss_config.toml
+++ b/packaging/templates/mainnet-v1/without-sentry/bor/pbss_config.toml
@@ -37,6 +37,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v4disc = true
         # v5disc = false

--- a/packaging/templates/testnet-amoy/archive/config.toml
+++ b/packaging/templates/testnet-amoy/archive/config.toml
@@ -34,6 +34,7 @@ gcmode = "archive"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v5disc = false
         # bootnodesv4 = []

--- a/packaging/templates/testnet-amoy/sentry/sentry/bor/config.toml
+++ b/packaging/templates/testnet-amoy/sentry/sentry/bor/config.toml
@@ -33,6 +33,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v5disc = false
         # bootnodesv4 = []

--- a/packaging/templates/testnet-amoy/sentry/sentry/bor/pbss_config.toml
+++ b/packaging/templates/testnet-amoy/sentry/sentry/bor/pbss_config.toml
@@ -34,6 +34,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v5disc = false
         # bootnodesv4 = []

--- a/packaging/templates/testnet-amoy/sentry/validator/bor/config.toml
+++ b/packaging/templates/testnet-amoy/sentry/validator/bor/config.toml
@@ -35,6 +35,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v5disc = false
         # bootnodesv4 = []

--- a/packaging/templates/testnet-amoy/sentry/validator/bor/pbss_config.toml
+++ b/packaging/templates/testnet-amoy/sentry/validator/bor/pbss_config.toml
@@ -36,6 +36,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v5disc = false
         # bootnodesv4 = []

--- a/packaging/templates/testnet-amoy/without-sentry/bor/config.toml
+++ b/packaging/templates/testnet-amoy/without-sentry/bor/config.toml
@@ -35,6 +35,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v5disc = false
         # bootnodesv4 = []

--- a/packaging/templates/testnet-amoy/without-sentry/bor/pbss_config.toml
+++ b/packaging/templates/testnet-amoy/without-sentry/bor/pbss_config.toml
@@ -36,6 +36,7 @@ syncmode = "full"
     # nodekey = ""
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
+    # txannouncementonly = false
     [p2p.discovery]
         # v5disc = false
         # bootnodesv5 = []

--- a/scripts/getconfig.go
+++ b/scripts/getconfig.go
@@ -172,6 +172,7 @@ var nameTagMap = map[string]string{
 	"maxpeers":                "maxpeers",
 	"maxpendpeers":            "maxpendpeers",
 	"txarrivalwait":           "txarrivalwait",
+	"txannouncementonly":      "txannouncementonly",
 	"nat":                     "nat",
 	"nodiscover":              "nodiscover",
 	"v5disc":                  "v5disc",


### PR DESCRIPTION
# Description

Introducing `txannouncementonly` option.
When enabled, the node will gossip transactions to its peers via announcements only.
Default value is `false` (standard behavior).

This is a convenience option for validators who enable the Fastlane MEV protocol.

Validators participating in the Fastlane protocol have been patching their sentry nodes to achieve the same for more than 2 years. Allowing it as a standard parameter would greatly improve validators experience on each new Bor release.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated


## Testing

- [x] I have added unit tests
- [x] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai/amoy
- [ ] I have created new e2e tests into express-cli
