### PR TITLE
Fix localEndBlock nil check

### DIFF
--- a/eth/bor_api_backend.go
+++ b/eth/bor_api_backend.go
@@ -64,7 +64,7 @@ func (b *EthAPIBackend) GetVoteOnHash(ctx context.Context, starBlockNr uint64, e
 
 	// Check if end block exist
 	localEndBlock, err := b.BlockByNumber(ctx, rpc.BlockNumber(endBlockNr))
-	if err != nil {
+	if err != nil || localEndBlock == nil {
 		return false, errEndBlock
 	}
 


### PR DESCRIPTION
# Description

Found issue:

```
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]: ERROR[06-03|17:45:36.599] RPC method bor_getVoteOnHash crashed: runtime error: invalid memory address or nil pointer dereference
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]: goroutine 194485 [running]:
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]: github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]:         /home/runner/work/bor/bor/rpc/service.go:216 +0x85
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]: panic({0x275c660?, 0x4f5efc0?})
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]:         /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/panic.go:785 +0x132
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]: github.com/ethereum/go-ethereum/core/types.(*Block).Hash(0x0?)
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]:         /home/runner/work/bor/bor/core/types/block.go:636 +0x29
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]: github.com/ethereum/go-ethereum/eth.(*EthAPIBackend).GetVoteOnHash(0xc00355b0e0, {0x38b11a0, 0xc0133d1c70}, 0xc0133d1c70?, 0x156c1bf, {0xc001748690, 0x42}, {0xc00083ec00, 0x51})
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]:         /home/runner/work/bor/bor/eth/bor_api_backend.go:71 +0x185
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]: github.com/ethereum/go-ethereum/internal/ethapi.(*BorAPI).GetVoteOnHash(0x295c120?, {0x38b11a0?, 0xc0133d1c70?}, 0xc0035d95b8?, 0x5116b8?, {0xc001748690?, 0x295c120?}, {0xc00083ec00?, 0xc00c86df20?})
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]:         /home/runner/work/bor/bor/internal/ethapi/bor_api.go:110 +0x38
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]: reflect.Value.call({0xc01273ab80?, 0xc012893798?, 0x258cc40?}, {0x2b947ac, 0x4}, {0xc003a1d9e0, 0x6, 0xc003a1da10?})
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]:         /opt/hostedtoolcache/go/1.23.6/x64/src/reflect/value.go:581 +0xca6
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]: reflect.Value.Call({0xc01273ab80?, 0xc012893798?, 0x4?}, {0xc003a1d9e0?, 0x16?, 0x16?})
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]:         /opt/hostedtoolcache/go/1.23.6/x64/src/reflect/value.go:365 +0xb9
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]: github.com/ethereum/go-ethereum/rpc.(*callback).call(0xc0128ce120, {0x38b11a0, 0xc0133d1c70}, {0xc01248f5d8, 0x11}, {0xc0045a4e40, 0x4, 0x4b24af?})
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]:         /home/runner/work/bor/bor/rpc/service.go:223 +0x365
Jun 03 17:45:36 amoy-testnet-rpc-ubuntu-amd64-003 bor[499021]: github.com/ethereum/go-ethereum/rpc.(*handler).runMethod(0xc00b5226e0?, {0x38b11a0?, 0xc0133d1c70?}, 0xc0005c71f0, 0x4?, {0xc0045a4e40?, 0xc005accdc8?, 0x103?})
```

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
