### PR TITLE
[bug fix] Avoid concurrent access to hasher buffer

### DIFF
--- a/core/state/reader.go
+++ b/core/state/reader.go
@@ -79,7 +79,7 @@ func newStateReader(root common.Hash, snaps *snapshot.Tree) (*stateReader, error
 //
 // The returned account might be nil if it's not existent.
 func (r *stateReader) Account(addr common.Address) (*types.StateAccount, error) {
-	ret, err := r.snap.Account(crypto.HashData(r.buff, addr.Bytes()))
+	ret, err := r.snap.Account(crypto.HashData(crypto.NewKeccakState(), addr.Bytes()))
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +109,8 @@ func (r *stateReader) Account(addr common.Address) (*types.StateAccount, error) 
 //
 // The returned storage slot might be empty if it's not existent.
 func (r *stateReader) Storage(addr common.Address, key common.Hash) (common.Hash, error) {
-	addrHash := crypto.HashData(r.buff, addr.Bytes())
-	slotHash := crypto.HashData(r.buff, key.Bytes())
+	addrHash := crypto.HashData(crypto.NewKeccakState(), addr.Bytes())
+	slotHash := crypto.HashData(crypto.NewKeccakState(), key.Bytes())
 	ret, err := r.snap.Storage(addrHash, slotHash)
 	if err != nil {
 		return common.Hash{}, err
@@ -223,7 +223,7 @@ func (r *trieReader) Storage(addr common.Address, key common.Hash) (common.Hash,
 				root = r.subRoots[addr]
 			}
 			var err error
-			tr, err = trie.NewStateTrie(trie.StorageTrieID(r.root, crypto.HashData(r.buff, addr.Bytes()), root), r.db)
+			tr, err = trie.NewStateTrie(trie.StorageTrieID(r.root, crypto.HashData(crypto.NewKeccakState(), addr.Bytes()), root), r.db)
 			if err != nil {
 				return common.Hash{}, err
 			}

--- a/params/version.go
+++ b/params/version.go
@@ -25,7 +25,7 @@ import (
 const (
 	VersionMajor = 2  // Major version component of the current release
 	VersionMinor = 0  // Minor version component of the current release
-	VersionPatch = 2  // Patch version component of the current release
+	VersionPatch = 3  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
# Description

This is to fix hasher panic caused by a recent upstream merge.

```
/home/runner/work/bor/bor/core/state/reader.go:82 +0x6b
github.com/ethereum/go-ethereum/core/state.(*stateReader).Account(0xc101562400, {0xfb, 0xf8, 0xb7, 0xd2, 0xdd, 0x10, 0x44, 0x7d, 0xcb, ...})
/home/runner/work/bor/bor/crypto/crypto.go:92 +0x6b
github.com/ethereum/go-ethereum/crypto.HashData({0x7d7d9c1d3288, 0xc0b5bb81e0}, {0xc19359c558, 0x14, 0x14})
/home/runner/go/pkg/mod/golang.org/x/crypto@v0.31.0/sha3/sha3.go:117 +0x1c5
golang.org/x/crypto/sha3.(*state).Write(0xc138702f70?, {0xc19359c558?, 0x14?, 0x29edcc0?})
goroutine 362766824 [running]:
panic: sha3: Write after Read
```

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
