### PR TITLE
Stateless execution

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -884,8 +884,8 @@ func (c *Bor) Finalize(chain consensus.ChainHeaderReader, header *types.Header, 
 	header.UncleHash = types.CalcUncleHash(nil)
 
 	// Set state sync data to blockchain
-	bc := chain.(*core.BlockChain)
-	bc.SetStateSync(stateSyncData)
+	hc := chain.(*core.HeaderChain)
+	hc.SetStateSync(stateSyncData)
 }
 
 func decodeGenesisAlloc(i interface{}) (types.GenesisAlloc, error) {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -3492,6 +3492,9 @@ func (bc *BlockChain) SubscribeChain2HeadEvent(ch chan<- Chain2HeadEvent) event.
 
 // ProcessBlockWithWitnesses processes a block in stateless mode using the provided witnesses.
 func (bc *BlockChain) ProcessBlockWithWitnesses(block *types.Block, parent *types.Header, witness *stateless.Witness) error {
+	if witness == nil {
+		return errors.New("nil witness")
+	}
 	// Remove critical computed fields from the block to force true recalculation
 	context := block.Header()
 	context.Root = common.Hash{}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -364,7 +364,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	bc.statedb = state.NewDatabase(bc.triedb, nil)
 	bc.validator = NewBlockValidator(chainConfig, bc)
 	bc.prefetcher = newStatePrefetcher(chainConfig, bc.hc)
-	bc.processor = NewStateProcessor(chainConfig, bc, bc.hc)
+	bc.processor = NewStateProcessor(chainConfig, bc.hc)
 
 	bc.genesisBlock = bc.GetBlockByNumber(0)
 	if bc.genesisBlock == nil {
@@ -637,7 +637,7 @@ func (bc *BlockChain) ProcessBlock(block *types.Block, parent *types.Header) (_ 
 		go func() {
 			parallelStatedb.StartPrefetcher("chain", nil)
 			pstart := time.Now()
-			res, err := bc.parallelProcessor.Process(block, parallelStatedb, bc.vmConfig, ctx)
+			res, err := bc.parallelProcessor.Process(block, parallelStatedb, bc.vmConfig, nil, ctx)
 			blockExecutionParallelTimer.UpdateSince(pstart)
 			if err == nil {
 				vstart := time.Now()
@@ -668,7 +668,7 @@ func (bc *BlockChain) ProcessBlock(block *types.Block, parent *types.Header) (_ 
 
 			statedb.StartPrefetcher("chain", witness)
 			pstart := time.Now()
-			res, err := bc.processor.Process(block, statedb, bc.vmConfig, ctx)
+			res, err := bc.processor.Process(block, statedb, bc.vmConfig, nil, ctx)
 			blockExecutionSerialTimer.UpdateSince(pstart)
 			if err == nil {
 				vstart := time.Now()
@@ -2682,7 +2682,7 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 
 	// Process block using the parent state as reference point
 	pstart := time.Now()
-	res, err := bc.processor.Process(block, statedb, bc.vmConfig, context.Background())
+	res, err := bc.processor.Process(block, statedb, bc.vmConfig, nil, context.Background())
 	if err != nil {
 		bc.reportBlock(block, res, err)
 		return nil, err
@@ -2711,9 +2711,10 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 		context.ReceiptHash = common.Hash{}
 
 		task := types.NewBlockWithHeader(context).WithBody(*block.Body())
+		author := NewEVMBlockContext(block.Header(), bc.hc, nil).Coinbase
 
 		// Run the stateless self-cross-validation
-		crossStateRoot, crossReceiptRoot, err := ExecuteStateless(bc.chainConfig, task, witness)
+		crossStateRoot, crossReceiptRoot, err := ExecuteStateless(bc.chainConfig, bc.vmConfig, task, witness, &author, bc.engine)
 		if err != nil {
 			return nil, fmt.Errorf("stateless self-validation failed: %v", err)
 		}
@@ -3491,23 +3492,29 @@ func (bc *BlockChain) SubscribeChain2HeadEvent(ch chan<- Chain2HeadEvent) event.
 
 // ProcessBlockWithWitnesses processes a block in stateless mode using the provided witnesses.
 func (bc *BlockChain) ProcessBlockWithWitnesses(block *types.Block, parent *types.Header, witness *stateless.Witness) error {
+	// Remove critical computed fields from the block to force true recalculation
+	context := block.Header()
+	context.Root = common.Hash{}
+	context.ReceiptHash = common.Hash{}
+
+	task := types.NewBlockWithHeader(context).WithBody(*block.Body())
+
+	// Bor: Calculate EvmBlockContext with Root and ReceiptHash to properly get the author
+	author := NewEVMBlockContext(block.Header(), bc.hc, nil).Coinbase
+
+	crossStateRoot, crossReceiptRoot, err := ExecuteStateless(bc.chainConfig, bc.vmConfig, task, witness, &author, bc.engine)
+
+	if err != nil {
+		return errors.New(fmt.Sprint("stateless self-validation failed: %v", err))
+	}
+	if crossStateRoot != block.Root() {
+		return errors.New(fmt.Sprint("stateless self-validation root mismatch (cross: %x local: %x)", crossStateRoot, block.Root()))
+	}
+	if crossReceiptRoot != block.ReceiptHash() {
+		return errors.New(fmt.Sprint("stateless self-validation receipt root mismatch (cross: %x local: %x)", crossReceiptRoot, block.ReceiptHash()))
+	}
+	if !(err != nil || crossStateRoot != block.Root() || crossReceiptRoot != block.ReceiptHash()) {
+		log.Info("Successfully self validated the block", "block", block.Number(), "hash", block.Hash())
+	}
 	return nil
-	// context := block.Header()
-	// context.Root = common.Hash{}
-	// context.ReceiptHash = common.Hash{}
-
-	// task := types.NewBlockWithHeader(context).WithBody(*block.Body())
-
-	// // Run the stateless self-cross-validation
-	// crossStateRoot, crossReceiptRoot, err := ExecuteStateless(bc.chainConfig, task, witness)
-	// if err != nil {
-	// 	return fmt.Errorf("stateless self-validation failed: %v", err)
-	// }
-	// if crossStateRoot != block.Root() {
-	// 	return fmt.Errorf("stateless self-validation root mismatch (cross: %x local: %x)", crossStateRoot, block.Root())
-	// }
-	// if crossReceiptRoot != block.ReceiptHash() {
-	// 	return fmt.Errorf("stateless self-validation receipt root mismatch (cross: %x local: %x)", crossReceiptRoot, block.ReceiptHash())
-	// }
-	// return nil
 }

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -70,6 +70,8 @@ type HeaderChain struct {
 
 	procInterrupt func() bool
 	engine        consensus.Engine
+
+	stateSyncData []*types.StateSyncData // State sync data
 }
 
 // NewHeaderChain creates a new HeaderChain structure. ProcInterrupt points
@@ -738,4 +740,13 @@ func (hc *HeaderChain) Engine() consensus.Engine { return hc.engine }
 // a header chain does not have blocks available for retrieval.
 func (hc *HeaderChain) GetBlock(hash common.Hash, number uint64) *types.Block {
 	return nil
+}
+
+// SetStateSync set sync data in state_data
+func (hc *HeaderChain) SetStateSync(stateData []*types.StateSyncData) {
+	hc.stateSyncData = stateData
+}
+
+func (hc *HeaderChain) GetStateSync() []*types.StateSyncData {
+	return hc.stateSyncData
 }

--- a/core/parallel_state_processor.go
+++ b/core/parallel_state_processor.go
@@ -265,7 +265,7 @@ var parallelizabilityTimer = metrics.NewRegisteredTimer("block/parallelizability
 // returns the amount of gas that was used in the process. If any of the
 // transactions failed to execute due to insufficient gas it will return an error.
 // nolint:gocognit
-func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, interruptCtx context.Context) (*ProcessResult, error) {
+func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, author *common.Address, interruptCtx context.Context) (*ProcessResult, error) {
 	var (
 		receipts    types.Receipts
 		header      = block.Header()
@@ -300,7 +300,7 @@ func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.Stat
 		metadata = true
 	}
 
-	blockContext := NewEVMBlockContext(header, p.bc, nil)
+	blockContext := NewEVMBlockContext(header, p.bc, author)
 	context := NewEVMBlockContext(header, p.bc.hc, nil)
 	vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, p.config, cfg)
 
@@ -404,7 +404,7 @@ func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.Stat
 	}
 
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
-	p.engine.Finalize(p.bc, header, statedb, block.Body())
+	p.engine.Finalize(p.bc.hc, header, statedb, block.Body())
 
 	return &ProcessResult{
 		Receipts: receipts,

--- a/core/types.go
+++ b/core/types.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync/atomic"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -49,7 +50,7 @@ type Processor interface {
 	// Process processes the state changes according to the Ethereum rules by running
 	// the transaction messages using the statedb and applying any rewards to both
 	// the processor (coinbase) and any included uncles.
-	Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, interruptCtx context.Context) (*ProcessResult, error)
+	Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, author *common.Address, interruptCtx context.Context) (*ProcessResult, error)
 }
 
 // ProcessResult contains the values computed by Process.

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -973,7 +973,7 @@ func (api *ConsensusAPI) executeStatelessPayload(params engine.ExecutableData, v
 	api.lastNewPayloadLock.Unlock()
 
 	log.Trace("Executing block statelessly", "number", block.Number(), "hash", params.BlockHash)
-	stateRoot, receiptRoot, err := core.ExecuteStateless(api.eth.BlockChain().Config(), block, witness)
+	stateRoot, receiptRoot, err := core.ExecuteStateless(api.eth.BlockChain().Config(), *api.eth.BlockChain().GetVMConfig(), block, witness, nil, api.eth.Engine())
 	if err != nil {
 		log.Warn("ExecuteStatelessPayload: execution failed", "err", err)
 		errorMsg := err.Error()

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -156,7 +156,7 @@ func (eth *Ethereum) hashState(ctx context.Context, block *types.Block, reexec u
 		if current = eth.blockchain.GetBlockByNumber(next); current == nil {
 			return nil, nil, fmt.Errorf("block #%d not found", next)
 		}
-		_, err := eth.blockchain.Processor().Process(current, statedb, vm.Config{}, nil)
+		_, err := eth.blockchain.Processor().Process(current, statedb, vm.Config{}, nil, nil)
 		if err != nil {
 			return nil, nil, fmt.Errorf("processing block %d failed: %v", current.NumberU64(), err)
 		}


### PR DESCRIPTION
# Description
Stateless execution is now functional. To support it, we clear parts of the block header, which prevents retrieving the original coinbase (author) since that field is part of the signed data. As a result, the author must now be explicitly provided to avoid incorrect values.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

