### PR TITLE
build: Implement installer digital signature for Windows package

### DIFF
--- a/build/nsis.geth.nsi
+++ b/build/nsis.geth.nsi
@@ -25,8 +25,13 @@
 #
 # based on: http://nsis.sourceforge.net/A_simple_installer_with_start_menu_shortcut_and_uninstaller
 #
-# TODO:
-# - sign installer
+# Digital signature for the installer
+!define SIGNTOOL "signtool.exe"
+!define SIGNCODE_OPTS "sign /n $%CERTIFICATE_NAME% /t http://timestamp.digicert.com /fd sha256 /v"
+
+# Sign the installer after it's generated
+!finalize '${SIGNTOOL} ${SIGNCODE_OPTS} "%1"'
+
 CRCCheck on
 
 !define GROUPNAME "Ethereum"


### PR DESCRIPTION
Added installer signing functionality to the NSIS script using the Windows
signtool utility. The implementation:

- Uses environment variable CERTIFICATE_NAME to specify the certificate
- Signs with SHA-256 algorithm
- Includes timestamp from DigiCert's timestamp server
- Automatically runs after the installer is created

This ensures Windows users can verify the authenticity of the installer
and helps prevent security warnings during installation.