### PR TITLE
eth_getTdByNumber method

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -285,6 +285,13 @@ func (b *EthAPIBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {
 	return nil
 }
 
+func (b *EthAPIBackend) GetTdByNumber(ctx context.Context, blockNr rpc.BlockNumber) *big.Int {
+	if header, err := b.HeaderByNumber(ctx, blockNr); header != nil && err == nil {
+		return b.eth.blockchain.GetTd(header.Hash(), uint64(blockNr.Int64()))
+	}
+	return nil
+}
+
 func (b *EthAPIBackend) GetEVM(ctx context.Context, msg *core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config, blockCtx *vm.BlockContext) *vm.EVM {
 	if vmConfig == nil {
 		vmConfig = b.eth.blockchain.GetVMConfig()

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -771,7 +771,6 @@ func (api *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rp
 
 // GetTdByHash returns a map containing the total difficulty (hex-encoded) for the given block hash.
 func (api *BlockChainAPI) GetTdByHash(ctx context.Context, hash common.Hash) map[string]interface{} {
-
 	td := api.b.GetTd(ctx, hash)
 	if td == nil {
 		return nil

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -769,6 +769,33 @@ func (api *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rp
 	return result, nil
 }
 
+// GetTdByHash returns a map containing the total difficulty (hex-encoded) for the given block hash.
+func (api *BlockChainAPI) GetTdByHash(ctx context.Context, hash common.Hash) map[string]interface{} {
+
+	td := api.b.GetTd(ctx, hash)
+	if td == nil {
+		return nil
+	}
+
+	resp := make(map[string]interface{}, 2)
+	resp["blockHash"] = hash.Hex()
+	resp["totalDifficulty"] = hexutil.EncodeBig(td)
+	return resp
+}
+
+// GetTdByNumber returns a map containing the total difficulty (hex-encoded) for the given block number.
+func (api *BlockChainAPI) GetTdByNumber(ctx context.Context, blockNr rpc.BlockNumber) map[string]interface{} {
+	td := api.b.GetTdByNumber(ctx, blockNr)
+	if td == nil {
+		return nil
+	}
+
+	resp := make(map[string]interface{}, 2)
+	resp["blockNumber"] = hexutil.EncodeUint64(uint64(blockNr.Int64()))
+	resp["totalDifficulty"] = hexutil.EncodeBig(td)
+	return resp
+}
+
 // OverrideAccount indicates the overriding fields of account during the execution
 // of a message call.
 // Note, state and stateDiff can't be specified at the same time. If state is

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -568,6 +568,10 @@ func (b testBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {
 	}
 	return big.NewInt(1)
 }
+func (b testBackend) GetTdByNumber(ctx context.Context, blockNr rpc.BlockNumber) *big.Int {
+	panic("not implemented")
+}
+
 func (b testBackend) GetEVM(ctx context.Context, msg *core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config, blockContext *vm.BlockContext) *vm.EVM {
 	if vmConfig == nil {
 		vmConfig = b.chain.GetVMConfig()

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -70,6 +70,8 @@ type Backend interface {
 	Pending() (*types.Block, types.Receipts, *state.StateDB)
 	GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error)
 	GetEVM(ctx context.Context, msg *core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config, blockCtx *vm.BlockContext) *vm.EVM
+	GetTd(ctx context.Context, hash common.Hash) *big.Int
+	GetTdByNumber(ctx context.Context, blockNr rpc.BlockNumber) *big.Int
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -470,3 +470,7 @@ func (b *backendMock) PurgeWhitelistedMilestone() {}
 func (b backendMock) PeerStats() interface{} {
 	return nil
 }
+
+func (b backendMock) GetTdByNumber(ctx context.Context, blockNr rpc.BlockNumber) *big.Int {
+	panic("not implemented")
+}


### PR DESCRIPTION
# Description

The implemented method returns the `totalDifficulty` given a block number. The main goal is allow heimdall querying the Total Difficulty of a produced block when building a milestone.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
