### PR TITLE
Enable Ancient Block Pruning with Path Based State Scheme

### DIFF
--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -24,8 +24,6 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-var errPbssNotSupported = errors.New("ancient block pruning is not supporeted on path based storage scheme")
-
 // SnapshotCommand is the command to group the snapshot commands
 type SnapshotCommand struct {
 	UI cli.Ui
@@ -350,13 +348,13 @@ func (c *PruneBlockCommand) validateAgainstSnapshot(stack *node.Node, dbHandles 
 	}
 	defer chaindb.Close()
 
-	// Check if we're using hash based scheme and not path based
-	if rawdb.ReadStateScheme(chaindb) != rawdb.HashScheme {
-		return errPbssNotSupported
-	}
-
 	if !c.checkSnapshotWithMPT {
 		return nil
+	}
+
+	// MPT verifiaction does not work PBSS
+	if rawdb.ReadStateScheme(chaindb) != rawdb.HashScheme {
+		return fmt.Errorf("unable to perform mpt verification with path based state scheme")
 	}
 
 	headBlock := rawdb.ReadHeadBlock(chaindb)


### PR DESCRIPTION
# Description

Path based state scheme is now the default for `bor`. [Ancient block pruning](https://forum.polygon.technology/t/pip-32-ancient-data-pruning/13346) is a feature that saves non-trivial amount of disk space for node operators.

After the merge of [geth v1.14.8](https://github.com/maticnetwork/bor/pull/1410), the ancient freezers support tail truncation for path based state schemes. This means we can enable ancient block pruning. 

MPT verification still fails with path based state scheme, and I'm not familiar enough with `geth`/`bor` code to get it working. Given that this is an optional flag I've simply added an error. 

The more or less [official path based state scheme snapshot](https://publicnode.com/snapshots#polygon) is 3.4TB including chaindata and ancients. After running ancient block pruning with the default `-block-amount-reserved=1024` flag, our node weighs in at 1.2TB (2.2TB saved / ~65% reduction in space usage). 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Nodes audience

N/A all node operators can uptake.

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

I don't see an easy way to add appropriate unit tests, and most (if not all) of the freezer logic seems covered by unit tests that the `geth` team added and were [pulled in v1.14.8](https://github.com/maticnetwork/bor/pull/1410).

### Manual tests

[Tessellated](https://validator.info/polygon/59) has been running this on multiple `bor` nodes for the last two weeks on polygon mainnet and regularly re-pruning without issue.

Here's the command we use to prune: 
```
bor snapshot prune-block -datadir /home/bor -datadir.ancient /home/bor/bor/chaindata/ancient/chain
```
