### PR TITLE
fix(consensus, span): avoid duplicate span commit for spanId 1

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1155,7 +1155,7 @@ func (c *Bor) needToCommitSpan(currentSpan *span.Span, headerNumber uint64) bool
 	// But here we should skip the check for the 0th span, as it will cause the span to be committed to be committed twice.
 	if currentSpan.EndBlock > c.config.CalculateSprint(headerNumber) && currentSpan.EndBlock-c.config.CalculateSprint(headerNumber)+1 == headerNumber {
 		if currentSpan.ID == 0 {
-			// If the current span is the 0th span, we will skip commiting the span.
+			// If the current span is the 0th span, we will skip committing the span.
 			log.Info("Skipping the last sprint commit for 0th span", "spanID", currentSpan.ID, "headerNumber", headerNumber)
 			return false
 		}

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1156,6 +1156,7 @@ func (c *Bor) needToCommitSpan(currentSpan *span.Span, headerNumber uint64) bool
 	if currentSpan.EndBlock > c.config.CalculateSprint(headerNumber) && currentSpan.EndBlock-c.config.CalculateSprint(headerNumber)+1 == headerNumber {
 		if currentSpan.ID == 0 {
 			// If the current span is the 0th span, we will skip commiting the span.
+			log.Info("Skipping the last sprint commit for 0th span", "spanID", currentSpan.ID, "headerNumber", headerNumber)
 			return false
 		}
 		return true


### PR DESCRIPTION
# Description

TL;DR
https://0xpolygon.slack.com/archives/C03PD53G8L9/p1748858685398169

Before:
```bash
INFO "✅ Committing new span"                id=1                startBlock=256 endBlock=1855 validatorBytes=dad9018227109459425e069c8143bf456506d670c900a713bd836a producerBytes=dad9018227109459425e069c8143bf456506d670c900a713bd836a

INFO "✅ Committing new span"                id=1                startBlock=256 endBlock=1855 validatorBytes=dad9018227109459425e069c8143bf456506d670c900a713bd836a producerBytes=dad9018227109459425e069c8143bf456506d670c900a713bd836a
ERROR message execution failed on contract     err="execution reverted"
```
After:
```bash
INFO  "✅ Committing new span"                id=1                startBlock=256 endBlock=1855 validatorBytes=dad9018227109459425e069c8143bf456506d670c900a713bd836a producerBytes=dad9018227109459425e069c8143bf456506d670c900a713bd836a

INFO Skipping the last sprint commit for 0th span spanID=0 headerNumber=240
```