### PR TITLE
miner: reduce commit interrupt timer for on-time block announcement

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1557,8 +1557,10 @@ func resetAndCopyInterruptCtx(interruptCtx context.Context) context.Context {
 }
 
 func getInterruptTimer(interruptCtx context.Context, number, timestamp uint64) (context.Context, func()) {
-	delay := time.Until(time.Unix(int64(timestamp), 0))
-	interruptCtx, cancel := context.WithTimeout(interruptCtx, delay)
+	// Instead of interrupting block building at exact header time, we leave 500ms as buffer
+	// for consensus operations (in Finalize) and state root calculation.
+	adjustedDelay := time.Unix(int64(timestamp), 0).Add(-500 * time.Millisecond)
+	interruptCtx, cancel := context.WithTimeout(interruptCtx, time.Until(adjustedDelay))
 
 	go func() {
 		<-interruptCtx.Done()


### PR DESCRIPTION
# Description

Previously, the commit interrupt timer triggers exactly at header's timestamp i.e. 2s (for non-sprint end blocks proposed by primary producer) to stop block building and announce the block to rest of the peers. 

There's some overhead after this timer is triggered which is consensus checks and state root calculation which isn't accounted in the 2s delay. On average, 300ms are spent on such operations (this is just a rough average from a sentry in a limited time range). This leads to delay in block announcement which may lead to reorgs in some scenarios (because the block reaches late to rest of the validators and the secondary producer kicks in). 

This PR reduces that delay and leaves a 500ms buffer for these misc operations before block is announced. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
