### PR TITLE
VeBlop span rotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,20 +201,20 @@ jobs:
         with:
           go-version: 1.23.x
 
-        - name: Checkout matic-cli
-          uses: actions/checkout@v4
-          with:
-            repository: maticnetwork/matic-cli
-            ref: heimdall-v2
-            path: matic-cli
+      - name: Checkout matic-cli
+        uses: actions/checkout@v4
+        with:
+          repository: maticnetwork/matic-cli
+          ref: heimdall-v2
+          path: matic-cli
 
-        - name: Install dependencies on Linux
-          if: runner.os == 'Linux'
-          run: |
-            sudo apt update
-            sudo apt install build-essential
-            curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
-            sudo apt install jq curl
+      - name: Install dependencies on Linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install build-essential
+          curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
+          sudo apt install jq curl
 
       - uses: actions/setup-node@v3
         with:
@@ -226,49 +226,37 @@ jobs:
             matic-cli/devnet/code/genesis-contracts/package-lock.json
             matic-cli/devnet/code/genesis-contracts/matic-contracts/package-lock.json
 
-        - name: Install solc-select
-          run: |
-            sudo apt update
-            sudo apt install python3 python3-pip -y
-            sudo ln -sf /usr/bin/python3 /usr/bin/python
-            pip install solc-select
+      - name: Install solc-select
+        run: |
+          sudo apt update
+          sudo apt install python3 python3-pip -y
+          sudo ln -sf /usr/bin/python3 /usr/bin/python
+          pip install solc-select
 
-        - name: Install Solidity Version
-          run: |
-            solc-select install 0.5.17
-            solc-select install 0.6.12
-            solc-select use 0.5.17
-            solc --version
+      - name: Install Solidity Version
+        run: |
+          solc-select install 0.5.17
+          solc-select install 0.6.12
+          solc-select use 0.5.17
+          solc --version
 
-        - name: Install Foundry
-          uses: foundry-rs/foundry-toolchain@v1
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
 
-        - name: Bootstrap devnet
-          run: |
-            cd matic-cli
-            npm install --prefer-offline --no-audit --progress=false
-            mkdir devnet
-            cd devnet
-            ../bin/matic-cli.js setup devnet -c ../../bor/.github/matic-cli-config.yml
+      - name: Bootstrap devnet
+        run: |
+          cd matic-cli
+          npm install --prefer-offline --no-audit --progress=false
+          mkdir devnet
+          cd devnet
+          ../bin/matic-cli.js setup devnet -c ../../bor/.github/matic-cli-config.yml
 
-        - name: Launch devnet
-          run: |
-            cd matic-cli/devnet
-            bash ../util-scripts/docker/devnet_setup.sh
-            cd -
-            timeout 2m bash bor/integration-tests/bor_health.sh
-
-        - name: Run smoke tests
-          run: |
-            echo "Deposit 100 matic for each account to bor network"
-            cd matic-cli/devnet/devnet
-            SCRIPT_ADDRESS=$(jq -r '.[0].address' signer-dump.json)
-            SCRIPT_PRIVATE_KEY=$(jq -r '.[0].priv_key' signer-dump.json)
-            cd ../code/pos-contracts
-            CONTRACT_ADDRESS=$(jq -r .root.tokens.MaticToken contractAddresses.json)
-            forge script scripts/matic-cli-scripts/Deposit.s.sol:MaticDeposit --rpc-url http://localhost:9545 --private-key $SCRIPT_PRIVATE_KEY --broadcast --sig "run(address,address,uint256)" $SCRIPT_ADDRESS $CONTRACT_ADDRESS 100000000000000000000
-            cd ../../../..
-            timeout 60m bash bor/integration-tests/smoke_test.sh
+      - name: Launch devnet
+        run: |
+          cd matic-cli/devnet
+          bash ../util-scripts/docker/devnet_setup.sh
+          cd -
+          timeout 2m bash bor/integration-tests/bor_health.sh
 
       - name: Run smoke tests
         run: |

--- a/consensus/bor/api.go
+++ b/consensus/bor/api.go
@@ -47,7 +47,7 @@ func (api *API) GetSnapshot(number *rpc.BlockNumber) (*Snapshot, error) {
 		return nil, errUnknownBlock
 	}
 
-	return api.bor.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	return api.bor.snapshot(api.chain, header, nil, false)
 }
 
 type BlockSigners struct {
@@ -209,7 +209,7 @@ func (api *API) GetSnapshotAtHash(hash common.Hash) (*Snapshot, error) {
 		return nil, errUnknownBlock
 	}
 
-	return api.bor.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	return api.bor.snapshot(api.chain, header, nil, false)
 }
 
 // GetSigners retrieves the list of authorized signers at the specified block.
@@ -226,7 +226,7 @@ func (api *API) GetSigners(number *rpc.BlockNumber) ([]common.Address, error) {
 		return nil, errUnknownBlock
 	}
 
-	snap, err := api.bor.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	snap, err := api.bor.snapshot(api.chain, header, nil, false)
 
 	if err != nil {
 		return nil, err
@@ -242,7 +242,7 @@ func (api *API) GetSignersAtHash(hash common.Hash) ([]common.Address, error) {
 		return nil, errUnknownBlock
 	}
 
-	snap, err := api.bor.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	snap, err := api.bor.snapshot(api.chain, header, nil, false)
 
 	if err != nil {
 		return nil, err

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -45,14 +45,16 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
+	ttlcache "github.com/jellydator/ttlcache/v3"
 )
 
 const (
-	defaultSpanLength  = 6400 // Default span length i.e. number of bor blocks in a span
-	zerothSpanEnd      = 255  // End block of 0th span
-	checkpointInterval = 1024 // Number of blocks after which to save the vote snapshot to the database
-	inmemorySnapshots  = 128  // Number of recent vote snapshots to keep in memory
-	inmemorySignatures = 4096 // Number of recent block signatures to keep in memory
+	defaultSpanLength  = 6400            // Default span length i.e. number of bor blocks in a span
+	zerothSpanEnd      = 255             // End block of 0th span
+	checkpointInterval = 1024            // Number of blocks after which to save the vote snapshot to the database
+	inmemorySnapshots  = 128             // Number of recent vote snapshots to keep in memory
+	inmemorySignatures = 4096            // Number of recent block signatures to keep in memory
+	veblopBlockTimeout = time.Second * 4 // Timeout for new span check. DO NOT CHANGE THIS VALUE.
 )
 
 // Bor protocol constants.
@@ -220,8 +222,9 @@ type Bor struct {
 	config      *params.BorConfig   // Consensus engine configuration parameters for bor consensus
 	db          ethdb.Database      // Database to store and retrieve snapshot checkpoints
 
-	recents    *lru.ARCCache // Snapshots for recent block to speed up reorgs
-	signatures *lru.ARCCache // Signatures of recent blocks to speed up mining
+	recents               *ttlcache.Cache[common.Hash, *Snapshot]     // Snapshots for recent block to speed up reorgs
+	recentVerifiedHeaders *ttlcache.Cache[common.Hash, *types.Header] // Headers for recent blocks to speed up reorgs
+	signatures            *lru.ARCCache                               // Signatures of recent blocks to speed up mining
 
 	authorizedSigner atomic.Pointer[signer] // Ethereum address and sign function of the signing key
 
@@ -231,7 +234,8 @@ type Bor struct {
 	HeimdallClient         IHeimdallClient
 	HeimdallWSClient       IHeimdallWSClient
 
-	spanStore SpanStore // Store to save previous span data from heimdall
+	spanStore            *SpanStore // Store to save previous span data from heimdall
+	latestMilestoneBlock uint64
 
 	// The fields below are for testing only
 	fakeDiff      bool // Skip difficulty verifications
@@ -264,8 +268,19 @@ func New(
 		borConfig.Sprint = defaultSprintLength
 	}
 	// Allocate the snapshot caches and create the engine
-	recents, _ := lru.NewARC(inmemorySnapshots)
+	recents := ttlcache.New[common.Hash, *Snapshot](
+		ttlcache.WithTTL[common.Hash, *Snapshot](veblopBlockTimeout),
+		ttlcache.WithCapacity[common.Hash, *Snapshot](inmemorySnapshots),
+		ttlcache.WithDisableTouchOnHit[common.Hash, *Snapshot](),
+	)
+
 	signatures, _ := lru.NewARC(inmemorySignatures)
+
+	recentVerifiedHeaders := ttlcache.New[common.Hash, *types.Header](
+		ttlcache.WithTTL[common.Hash, *types.Header](veblopBlockTimeout),
+		ttlcache.WithCapacity[common.Hash, *types.Header](inmemorySignatures),
+		ttlcache.WithDisableTouchOnHit[common.Hash, *types.Header](),
+	)
 
 	// Create a new span store
 	spanStore := NewSpanStore(heimdallClient, spanner, chainConfig.ChainID.String())
@@ -276,6 +291,7 @@ func New(
 		db:                     db,
 		ethAPI:                 ethAPI,
 		recents:                recents,
+		recentVerifiedHeaders:  recentVerifiedHeaders,
 		signatures:             signatures,
 		spanner:                spanner,
 		GenesisContractsClient: genesisContracts,
@@ -289,7 +305,7 @@ func New(
 		common.Address{},
 		func(_ accounts.Account, _ string, i []byte) ([]byte, error) {
 			// return an error to prevent panics
-			return nil, &UnauthorizedSignerError{0, common.Address{}.Bytes()}
+			return nil, &UnauthorizedSignerError{0, common.Address{}.Bytes(), []*valset.Validator{}}
 		},
 	})
 
@@ -411,7 +427,13 @@ func (c *Bor) verifyHeader(chain consensus.ChainHeaderReader, header *types.Head
 	}
 
 	// All basic checks passed, verify cascading fields
-	return c.verifyCascadingFields(chain, header, parents)
+	err := c.verifyCascadingFields(chain, header, parents)
+	if err != nil {
+		return err
+	}
+
+	c.recentVerifiedHeaders.Set(header.Hash(), header, ttlcache.DefaultTTL)
+	return nil
 }
 
 // validateHeaderExtraField validates that the extra-data contains both the vanity and signature.
@@ -476,81 +498,13 @@ func (c *Bor) verifyCascadingFields(chain consensus.ChainHeaderReader, header *t
 		return ErrInvalidTimestamp
 	}
 
-	// Retrieve the snapshot needed to verify this header and cache it
-
-	var snap *Snapshot
-
-	// TODO:
-	// Verify validator statelessly
-
-	// snap, err := c.snapshot(chain, number-1, header.ParentHash, parents)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// Verify if the producer set in header's extra data matches with the list in span.
-	// We skip the check for 0th span as the producer set in contract v/s producer set
-	// in heimdall span is different which will lead a mismatch. Moreover, to make the
-	// validation stateless, we use the span from heimdall (via span store) instead of
-	// span from validator set genesis contract as both are supposed to be equivalent.
-	if number > zerothSpanEnd && IsSprintStart(number+1, c.config.CalculateSprint(number)) {
-		span, err := c.spanStore.spanByBlockNumber(context.Background(), number+1)
-		if err != nil {
-			return err
-		}
-
-		// Use producer set from span as it's equivalent to the data we get from genesis contract
-		newValidators := make([]*valset.Validator, len(span.SelectedProducers))
-		for i, val := range span.SelectedProducers {
-			newValidators[i] = &val
-		}
-		sort.Sort(valset.ValidatorsByAddress(newValidators))
-
-		headerVals, err := valset.ParseValidators(header.GetValidatorBytes(c.chainConfig))
-		if err != nil {
-			return err
-		}
-
-		if len(newValidators) != len(headerVals) {
-			log.Warn("Invalid validator set", "block number", number, "newValidators", newValidators, "headerVals", headerVals)
-			return errInvalidSpanValidators
-		}
-
-		for i, val := range newValidators {
-			if !bytes.Equal(val.HeaderBytes(), headerVals[i].HeaderBytes()) {
-				log.Warn("Invalid validator set", "block number", number, "index", i, "local validator", val, "header validator", headerVals[i])
-				return errInvalidSpanValidators
-			}
-		}
-	}
-
-	// verify the validator list in the last sprint block
-	if false && IsSprintStart(number, c.config.CalculateSprint(number)) {
-		parentValidatorBytes := parent.GetValidatorBytes(c.chainConfig)
-		validatorsBytes := make([]byte, len(snap.ValidatorSet.Validators)*validatorHeaderBytesLength)
-
-		currentValidators := snap.ValidatorSet.Copy().Validators
-		// sort validator by address
-		sort.Sort(valset.ValidatorsByAddress(currentValidators))
-
-		for i, validator := range currentValidators {
-			copy(validatorsBytes[i*validatorHeaderBytesLength:], validator.HeaderBytes())
-		}
-		// len(header.Extra) >= extraVanity+extraSeal has already been validated in validateHeaderExtraField, so this won't result in a panic
-		if !bytes.Equal(parentValidatorBytes, validatorsBytes) {
-			return &MismatchingValidatorsError{number - 1, validatorsBytes, parentValidatorBytes}
-		}
-	}
-
 	// All basic checks passed, verify the seal and return
-	// TODO: Verify seal statelessly
-	// return c.verifySeal(chain, header, parents)
-	return nil
+	return c.verifySeal(chain, header, parents)
 }
 
 // snapshot retrieves the authorization snapshot at a given point in time.
 // nolint: gocognit
-func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash common.Hash, parents []*types.Header) (*Snapshot, error) {
+func (c *Bor) snapshot(chain consensus.ChainHeaderReader, targetHeader *types.Header, parents []*types.Header, checkNewSpan bool) (*Snapshot, error) {
 	// Search for a snapshot in memory or on disk for checkpoints
 	signer := common.BytesToAddress(c.authorizedSigner.Load().signer.Bytes())
 	if c.devFakeAuthor && signer.String() != "0x0000000000000000000000000000000000000000" {
@@ -559,7 +513,7 @@ func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash co
 		val := valset.NewValidator(signer, 1000)
 		validatorset := valset.NewValidatorSet([]*valset.Validator{val})
 
-		snapshot := newSnapshot(c.chainConfig, c.signatures, number, hash, validatorset.Validators)
+		snapshot := newSnapshot(c.chainConfig, c.signatures, targetHeader.Number.Uint64(), targetHeader.Hash(), validatorset.Validators)
 
 		return snapshot, nil
 	}
@@ -568,12 +522,14 @@ func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash co
 
 	headers := make([]*types.Header, 0, 16)
 
+	hash := targetHeader.ParentHash
+	number := targetHeader.Number.Uint64() - 1
+
 	//nolint:govet
 	for snap == nil {
 		// If an in-memory snapshot was found, use that
-		if s, ok := c.recents.Get(hash); ok {
-			snap = s.(*Snapshot)
-
+		if v := c.recents.Get(hash); v != nil {
+			snap = v.Value()
 			break
 		}
 
@@ -649,12 +605,19 @@ func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash co
 		headers[i], headers[len(headers)-1-i] = headers[len(headers)-1-i], headers[i]
 	}
 
+	if checkNewSpan && c.config.IsVeBlop(targetHeader.Number) {
+		err := c.performSpanCheck(chain, targetHeader, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	snap, err := snap.apply(headers, c)
 	if err != nil {
 		return nil, err
 	}
 
-	c.recents.Add(snap.Hash, snap)
+	c.recents.Set(snap.Hash, snap, ttlcache.DefaultTTL)
 
 	// If we've generated a new checkpoint snapshot, save to disk
 	if snap.Number%checkpointInterval == 0 && len(headers) > 0 {
@@ -665,7 +628,108 @@ func (c *Bor) snapshot(chain consensus.ChainHeaderReader, number uint64, hash co
 		log.Trace("Stored snapshot to disk", "number", snap.Number, "hash", snap.Hash)
 	}
 
+	if c.config.IsVeBlop(targetHeader.Number) {
+		snap, err = snap.applyNumber(targetHeader.Number.Uint64(), c)
+		if err != nil {
+			return nil, err
+		}
+
+		snap.Number = targetHeader.Number.Uint64()
+		snap.Hash = targetHeader.Hash()
+	}
+
 	return snap, err
+}
+
+// Check if the node needs to wait for a new span
+func (c *Bor) performSpanCheck(chain consensus.ChainHeaderReader, targetHeader *types.Header, checkMilestone bool) error {
+	if targetHeader.Number.Uint64()-1 == 0 {
+		return nil
+	}
+
+	targetHeaderAuthor, missingTargetSignature := c.Author(targetHeader)
+	if missingTargetSignature != nil {
+		return nil
+	}
+
+	parentHeader := chain.GetHeader(targetHeader.ParentHash, targetHeader.Number.Uint64()-1)
+
+	// If parent header isn't known or a milestone check is requested, we need to wait for a new span
+	if parentHeader == nil || checkMilestone {
+		log.Debug("Parent header is nil or checkMilestone is true", "checkMilestone", checkMilestone, "targetHeader", targetHeader.Number.Uint64(), "parentHeaderHash", targetHeader.ParentHash)
+
+		if c.latestMilestoneBlock < targetHeader.Number.Uint64() && c.HeimdallClient != nil {
+			milestone, err := c.HeimdallClient.FetchMilestone(context.Background())
+			if err != nil {
+				log.Warn("Error while fetching milestone", "error", err)
+			}
+
+			c.latestMilestoneBlock = milestone.EndBlock
+
+			// If the milestone is greater than the target header, no need to wait for a new span
+			if c.latestMilestoneBlock >= targetHeader.Number.Uint64() {
+				return nil
+			}
+		} else {
+			return nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), veblopBlockTimeout*2)
+		defer cancel()
+
+		log.Info("Waiting for new span", "target block", targetHeader.Number.Uint64(), "targetHeaderAuthor", targetHeaderAuthor, "checkMilestone", checkMilestone)
+		_, err := c.spanStore.waitForNewSpan(ctx, targetHeader.Number.Uint64(), targetHeaderAuthor)
+		if err != nil {
+			log.Warn("Error while waiting for new span", "error", err)
+			return err
+		}
+
+		return nil
+	}
+
+	parentHeaderAuthor, missingParentSignature := c.Author(parentHeader)
+	if missingParentSignature != nil {
+		return missingParentSignature
+	}
+
+	if !c.recentVerifiedHeaders.Has(targetHeader.ParentHash) && targetHeaderAuthor == parentHeaderAuthor {
+		log.Info("Starting span check due to longer than expected block time", "target block", targetHeader.Number.Uint64(), "parentHeader", targetHeader.ParentHash, "parentHeaderAuthor", parentHeaderAuthor, "targetHeaderAuthor", targetHeaderAuthor)
+
+		// Keep getting the latest span until we get a new span or a new milestone
+		ctx, cancel := context.WithTimeout(context.Background(), veblopBlockTimeout*2)
+		defer cancel()
+
+		foundNewSpan, err := c.spanStore.waitForNewSpan(ctx, targetHeader.Number.Uint64(), targetHeaderAuthor)
+		if err != nil {
+			log.Warn("Error while waiting for new span", "error", err)
+			return err
+		}
+
+		log.Info("Span check complete", "foundNewSpan", foundNewSpan)
+
+		if !foundNewSpan {
+			return c.performSpanCheck(chain, targetHeader, true)
+		}
+
+		return nil
+	} else if missingTargetSignature == nil && targetHeaderAuthor != parentHeaderAuthor {
+		log.Info("Updating latest span due to different author", "target block", targetHeader.Number.Uint64(), "parentHeader", targetHeader.ParentHash, "parentHeaderAuthor", parentHeaderAuthor, "targetHeaderAuthor", targetHeaderAuthor)
+
+		// We don't want to wait for a new span forever if the target header author is different from the parent header author, because it would lead to a deadlock if the header is signed by a malicious producer who is not in the validator set.
+		ctx, cancel := context.WithTimeout(context.Background(), veblopBlockTimeout)
+		defer cancel()
+		foundNewSpan, err := c.spanStore.waitForNewSpan(ctx, targetHeader.Number.Uint64(), parentHeaderAuthor)
+		if err != nil {
+			log.Warn("Error while waiting for new span", "error", err)
+			return err
+		}
+
+		log.Info("Span check complete", "foundNewSpan", foundNewSpan)
+
+		return nil
+	}
+
+	return nil
 }
 
 // VerifyUncles implements consensus.Engine, always returning an error for any
@@ -695,7 +759,7 @@ func (c *Bor) verifySeal(chain consensus.ChainHeaderReader, header *types.Header
 		return errUnknownBlock
 	}
 	// Retrieve the snapshot needed to verify this header and cache it
-	snap, err := c.snapshot(chain, number-1, header.ParentHash, parents)
+	snap, err := c.snapshot(chain, header, parents, true)
 	if err != nil {
 		return err
 	}
@@ -708,7 +772,7 @@ func (c *Bor) verifySeal(chain consensus.ChainHeaderReader, header *types.Header
 
 	if !snap.ValidatorSet.HasAddress(signer) {
 		// Check the UnauthorizedSignerError.Error() msg to see why we pass number-1
-		return &UnauthorizedSignerError{number - 1, signer.Bytes()}
+		return &UnauthorizedSignerError{number, signer.Bytes(), snap.ValidatorSet.Validators}
 	}
 
 	succession, err := snap.GetSignerSuccessionNumber(signer)
@@ -751,7 +815,7 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header) e
 
 	number := header.Number.Uint64()
 	// Assemble the validator snapshot to check which votes make sense
-	snap, err := c.snapshot(chain, number-1, header.ParentHash, nil)
+	snap, err := c.snapshot(chain, header, nil, true)
 	if err != nil {
 		return err
 	}
@@ -769,10 +833,15 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header) e
 	header.Extra = header.Extra[:types.ExtraVanityLength]
 
 	// get validator set if number
-	if IsSprintStart(number+1, c.config.CalculateSprint(number)) {
-		newValidators, err := c.spanner.GetCurrentValidatorsByHash(context.Background(), header.ParentHash, number+1)
+	if IsSprintStart(number+1, c.config.CalculateSprint(number)) && !c.config.IsVeBlop(header.Number) {
+		span, err := c.spanStore.spanByBlockNumber(context.Background(), number+1)
 		if err != nil {
-			return errUnknownValidators
+			return err
+		}
+
+		newValidators := make([]*valset.Validator, len(span.SelectedProducers))
+		for i, val := range span.SelectedProducers {
+			newValidators[i] = &val
 		}
 
 		// sort validator by address
@@ -870,9 +939,11 @@ func (c *Bor) Finalize(chain consensus.ChainHeaderReader, header *types.Header, 
 		start := time.Now()
 		cx := statefull.ChainContext{Chain: chain, Bor: c}
 		// check and commit span
-		if err := c.checkAndCommitSpan(state, header, cx); err != nil {
-			log.Error("Error while committing span", "error", err)
-			return
+		if !c.config.IsVeBlop(header.Number) {
+			if err := c.checkAndCommitSpan(state, header, cx); err != nil {
+				log.Error("Error while committing span", "error", err)
+				return
+			}
 		}
 
 		if c.HeimdallClient != nil {
@@ -955,9 +1026,11 @@ func (c *Bor) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *typ
 		cx := statefull.ChainContext{Chain: chain, Bor: c}
 
 		// check and commit span
-		if err = c.checkAndCommitSpan(state, header, cx); err != nil {
-			log.Error("Error while committing span", "error", err)
-			return nil, err
+		if !c.config.IsVeBlop(header.Number) {
+			if err = c.checkAndCommitSpan(state, header, cx); err != nil {
+				log.Error("Error while committing span", "error", err)
+				return nil, err
+			}
 		}
 
 		if c.HeimdallClient != nil {
@@ -1019,7 +1092,7 @@ func (c *Bor) Seal(chain consensus.ChainHeaderReader, block *types.Block, witnes
 	// Don't hold the signer fields for the entire sealing procedure
 	currentSigner := *c.authorizedSigner.Load()
 
-	snap, err := c.snapshot(chain, number-1, header.ParentHash, nil)
+	snap, err := c.snapshot(chain, header, nil, true)
 	if err != nil {
 		return err
 	}
@@ -1027,7 +1100,7 @@ func (c *Bor) Seal(chain consensus.ChainHeaderReader, block *types.Block, witnes
 	// Bail out if we're unauthorized to sign a block
 	if !snap.ValidatorSet.HasAddress(currentSigner.signer) {
 		// Check the UnauthorizedSignerError.Error() msg to see why we pass number-1
-		return &UnauthorizedSignerError{number - 1, currentSigner.signer.Bytes()}
+		return &UnauthorizedSignerError{number, currentSigner.signer.Bytes(), snap.ValidatorSet.Validators}
 	}
 
 	successionNumber, err := snap.GetSignerSuccessionNumber(currentSigner.signer)
@@ -1098,7 +1171,7 @@ func Sign(signFn SignerFn, signer common.Address, header *types.Header, c *param
 // that a new block should have based on the previous blocks in the chain and the
 // current signer.
 func (c *Bor) CalcDifficulty(chain consensus.ChainHeaderReader, _ uint64, parent *types.Header) *big.Int {
-	snap, err := c.snapshot(chain, parent.Number.Uint64(), parent.Hash(), nil)
+	snap, err := c.snapshot(chain, parent, nil, true)
 	if err != nil {
 		return nil
 	}
@@ -1127,6 +1200,10 @@ func (c *Bor) Close() error {
 	c.closeOnce.Do(func() {
 		if c.HeimdallClient != nil {
 			c.HeimdallClient.Close()
+		}
+
+		if c.spanStore != nil {
+			c.spanStore.Close()
 		}
 	})
 
@@ -1406,7 +1483,7 @@ func (c *Bor) getNextHeimdallSpanForTest(
 	// get local chain context object
 	localContext := chain.(statefull.ChainContext)
 	// Retrieve the snapshot needed to verify this header and cache it
-	snap, err := c.snapshot(localContext.Chain, headerNumber-1, header.ParentHash, nil)
+	snap, err := c.snapshot(localContext.Chain, header, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/bor/errors.go
+++ b/consensus/bor/errors.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/consensus/bor/clerk"
+	"github.com/ethereum/go-ethereum/consensus/bor/valset"
 )
 
 type MaxCheckpointLengthExceededError struct {
@@ -67,15 +68,17 @@ func (e *UnauthorizedProposerError) Error() string {
 
 // UnauthorizedSignerError is returned if a header is [being] signed by an unauthorized entity.
 type UnauthorizedSignerError struct {
-	Number uint64
-	Signer []byte
+	Number         uint64
+	Signer         []byte
+	AllowedSigners []*valset.Validator
 }
 
 func (e *UnauthorizedSignerError) Error() string {
 	return fmt.Sprintf(
-		"Signer 0x%x is not a part of the producer set at block %d",
+		"Signer 0x%x is not a part of the producer set at block %d. Allowed signers: %v",
 		e.Signer,
 		e.Number,
+		e.AllowedSigners,
 	)
 }
 

--- a/consensus/bor/heimdall.go
+++ b/consensus/bor/heimdall.go
@@ -14,6 +14,7 @@ import (
 type IHeimdallClient interface {
 	StateSyncEvents(ctx context.Context, fromID uint64, to int64) ([]*clerk.EventRecordWithTime, error)
 	GetSpan(ctx context.Context, spanID uint64) (*types.Span, error)
+	GetLatestSpan(ctx context.Context) (*types.Span, error)
 	FetchCheckpoint(ctx context.Context, number int64) (*checkpoint.Checkpoint, error)
 	FetchCheckpointCount(ctx context.Context) (int64, error)
 	FetchMilestone(ctx context.Context) (*milestone.Milestone, error)

--- a/consensus/bor/heimdall/client_test.go
+++ b/consensus/bor/heimdall/client_test.go
@@ -48,7 +48,7 @@ func CreateMockHeimdallServer(wg *sync.WaitGroup, port int, listener net.Listene
 	})
 
 	// Create a route for fetching milestone
-	mux.HandleFunc("/milestone/latest", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/milestones/latest", func(w http.ResponseWriter, r *http.Request) {
 		handler.GetMilestoneHandler()(w, r)
 	})
 
@@ -377,7 +377,7 @@ func TestSpanURL(t *testing.T) {
 		t.Fatal("got an error", err)
 	}
 
-	const expected = "http://bor0/bor/span/1"
+	const expected = "http://bor0/bor/spans/1"
 
 	if url.String() != expected {
 		t.Fatalf("expected URL %q, got %q", expected, url.String())

--- a/consensus/bor/heimdall/metrics.go
+++ b/consensus/bor/heimdall/metrics.go
@@ -20,6 +20,7 @@ type (
 const (
 	StateSyncRequest       requestType = "state-sync"
 	SpanRequest            requestType = "span"
+	LatestSpanRequest      requestType = "latest-span"
 	CheckpointRequest      requestType = "checkpoint"
 	CheckpointCountRequest requestType = "checkpoint-count"
 	MilestoneRequest       requestType = "milestone"

--- a/consensus/bor/heimdallgrpc/span.go
+++ b/consensus/bor/heimdallgrpc/span.go
@@ -40,3 +40,29 @@ func (h *HeimdallGRPCClient) GetSpan(ctx context.Context, spanID uint64) (*types
 
 	return resSpan, nil
 }
+
+func (h *HeimdallGRPCClient) GetLatestSpan(ctx context.Context) (*types.Span, error) {
+	log.Info("Fetching latest span")
+
+	var err error
+
+	// Start the timer and set the request type on the context.
+	start := time.Now()
+	ctx = heimdall.WithRequestType(ctx, heimdall.LatestSpanRequest)
+
+	// Defer the metrics call.
+	defer func() {
+		heimdall.SendMetrics(ctx, start, err == nil)
+	}()
+
+	res, err := h.borQueryClient.GetLatestSpan(ctx, &types.QueryLatestSpanRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	resSpan := res.GetSpan()
+
+	log.Info("Fetched latest span")
+
+	return &resSpan, nil
+}

--- a/consensus/bor/span_store.go
+++ b/consensus/bor/span_store.go
@@ -3,6 +3,8 @@ package bor
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/bor/heimdall/span"
@@ -22,22 +24,105 @@ const maxSpanFetchLimit = 10_000
 type SpanStore struct {
 	store *lru.ARCCache
 
+	latestSpanCache atomic.Pointer[span.HeimdallSpan]
+
 	heimdallClient IHeimdallClient
 	spanner        Spanner
 
-	latestKnownSpanId uint64
-	chainId           string
+	chainId      string
+	lastUsedSpan atomic.Pointer[span.HeimdallSpan]
+
+	// cancel function to stop the background routine
+	cancel context.CancelFunc
 }
 
-func NewSpanStore(heimdallClient IHeimdallClient, spanner Spanner, chainId string) SpanStore {
+func NewSpanStore(heimdallClient IHeimdallClient, spanner Spanner, chainId string) *SpanStore {
 	cache, _ := lru.NewARC(10)
-	return SpanStore{
-		store:             cache,
-		heimdallClient:    heimdallClient,
-		spanner:           spanner,
-		latestKnownSpanId: 0,
-		chainId:           chainId,
+	store := SpanStore{
+		store:           cache,
+		heimdallClient:  heimdallClient,
+		spanner:         spanner,
+		chainId:         chainId,
+		latestSpanCache: atomic.Pointer[span.HeimdallSpan]{},
+		lastUsedSpan:    atomic.Pointer[span.HeimdallSpan]{},
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	store.cancel = cancel
+
+	if heimdallClient != nil {
+		go func() {
+			for {
+				err := store.updateLatestSpan(ctx)
+				if err != nil {
+					log.Error("Failed to update latest span", "err", err)
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(200 * time.Millisecond):
+				}
+			}
+		}()
+	}
+
+	return &store
+}
+
+func (s *SpanStore) getLatestSpan(ctx context.Context) (*span.HeimdallSpan, error) {
+	if s.latestSpanCache.Load() != nil {
+		return s.latestSpanCache.Load(), nil
+	}
+
+	err := s.updateLatestSpan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.latestSpanCache.Load(), nil
+}
+
+func (s *SpanStore) updateLatestSpan(ctx context.Context) error {
+	if s.heimdallClient == nil {
+		return nil
+	}
+
+	latestSpan, err := s.heimdallClient.GetLatestSpan(ctx)
+	if err != nil {
+		return err
+	}
+
+	validators := make([]*valset.Validator, len(latestSpan.ValidatorSet.Validators))
+	for i, v := range latestSpan.ValidatorSet.Validators {
+		validators[i] = &valset.Validator{
+			ID:               v.ValId,
+			Address:          common.HexToAddress(v.Signer),
+			VotingPower:      v.VotingPower,
+			ProposerPriority: v.ProposerPriority,
+		}
+	}
+
+	selectedProducers := make([]valset.Validator, len(latestSpan.SelectedProducers))
+	for i, v := range latestSpan.SelectedProducers {
+		selectedProducers[i] = valset.Validator{
+			ID:               v.ValId,
+			Address:          common.HexToAddress(v.Signer),
+			VotingPower:      v.VotingPower,
+			ProposerPriority: v.ProposerPriority,
+		}
+	}
+
+	s.latestSpanCache.Store(&span.HeimdallSpan{
+		Span: span.Span{
+			ID:         latestSpan.Id,
+			StartBlock: latestSpan.StartBlock,
+			EndBlock:   latestSpan.EndBlock,
+		},
+		SelectedProducers: selectedProducers,
+		ValidatorSet:      *valset.NewValidatorSet(validators),
+		ChainID:           s.chainId,
+	})
+	return nil
 }
 
 // spanById returns a span given its id. It fetches span from heimdall if not found in cache.
@@ -98,9 +183,6 @@ func (s *SpanStore) spanById(ctx context.Context, spanId uint64) (*span.Heimdall
 			}
 		}
 		s.store.Add(spanId, currentSpan)
-		if currentSpan.Span.ID > s.latestKnownSpanId {
-			s.latestKnownSpanId = currentSpan.ID
-		}
 	}
 
 	return currentSpan, nil
@@ -110,60 +192,117 @@ func (s *SpanStore) spanById(ctx context.Context, spanId uint64) (*span.Heimdall
 // assumes that a span has been committed before (i.e. is current or past span) and returns an error if
 // asked for a future span. This is safe to assume as we don't have a way to find out span id for a future block
 // unless we hardcode the span length (which we don't want to).
-func (s *SpanStore) spanByBlockNumber(ctx context.Context, blockNumber uint64) (*span.HeimdallSpan, error) {
+// With overlapping spans support, this function ensures we return the span with the largest span ID that contains the block.
+func (s *SpanStore) spanByBlockNumber(ctx context.Context, blockNumber uint64) (res *span.HeimdallSpan, err error) {
 	// As we don't persist latest known span to db, we loose the value on restarts. This leads to multiple heimdall calls
 	// which can be avoided. Hence we estimate the span id from block number which updates the latest known span id. Note
 	// that we still check if the block number lies in the range of span before returning it.
-	estimatedSpanId := estimateSpanId(blockNumber)
-	// Ignore the return value of this span as we validate it later in the loop
-	_, err := s.spanById(ctx, estimatedSpanId)
-	if err != nil {
-		return nil, err
-	}
-	// Iterate over all spans and check for number. This is to replicate the behaviour implemented in
-	// https://github.com/maticnetwork/genesis-contracts/blob/master/contracts/BorValidatorSet.template#L118-L134
-	// This logic is independent of the span length (bit extra effort but maintains equivalence) and will work
-	// for all span lengths (even if we change it in future).
-	latestKnownSpanId := s.latestKnownSpanId
-	for id := int(latestKnownSpanId); id >= 0; id-- {
+	estimatedSpanId := s.estimateSpanId(blockNumber)
+	defer func() {
+		if res != nil && err == nil {
+			s.lastUsedSpan.Store(res)
+		}
+	}()
+
+	// Search backwards from the highest known span ID to find the latest span containing the block
+	// Since we iterate from high to low, the first match will be the span with the largest ID among known spans
+	for id := int(estimatedSpanId); id >= 0; id-- {
 		span, err := s.spanById(ctx, uint64(id))
 		if err != nil {
 			return nil, err
 		}
 		if blockNumber >= span.StartBlock && blockNumber <= span.EndBlock {
-			return span, nil
+			// Found a span that contains the block number in known spans
+			res = span
+			break
 		}
-		// Check if block number given is out of bounds
-		if id == int(latestKnownSpanId) && blockNumber > span.EndBlock {
-			return getFutureSpan(ctx, uint64(id)+1, blockNumber, latestKnownSpanId, s)
+		// Check if block number given is out of bounds (future block) for the latest known span
+		if id == int(estimatedSpanId) && blockNumber > span.EndBlock {
+			// Block is in the future, search future spans
+			return s.getFutureSpan(ctx, uint64(id)+1, blockNumber, estimatedSpanId)
 		}
+	}
+
+	// If we found a candidate in known spans, we still need to check if there are newer spans in future
+	// that also contain this block number due to overlapping spans
+	if res != nil {
+		futureSpan, err := s.getFutureSpan(ctx, estimatedSpanId+1, blockNumber, estimatedSpanId)
+		if err == nil && futureSpan != nil {
+			// Found a future span that also contains the block, return the newer one
+			return futureSpan, nil
+		}
+		// No future span found or error occurred, return the candidate from known spans
+		return res, nil
 	}
 
 	return nil, fmt.Errorf("span not found for block %d", blockNumber)
 }
 
 // getFutureSpan fetches span for future block number. It is mostly needed during snap sync.
-func getFutureSpan(ctx context.Context, id uint64, blockNumber uint64, latestKnownSpanId uint64, s *SpanStore) (*span.HeimdallSpan, error) {
+func (s *SpanStore) getFutureSpan(ctx context.Context, id uint64, blockNumber uint64, latestKnownSpanId uint64) (*span.HeimdallSpan, error) {
+	latestSpan, err := s.getLatestSpan(ctx)
+	if err != nil || latestSpan == nil {
+		return nil, err
+	}
+
+	var candidateSpan *span.HeimdallSpan
+	skippedSpans := 0
 	for {
-		if id > latestKnownSpanId+maxSpanFetchLimit {
-			return nil, fmt.Errorf("span not found for block %d", blockNumber)
+		if id > latestSpan.ID {
+			if candidateSpan == nil {
+				return nil, fmt.Errorf("span not found for block %d", blockNumber)
+			}
+			return candidateSpan, nil
 		}
 		span, err := s.spanById(ctx, id)
 		if err != nil {
-			return nil, err
+			if candidateSpan == nil {
+				return nil, err
+			}
+			return candidateSpan, nil
 		}
 		if blockNumber >= span.StartBlock && blockNumber <= span.EndBlock {
-			return span, nil
+			candidateSpan = span
+			skippedSpans = 0
+		}
+		if blockNumber < span.StartBlock {
+			skippedSpans++
+			if skippedSpans > 1 {
+				if candidateSpan == nil {
+					return nil, fmt.Errorf("span not found for block %d", blockNumber)
+				}
+				return candidateSpan, nil
+			}
 		}
 		id++
 	}
 }
 
 // estimateSpanId returns the corresponding span id for the given block number in a deterministic way.
-func estimateSpanId(blockNumber uint64) uint64 {
-	if blockNumber > zerothSpanEnd {
+func (s *SpanStore) estimateSpanId(blockNumber uint64) uint64 {
+	if blockNumber > zerothSpanEnd && blockNumber > 0 {
+		if s.lastUsedSpan.Load() != nil {
+			lastUsedSpan := s.lastUsedSpan.Load()
+			startBlock := lastUsedSpan.Span.StartBlock
+			endBlock := lastUsedSpan.Span.EndBlock
+			if blockNumber > endBlock {
+				return lastUsedSpan.Span.ID + 1 + (blockNumber-endBlock)/defaultSpanLength
+			} else if blockNumber < startBlock {
+				// Calculate how many spans to go back. (startBlock - blockNumber + defaultSpanLength - 1) / defaultSpanLength is ceil((startBlock - blockNumber)/defaultSpanLength)
+				spansToDecrement := (startBlock - blockNumber + defaultSpanLength - 1) / defaultSpanLength
+				if lastUsedSpan.Span.ID >= spansToDecrement { // Prevent underflow for uint64
+					return lastUsedSpan.Span.ID - spansToDecrement
+				} else {
+
+					return 1 + (blockNumber-zerothSpanEnd-1)/defaultSpanLength
+				}
+			} else {
+				return lastUsedSpan.Span.ID
+			}
+		}
 		return 1 + (blockNumber-zerothSpanEnd-1)/defaultSpanLength
 	}
+
 	return 0
 }
 
@@ -185,13 +324,16 @@ func getMockSpan0(ctx context.Context, spanner Spanner, chainId string) (*span.H
 	if err != nil {
 		return nil, err
 	}
+	if len(vals) == 0 {
+		return nil, fmt.Errorf("no validators found for genesis, cannot create mock span 0")
+	}
 	validatorSet := valset.ValidatorSet{
 		Validators: vals,
 		Proposer:   vals[0],
 	}
 	selectedProducers := make([]valset.Validator, len(vals))
-	for _, v := range vals {
-		selectedProducers = append(selectedProducers, *v)
+	for i, v := range vals {
+		selectedProducers[i] = *v
 	}
 	return &span.HeimdallSpan{
 		Span: span.Span{
@@ -203,4 +345,40 @@ func getMockSpan0(ctx context.Context, spanner Spanner, chainId string) (*span.H
 		SelectedProducers: selectedProducers,
 		ChainID:           chainId,
 	}, nil
+}
+
+// Close cancels the background routine and cleans up resources
+func (s *SpanStore) Close() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+// Wait for a new span whose selected producers are different from the current header author
+func (s *SpanStore) waitForNewSpan(ctx context.Context, targetBlockNumber uint64, currentHeaderAuthor common.Address) (bool, error) {
+	delay := 200 * time.Millisecond
+
+	currentSpan, err := s.spanByBlockNumber(ctx, targetBlockNumber)
+	if err != nil {
+		return false, err
+	}
+
+	for {
+		if currentSpan.Span.StartBlock <= targetBlockNumber && currentSpan.Span.EndBlock >= targetBlockNumber {
+			if len(currentSpan.SelectedProducers) > 0 && currentSpan.SelectedProducers[0].Address != currentHeaderAuthor {
+				return true, nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return false, nil
+		case <-time.After(delay):
+			// Only update span after delay if we need to keep waiting
+			currentSpan, err = s.spanByBlockNumber(ctx, targetBlockNumber)
+			if err != nil {
+				return false, err
+			}
+		}
+	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -663,7 +663,7 @@ func (s *Ethereum) startMilestoneWhitelistService() {
 		s.subscribeAndHandleMilestone(context.Background(), ethHandler, bor)
 	} else {
 		const (
-			tickerDuration = 30000 * time.Millisecond
+			tickerDuration = 500 * time.Millisecond
 			fnName         = "whitelist milestone"
 		)
 

--- a/eth/handler_bor_test.go
+++ b/eth/handler_bor_test.go
@@ -28,6 +28,7 @@ type mockHeimdall struct {
 	fetchCheckpointCount func(ctx context.Context) (int64, error)
 	fetchMilestone       func(ctx context.Context) (*milestone.Milestone, error)
 	fetchMilestoneCount  func(ctx context.Context) (int64, error)
+	getLatestSpan        func(ctx context.Context) (*heimdalltypes.Span, error)
 }
 
 func (m *mockHeimdall) StateSyncEvents(ctx context.Context, fromID uint64, to int64) ([]*clerk.EventRecordWithTime, error) {
@@ -50,7 +51,9 @@ func (m *mockHeimdall) FetchMilestone(ctx context.Context) (*milestone.Milestone
 func (m *mockHeimdall) FetchMilestoneCount(ctx context.Context) (int64, error) {
 	return m.fetchMilestoneCount(ctx)
 }
-
+func (m *mockHeimdall) GetLatestSpan(ctx context.Context) (*heimdalltypes.Span, error) {
+	return m.getLatestSpan(ctx)
+}
 func (m *mockHeimdall) Close() {}
 
 func TestFetchWhitelistCheckpointAndMilestone(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -273,6 +273,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/improbable-eng/grpc-web v0.15.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jellydator/ttlcache/v3 v3.3.0 // indirect
 	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/kilic/bls12-381 v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -743,6 +743,8 @@ github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7Bd
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267 h1:TMtDYDHKYY15rFihtRfck/bfFqNfvcabqvXAFQfAUpY=
 github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267/go.mod h1:h1nSAbGFqGVzn6Jyl1R/iCcBUHN4g+gW1u9CoBTrb9E=
+github.com/jellydator/ttlcache/v3 v3.3.0 h1:BdoC9cE81qXfrxeb9eoJi9dWrdhSuwXMAnHTbnBm4Wc=
+github.com/jellydator/ttlcache/v3 v3.3.0/go.mod h1:bj2/e0l4jRnQdrnSTaGTsh4GSXvMjQcy41i7th0GVGw=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -692,7 +692,7 @@ func DefaultConfig() *Config {
 			GasCeil:             30_000_000,                                 // geth's default
 			GasPrice:            big.NewInt(params.BorDefaultMinerGasPrice), // bor's default
 			ExtraData:           "",
-			Recommit:            125 * time.Second,
+			Recommit:            1 * time.Second,
 			CommitInterruptFlag: true,
 		},
 		Gpo: &GpoConfig{

--- a/internal/cli/server/testdata/default.toml
+++ b/internal/cli/server/testdata/default.toml
@@ -75,7 +75,7 @@ devfakeauthor = false
   extradata = ""
   gaslimit = 30000000
   gasprice = "25000000000"
-  recommit = "2m5s"
+  recommit = "1s"
   commitinterrupt = true
 
 [jsonrpc]

--- a/miner/fake_miner.go
+++ b/miner/fake_miner.go
@@ -64,6 +64,7 @@ func NewBorDefaultMiner(t *testing.T) *DefaultBorMiner {
 	heimdallClient := mocks.NewMockIHeimdallClient(ctrl)
 	heimdallWSClient := mocks.NewMockIHeimdallWSClient(ctrl)
 	heimdallClient.EXPECT().GetSpan(gomock.Any(), uint64(0)).Return(&span0, nil).AnyTimes()
+	heimdallClient.EXPECT().GetLatestSpan(gomock.Any()).Return(&span0, nil).AnyTimes()
 	heimdallClient.EXPECT().Close().Times(1)
 
 	genesisContracts := bor.NewMockGenesisContract(ctrl)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -538,11 +538,14 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 			// If sealing is running resubmit a new work cycle periodically to pull in
 			// higher priced transactions. Disable this overhead for pending blocks.
 			if w.IsRunning() && (w.chainConfig.Clique == nil || w.chainConfig.Clique.Period > 0) {
+				// TODO: In veblop, short circuit prevents the non-producers from producing blocks when
+				// the primary producer is down. Figure out a way to keep short circuiting but allow the non-producers to produce blocks.
+
 				// Short circuit if no new transaction arrives.
-				if w.newTxs.Load() == 0 {
-					timer.Reset(recommit)
-					continue
-				}
+				// if w.newTxs.Load() == 0 {
+				// 	timer.Reset(recommit)
+				// 	continue
+				// }
 				commit(true, commitInterruptResubmit)
 			}
 

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -17,6 +17,7 @@
 package miner
 
 import (
+	"errors"
 	"math/big"
 	"os"
 	"sync/atomic"
@@ -72,6 +73,7 @@ func testGenerateBlockAndImport(t *testing.T, isClique bool, isBor bool) {
 		chainConfig = *params.BorUnittestChainConfig
 
 		engine, ctrl = getFakeBorFromConfig(t, &chainConfig)
+		defer engine.Close()
 		defer ctrl.Finish()
 	} else {
 		if isClique {
@@ -401,6 +403,8 @@ func getFakeBorFromConfig(t *testing.T, chainConfig *params.ChainConfig) (consen
 	heimdallWSClient := mocks.NewMockIHeimdallWSClient(ctrl)
 
 	heimdallClientMock.EXPECT().GetSpan(gomock.Any(), uint64(0)).Return(&span0, nil).AnyTimes()
+	heimdallClientMock.EXPECT().GetSpan(gomock.Any(), uint64(1)).Return(nil, errors.New("span not found")).AnyTimes()
+	heimdallClientMock.EXPECT().GetLatestSpan(gomock.Any()).Return(&span0, nil).AnyTimes()
 	heimdallClientMock.EXPECT().Close().AnyTimes()
 
 	contractMock := bor.NewMockGenesisContract(ctrl)
@@ -755,6 +759,7 @@ func testCommitInterruptExperimentBorContract(t *testing.T, delay uint, txCount 
 	log.SetDefault(log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelInfo, true)))
 
 	engine, _ = getFakeBorFromConfig(t, chainConfig)
+	defer engine.Close()
 
 	w, b, _ := newTestWorker(t, chainConfig, engine, rawdb.NewMemoryDatabase(), true, delay, opcodeDelay)
 	defer w.close()
@@ -808,6 +813,7 @@ func testCommitInterruptExperimentBor(t *testing.T, delay uint, txCount int, opc
 	log.SetDefault(log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelInfo, true)))
 
 	engine, ctrl = getFakeBorFromConfig(t, chainConfig)
+	defer engine.Close()
 
 	w, b, _ := newTestWorker(t, chainConfig, engine, rawdb.NewMemoryDatabase(), true, delay, opcodeDelay)
 	defer func() {
@@ -858,6 +864,7 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 	log.SetDefault(log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelInfo, true)))
 
 	engine, ctrl = getFakeBorFromConfig(t, chainConfig)
+	defer engine.Close()
 
 	w, b, _ := newTestWorker(t, chainConfig, engine, rawdb.NewMemoryDatabase(), true, uint(0), uint(0))
 	defer func() {
@@ -959,6 +966,7 @@ func BenchmarkBorMining(b *testing.B) {
 	heimdallClientMock := mocks.NewMockIHeimdallClient(ctrl)
 	heimdallWSClient := mocks.NewMockIHeimdallWSClient(ctrl)
 	heimdallClientMock.EXPECT().GetSpan(gomock.Any(), uint64(0)).Return(&span0, nil).AnyTimes()
+	heimdallClientMock.EXPECT().GetLatestSpan(gomock.Any()).Return(&span0, nil).AnyTimes()
 
 	heimdallClientMock.EXPECT().Close().Times(1)
 
@@ -1061,6 +1069,7 @@ func BenchmarkBorMiningBlockSTMMetadata(b *testing.B) {
 	heimdallClientMock := mocks.NewMockIHeimdallClient(ctrl)
 	heimdallWSClient := mocks.NewMockIHeimdallWSClient(ctrl)
 	heimdallClientMock.EXPECT().GetSpan(gomock.Any(), uint64(0)).Return(&span0, nil).AnyTimes()
+	heimdallClientMock.EXPECT().GetLatestSpan(gomock.Any()).Return(&span0, nil).AnyTimes()
 	heimdallClientMock.EXPECT().Close().Times(1)
 
 	contractMock := bor.NewMockGenesisContract(ctrl)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -405,6 +405,7 @@ func getFakeBorFromConfig(t *testing.T, chainConfig *params.ChainConfig) (consen
 	heimdallClientMock.EXPECT().GetSpan(gomock.Any(), uint64(0)).Return(&span0, nil).AnyTimes()
 	heimdallClientMock.EXPECT().GetSpan(gomock.Any(), uint64(1)).Return(nil, errors.New("span not found")).AnyTimes()
 	heimdallClientMock.EXPECT().GetLatestSpan(gomock.Any()).Return(&span0, nil).AnyTimes()
+	heimdallClientMock.EXPECT().FetchMilestone(gomock.Any()).Return(nil, nil).AnyTimes()
 	heimdallClientMock.EXPECT().Close().AnyTimes()
 
 	contractMock := bor.NewMockGenesisContract(ctrl)

--- a/params/config.go
+++ b/params/config.go
@@ -713,6 +713,7 @@ type BorConfig struct {
 	IndoreBlock                *big.Int               `json:"indoreBlock"`                // Indore switch block (nil = no fork, 0 = already on indore)
 	StateSyncConfirmationDelay map[string]uint64      `json:"stateSyncConfirmationDelay"` // StateSync Confirmation Delay, in seconds, to calculate `to`
 	AhmedabadBlock             *big.Int               `json:"ahmedabadBlock"`             // Ahmedabad switch block (nil = no fork, 0 = already on ahmedabad)
+	VeBlopBlock                *big.Int               `json:"veblopBlock"`                // VeBlop switch block (nil = no fork, 0 = already on veblop)
 }
 
 // String implements the stringer interface, returning the consensus engine details.
@@ -754,6 +755,10 @@ func (c *BorConfig) CalculateStateSyncDelay(number uint64) uint64 {
 
 func (c *BorConfig) IsAhmedabad(number *big.Int) bool {
 	return isBlockForked(c.AhmedabadBlock, number)
+}
+
+func (c *BorConfig) IsVeBlop(number *big.Int) bool {
+	return isBlockForked(c.VeBlopBlock, number)
 }
 
 // // TODO: modify this function once the block number is finalized

--- a/tests/bor/bor_test.go
+++ b/tests/bor/bor_test.go
@@ -379,7 +379,7 @@ func TestInsertingSpanSizeBlocks(t *testing.T) {
 	defer _bor.Close()
 
 	span0 := createMockSpan(addr, chain.Config().ChainID.String())
-	_, currentSpan := loadSpanFromFile(t)
+	currentSpan := loadSpanFromFile(t)
 
 	// Create mock heimdall client
 	ctrl := gomock.NewController(t)
@@ -440,7 +440,7 @@ func TestFetchStateSyncEvents(t *testing.T) {
 	currentValidators := span0.ValidatorSet.Validators
 
 	// Load mock span 0
-	res, _ := loadSpanFromFile(t)
+	res := loadSpanFromFile(t)
 
 	// reate mock bor spanner
 	spanner := getMockedSpanner(t, currentValidators)
@@ -506,7 +506,7 @@ func TestFetchStateSyncEvents_2(t *testing.T) {
 	span0 := createMockSpan(addr, chain.Config().ChainID.String())
 
 	// Load mock span 1
-	res, _ := loadSpanFromFile(t)
+	res := loadSpanFromFile(t)
 
 	spanner := getMockedSpanner(t, span0.ValidatorSet.Validators)
 	_bor.SetSpanner(spanner)
@@ -601,7 +601,7 @@ func TestOutOfTurnSigning(t *testing.T) {
 
 	span0 := createMockSpan(addr, chain.Config().ChainID.String())
 
-	_, heimdallSpan := loadSpanFromFile(t)
+	heimdallSpan := loadSpanFromFile(t)
 	proposer := valset.NewValidator(addr, 10)
 	heimdallSpan.ValidatorSet.Validators = append(heimdallSpan.ValidatorSet.Validators, proposer)
 
@@ -703,7 +703,7 @@ func TestSignerNotFound(t *testing.T) {
 
 	span0 := createMockSpan(addr, chain.Config().ChainID.String())
 
-	_, heimdallSpan := loadSpanFromFile(t)
+	heimdallSpan := loadSpanFromFile(t)
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/tests/bor/mocks/IHeimdallClient.go
+++ b/tests/bor/mocks/IHeimdallClient.go
@@ -116,6 +116,21 @@ func (mr *MockIHeimdallClientMockRecorder) FetchMilestoneCount(ctx any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchMilestoneCount", reflect.TypeOf((*MockIHeimdallClient)(nil).FetchMilestoneCount), ctx)
 }
 
+// GetLatestSpan mocks base method.
+func (m *MockIHeimdallClient) GetLatestSpan(ctx context.Context) (*types.Span, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLatestSpan", ctx)
+	ret0, _ := ret[0].(*types.Span)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestSpan indicates an expected call of GetLatestSpan.
+func (mr *MockIHeimdallClientMockRecorder) GetLatestSpan(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestSpan", reflect.TypeOf((*MockIHeimdallClient)(nil).GetLatestSpan), ctx)
+}
+
 // GetSpan mocks base method.
 func (m *MockIHeimdallClient) GetSpan(ctx context.Context, spanID uint64) (*types.Span, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Description

This PR introduces VeBlop span rotation.

Major changes:
* Today, each span is deterministically written to a contract for future blocks. After VeBlop, the span will be proactively retrieved from heimdall when the current block producer fails to deliver new blocks within a certain time range, which is currently set at 4s. 
* Remove span commit and validator set info in header after VeBlop, since the span info will be always retrieved from heimdall dynamically.


# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

A HF block number is introduced.

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
