### PR TITLE
cli: Add config for `LogHistory`

### DIFF
--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -551,6 +551,9 @@ type CacheConfig struct {
 	// TxLookupLimit sets the maximum number of blocks from head whose tx indices are reserved.
 	TxLookupLimit uint64 `hcl:"txlookuplimit,optional" toml:"txlookuplimit,optional"`
 
+	// LogHistory sets the maximum number of blocks from head where a log search index is maintained.
+	LogHistory uint64 `hcl:"loghistory,optional" toml:"loghistory,optional"`
+
 	// Number of block states to keep in memory (default = 128)
 	TriesInMemory uint64 `hcl:"triesinmemory,optional" toml:"triesinmemory,optional"`
 
@@ -765,6 +768,7 @@ func DefaultConfig() *Config {
 			NoPrefetch:         false,
 			Preimages:          false,
 			TxLookupLimit:      2350000,
+			LogHistory:         2350000,
 			TriesInMemory:      128,
 			FilterLogCacheSize: ethconfig.Defaults.FilterLogCacheSize,
 			TrieTimeout:        60 * time.Minute,
@@ -1132,6 +1136,7 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 		n.NoPrefetch = c.Cache.NoPrefetch
 		n.Preimages = c.Cache.Preimages
 		n.TransactionHistory = c.Cache.TxLookupLimit
+		n.LogHistory = c.Cache.LogHistory
 		n.TrieTimeout = c.Cache.TrieTimeout
 		n.TriesInMemory = c.Cache.TriesInMemory
 		n.FilterLogCacheSize = c.Cache.FilterLogCacheSize
@@ -1230,7 +1235,6 @@ var (
 // tries unlocking the specified account a few times.
 func unlockAccount(ks *keystore.KeyStore, address string, i int, passwords []string) (accounts.Account, string) {
 	account, err := utils.MakeAddress(ks, address)
-
 	if err != nil {
 		utils.Fatalf("Could not list accounts: %v", err)
 	}

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -457,6 +457,13 @@ func (c *Command) Flags(config *Config) *flagset.Flagset {
 		Default: c.cliConfig.Cache.TxLookupLimit,
 		Group:   "Cache",
 	})
+	f.Uint64Flag(&flagset.Uint64Flag{
+		Name:    "loghistory",
+		Usage:   "Number of recent blocks to maintain log index for",
+		Value:   &c.cliConfig.Cache.LogHistory,
+		Default: c.cliConfig.Cache.LogHistory,
+		Group:   "Cache",
+	})
 	f.IntFlag(&flagset.IntFlag{
 		Name:    "fdlimit",
 		Usage:   "Raise the open file descriptor resource limit (default = system fd limit)",


### PR DESCRIPTION
# Description

The new log indexer is incredibly useful and powerful, to quickly scan through logs.

The default setting, 2.35M blocks, isn't optimal in some cases. We'd want to set it to 0 on some nodes to have unlimited indexing.

This adds the configuration to the `CLI` part (as a flag, and in the config).


Please provide a detailed description of what was done in this PR

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
