### PR TITLE
Prune old witnesses

### DIFF
--- a/core/rawdb/accessors_state.go
+++ b/core/rawdb/accessors_state.go
@@ -282,3 +282,28 @@ func WriteWitness(db ethdb.KeyValueWriter, blockHash common.Hash, witness []byte
 		log.Crit("Failed to store witness", "err", err)
 	}
 }
+
+func DeleteWitness(db ethdb.KeyValueWriter, blockHash common.Hash) {
+	log.Debug("DeleteWitness", "blockHash", blockHash)
+	if err := db.Delete(witnessKey(blockHash)); err != nil {
+		log.Crit("Failed to remove witness", "err", err)
+	}
+}
+
+func ReadWitnessPruneCursor(db ethdb.KeyValueReader) *uint64 {
+	log.Debug("ReadWitnessCursor")
+	data, err := db.Get(witnessPruneCursorKey())
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+
+	number := binary.BigEndian.Uint64(data)
+	return &number
+}
+
+func WriteWitnessPruneCursor(db ethdb.KeyValueWriter, cursor uint64) {
+	log.Debug("WriteWitnessPruneCursor", "cursor", cursor)
+	if err := db.Put(witnessPruneCursorKey(), encodeBlockNumber(cursor)); err != nil {
+		log.Crit("Failed to store witness", "err", err)
+	}
+}

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -134,7 +134,8 @@ var (
 	configPrefix   = []byte("ethereum-config-")  // config prefix for the db
 	genesisPrefix  = []byte("ethereum-genesis-") // genesis state prefix for the db
 
-	WitnessPrefix = []byte("witness-")
+	WitnessPrefix         = []byte("witness-")
+	WitnessPruneCursorKey = []byte("witnessPruneCursorKey")
 
 	// BloomBitsIndexPrefix is the data table of a chain indexer to track its progress
 	BloomBitsIndexPrefix = []byte("iB")
@@ -255,6 +256,10 @@ func preimageKey(hash common.Hash) []byte {
 // witnessKey = WitnessPrefix + hash
 func witnessKey(hash common.Hash) []byte {
 	return append(WitnessPrefix, hash.Bytes()...)
+}
+
+func witnessPruneCursorKey() []byte {
+	return WitnessPruneCursorKey
 }
 
 // codeKey = CodePrefix + hash

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -300,21 +300,23 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	// Permit the downloader to use the trie cache allowance during fast sync
 	cacheLimit := cacheConfig.TrieCleanLimit + cacheConfig.TrieDirtyLimit + cacheConfig.SnapshotLimit
 	if eth.handler, err = newHandler(&handlerConfig{
-		Database:             chainDb,
-		Chain:                eth.blockchain,
-		TxPool:               eth.txPool,
-		Network:              config.NetworkId,
-		Sync:                 config.SyncMode,
-		BloomCache:           uint64(cacheLimit),
-		EventMux:             eth.eventMux,
-		RequiredBlocks:       config.RequiredBlocks,
-		EthAPI:               blockChainAPI,
-		checker:              checker,
-		enableBlockTracking:  eth.config.EnableBlockTracking,
-		txAnnouncementOnly:   eth.p2pServer.TxAnnouncementOnly,
-		syncWithWitnesses:    eth.config.SyncWithWitnesses,
-		computeWitness:       eth.config.WitnessProtocol,
-		FastForwardThreshold: config.FastForwardThreshold,
+		Database:              chainDb,
+		Chain:                 eth.blockchain,
+		TxPool:                eth.txPool,
+		Network:               config.NetworkId,
+		Sync:                  config.SyncMode,
+		BloomCache:            uint64(cacheLimit),
+		EventMux:              eth.eventMux,
+		RequiredBlocks:        config.RequiredBlocks,
+		EthAPI:                blockChainAPI,
+		checker:               checker,
+		enableBlockTracking:   eth.config.EnableBlockTracking,
+		txAnnouncementOnly:    eth.p2pServer.TxAnnouncementOnly,
+		syncWithWitnesses:     eth.config.SyncWithWitnesses,
+		computeWitness:        eth.config.WitnessProtocol,
+		fastForwardThreshold:  config.FastForwardThreshold,
+		witnessPruneThreshold: config.WitnessPruneThreshold,
+		witnessPruneInterval:  config.WitnessPruneInterval,
 	}); err != nil {
 		return nil, err
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -56,25 +56,27 @@ var FullNodeGPO = gasprice.Config{
 
 // Defaults contains default settings for use on the Ethereum main net.
 var Defaults = Config{
-	SyncMode:             downloader.FullSync,
-	NetworkId:            0, // enable auto configuration of networkID == chainID
-	TxLookupLimit:        2350000,
-	TransactionHistory:   2350000,
-	StateHistory:         params.FullImmutabilityThreshold,
-	DatabaseCache:        512,
-	TrieCleanCache:       154,
-	TrieDirtyCache:       256,
-	TrieTimeout:          60 * time.Minute,
-	SnapshotCache:        102,
-	FilterLogCacheSize:   32,
-	Miner:                miner.DefaultConfig,
-	TxPool:               legacypool.DefaultConfig,
-	BlobPool:             blobpool.DefaultConfig,
-	RPCGasCap:            50000000,
-	RPCEVMTimeout:        5 * time.Second,
-	GPO:                  FullNodeGPO,
-	RPCTxFeeCap:          1, // 1 ether
-	FastForwardThreshold: 100,
+	SyncMode:              downloader.FullSync,
+	NetworkId:             0, // enable auto configuration of networkID == chainID
+	TxLookupLimit:         2350000,
+	TransactionHistory:    2350000,
+	StateHistory:          params.FullImmutabilityThreshold,
+	DatabaseCache:         512,
+	TrieCleanCache:        154,
+	TrieDirtyCache:        256,
+	TrieTimeout:           60 * time.Minute,
+	SnapshotCache:         102,
+	FilterLogCacheSize:    32,
+	Miner:                 miner.DefaultConfig,
+	TxPool:                legacypool.DefaultConfig,
+	BlobPool:              blobpool.DefaultConfig,
+	RPCGasCap:             50000000,
+	RPCEVMTimeout:         5 * time.Second,
+	GPO:                   FullNodeGPO,
+	RPCTxFeeCap:           1, // 1 ether
+	FastForwardThreshold:  100,
+	WitnessPruneThreshold: 6400,
+	WitnessPruneInterval:  120,
 }
 
 //go:generate go run github.com/fjl/gencodec -type Config -formats toml -out gen_config.go
@@ -217,6 +219,12 @@ type Config struct {
 
 	// Minimum necessary distance between local header and peer to fast forward
 	FastForwardThreshold uint64
+
+	// Minimum necessary distance between local header and latest non pruned witness
+	WitnessPruneThreshold uint64
+
+	// The time interval between each witness prune routine
+	WitnessPruneInterval uint64
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -74,6 +74,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		OverrideVerkle                       *big.Int `toml:",omitempty"`
 		EnableBlockTracking                  bool
 		FastForwardThreshold                 uint64
+		WitnessPruneThreshold                uint64
+		WitnessPruneInterval                 uint64
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -131,6 +133,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.OverrideVerkle = c.OverrideVerkle
 	enc.EnableBlockTracking = c.EnableBlockTracking
 	enc.FastForwardThreshold = c.FastForwardThreshold
+	enc.WitnessPruneThreshold = c.WitnessPruneThreshold
+	enc.WitnessPruneInterval = c.WitnessPruneInterval
 	return &enc, nil
 }
 
@@ -193,6 +197,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		OverrideVerkle                       *big.Int `toml:",omitempty"`
 		EnableBlockTracking                  *bool
 		FastForwardThreshold                 *uint64
+		WitnessPruneThreshold                *uint64
+		WitnessPruneInterval                 *uint64
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -362,6 +368,12 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.FastForwardThreshold != nil {
 		c.FastForwardThreshold = *dec.FastForwardThreshold
+	}
+	if dec.WitnessPruneThreshold != nil {
+		c.WitnessPruneThreshold = *dec.WitnessPruneThreshold
+	}
+	if dec.WitnessPruneInterval != nil {
+		c.WitnessPruneInterval = *dec.WitnessPruneInterval
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

This PR adds a background goroutine that wakes every h.witnessPruneInterval to prune any witnesses older than the retention threshold. A persistent database cursor ensures each run picks up exactly where the last left off—avoiding redundant scans—and bounds the pruning window. All eligible witness hashes are deleted in a single batched transaction, the cursor is advanced atomically, and the loop cleanly shuts down when the quit channel is closed.


# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
