### PR TITLE
FastForward on HeimdallV1

### DIFF
--- a/eth/bor_checkpoint_verifier.go
+++ b/eth/bor_checkpoint_verifier.go
@@ -84,7 +84,7 @@ func borVerify(ctx context.Context, eth *Ethereum, handler *ethHandler, start ui
 	} else {
 		// in case of milestone(isCheckpoint==false) get the hash of endBlock
 		block, err := handler.ethAPI.GetBlockByNumber(ctx, rpc.BlockNumber(end), false)
-		if err != nil {
+		if err != nil || block == nil || block["hash"] == nil {
 			log.Debug("Failed to get end block hash while whitelisting milestone", "number", end, "err", err)
 			return hash, fmt.Errorf("%w: %v", errEndBlock, err)
 		}
@@ -148,7 +148,7 @@ func borVerify(ctx context.Context, eth *Ethereum, handler *ethHandler, start ui
 
 // Stop the miner if the mining process is running and rewind back the chain
 func rewindBack(eth *Ethereum, head uint64, rewindTo uint64) {
-	if eth.Miner().Mining() {
+	if eth.Miner() != nil && eth.Miner().Mining() {
 		ch := make(chan struct{})
 		eth.Miner().Stop(ch)
 

--- a/eth/downloader/beaconsync.go
+++ b/eth/downloader/beaconsync.go
@@ -106,7 +106,7 @@ func (b *beaconBackfiller) resume() {
 		}()
 		// If the downloader fails, report an error as in beacon chain mode there
 		// should be no errors as long as the chain we're syncing to is valid.
-		if err := b.downloader.synchronise("", common.Hash{}, nil, nil, mode, true, b.started); err != nil {
+		if err := b.downloader.synchronise("", common.Hash{}, nil, nil, mode, true, b.started, nil); err != nil {
 			log.Error("Beacon backfilling failed", "err", err)
 			return
 		}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -619,7 +619,7 @@ func (h *handler) BroadcastBlock(block *types.Block, witness *stateless.Witness,
 		// Calculate the TD of the block (it's not imported yet, so block.Td is not valid)
 		var td *big.Int
 		if parent := h.chain.GetBlock(block.ParentHash(), block.NumberU64()-1); parent != nil {
-			td = new(big.Int).Add(block.Difficulty(), h.chain.GetTd(block.ParentHash(), block.NumberU64()-1))
+			td = new(big.Int).Add(big.NewInt(1), h.chain.GetTd(block.ParentHash(), block.NumberU64()-1))
 		} else {
 			log.Error("Propagating dangling block", "number", block.Number(), "hash", hash)
 			return

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -275,7 +275,7 @@ func (h *handler) doSync(op *chainSyncOp) error {
 		}
 	}
 	// Run the sync cycle, and disable snap sync if we're past the pivot block
-	err := h.downloader.LegacySync(op.peer.ID(), op.head, op.td, h.chain.Config().TerminalTotalDifficulty, op.mode)
+	err := h.downloader.LegacySync(op.peer.ID(), op.head, op.td, h.chain.Config().TerminalTotalDifficulty, op.mode, h.database)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Implement a one-time fast-forward in the stateless client (bor-connected heimdall-v1) for tests by setting TotalDifficulty to the target block number on startup instead of fetching real TD and skipping formal validations. If it ever desyncs, simply restart to rerun the fast-forward.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

