### PR TITLE
Fix Span Committing on Stateless Client

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1137,13 +1137,16 @@ func (c *Bor) checkAndCommitSpan(
 	var ctx = context.Background()
 	headerNumber := header.Number.Uint64()
 
-	span, err := c.spanner.GetCurrentSpan(ctx, header.ParentHash)
+	span, err := c.spanner.GetCurrentSpan(ctx, header.ParentHash, state)
 	if err != nil {
 		return err
 	}
 
 	if c.needToCommitSpan(span, headerNumber) {
-		return c.FetchAndCommitSpan(ctx, span.ID+1, state, header, chain)
+		err = c.FetchAndCommitSpan(ctx, span.ID+1, state, header, chain)
+		if err != nil {
+		}
+		return err
 	}
 
 	return nil
@@ -1265,7 +1268,7 @@ func (c *Bor) CommitStates(
 
 	if c.config.IsIndore(header.Number) {
 		// Fetch the LastStateId from contract via current state instance
-		lastStateIDBig, err = c.GenesisContractsClient.LastStateId(state.Copy(), number-1, header.ParentHash)
+		lastStateIDBig, err = c.GenesisContractsClient.LastStateId(state, number-1, header.ParentHash)
 		if err != nil {
 			return nil, err
 		}
@@ -1376,7 +1379,7 @@ func (c *Bor) getNextHeimdallSpanForTest(
 ) (*span.HeimdallSpan, error) {
 	headerNumber := header.Number.Uint64()
 
-	spanBor, err := c.spanner.GetCurrentSpan(ctx, header.ParentHash)
+	spanBor, err := c.spanner.GetCurrentSpan(ctx, header.ParentHash, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1143,10 +1143,7 @@ func (c *Bor) checkAndCommitSpan(
 	}
 
 	if c.needToCommitSpan(span, headerNumber) {
-		err = c.FetchAndCommitSpan(ctx, span.ID+1, state, header, chain)
-		if err != nil {
-		}
-		return err
+		return c.FetchAndCommitSpan(ctx, span.ID+1, state, header, chain)
 	}
 
 	return nil

--- a/consensus/bor/heimdall/span/spanner.go
+++ b/consensus/bor/heimdall/span/spanner.go
@@ -47,7 +47,7 @@ func NewChainSpanner(ethAPI api.Caller, validatorSet abi.ABI, chainConfig *param
 }
 
 // GetCurrentSpan get current span from contract
-func (c *ChainSpanner) GetCurrentSpan(ctx context.Context, headerHash common.Hash) (*Span, error) {
+func (c *ChainSpanner) GetCurrentSpan(ctx context.Context, headerHash common.Hash, state *state.StateDB) (*Span, error) {
 	// block
 	blockNr := rpc.BlockNumberOrHashWithHash(headerHash, false)
 
@@ -66,11 +66,11 @@ func (c *ChainSpanner) GetCurrentSpan(ctx context.Context, headerHash common.Has
 	gas := (hexutil.Uint64)(uint64(math.MaxUint64 / 2))
 
 	// todo: would we like to have a timeout here?
-	result, err := c.ethAPI.Call(ctx, ethapi.TransactionArgs{
+	result, err := c.ethAPI.CallWithState(ctx, ethapi.TransactionArgs{
 		Gas:  &gas,
 		To:   &toAddress,
 		Data: &msgData,
-	}, &blockNr, nil, nil)
+	}, &blockNr, state, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/bor/span.go
+++ b/consensus/bor/span.go
@@ -15,7 +15,7 @@ import (
 
 //go:generate mockgen -destination=./span_mock.go -package=bor . Spanner
 type Spanner interface {
-	GetCurrentSpan(ctx context.Context, headerHash common.Hash) (*span.Span, error)
+	GetCurrentSpan(ctx context.Context, headerHash common.Hash, state *state.StateDB) (*span.Span, error)
 	GetCurrentValidatorsByHash(ctx context.Context, headerHash common.Hash, blockNumber uint64) ([]*valset.Validator, error)
 	GetCurrentValidatorsByBlockNrOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, blockNumber uint64) ([]*valset.Validator, error)
 	CommitSpan(ctx context.Context, minimalSpan span.Span, validators, producers []stakeTypes.MinimalVal, state *state.StateDB, header *types.Header, chainContext core.ChainContext) error

--- a/consensus/bor/span_mock.go
+++ b/consensus/bor/span_mock.go
@@ -57,18 +57,18 @@ func (mr *MockSpannerMockRecorder) CommitSpan(arg0, arg1, arg2, arg3, arg4, arg5
 }
 
 // GetCurrentSpan mocks base method.
-func (m *MockSpanner) GetCurrentSpan(arg0 context.Context, arg1 common.Hash) (*span.Span, error) {
+func (m *MockSpanner) GetCurrentSpan(arg0 context.Context, arg1 common.Hash, arg2 *state.StateDB) (*span.Span, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCurrentSpan", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetCurrentSpan", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*span.Span)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCurrentSpan indicates an expected call of GetCurrentSpan.
-func (mr *MockSpannerMockRecorder) GetCurrentSpan(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSpannerMockRecorder) GetCurrentSpan(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentSpan", reflect.TypeOf((*MockSpanner)(nil).GetCurrentSpan), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentSpan", reflect.TypeOf((*MockSpanner)(nil).GetCurrentSpan), arg0, arg1, arg2)
 }
 
 // GetCurrentValidatorsByBlockNrOrHash mocks base method.


### PR DESCRIPTION
# Description

Related Fixes:

- Include witness StateDB on `GetCurrentSpan` call on stateless client
- Include state prefetching of `LastStateId` call on block producer 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Tests

- Tests made on Kurtosis, solution is open and running. But facing issues on syncing