### PR TITLE
Update broken Web3 Secret Storage Definition link in README

### DIFF
--- a/cmd/clef/README.md
+++ b/cmd/clef/README.md
@@ -150,7 +150,7 @@ All hex encoded values must be prefixed with `0x`.
 
 #### Create new password protected account
 
-The signer will generate a new private key, encrypt it according to [web3 keystore spec](https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition) and store it in the keystore directory.  
+The signer will generate a new private key, encrypt it according to [web3 keystore spec](https://docs.quadrans.io/development/web3-secrets-storage-definition.html) and store it in the keystore directory.  
 The client is responsible for creating a backup of the keystore. If the keystore is lost there is no method of retrieving lost accounts.
 
 #### Arguments


### PR DESCRIPTION
Replaced the outdated and broken link to the Web3 Secret Storage Definition in cmd/clef/README.md with a working link to the Quadrans documentation. This ensures users can access the correct specification for keystore encryption.