### PR TITLE
Enable custom HTTP Modules in dev-mode

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1217,7 +1217,9 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 
 	if s.prefetcher != nil && len(addressesToPrefetch) > 0 {
 		if err := s.prefetcher.prefetch(common.Hash{}, s.originalRoot, common.Address{}, addressesToPrefetch, nil, false); err != nil {
-			log.Error("Failed to prefetch addresses", "addresses", len(addressesToPrefetch), "err", err)
+			if !errors.Is(err, errTerminated) {
+				log.Error("Failed to prefetch addresses", "addresses", len(addressesToPrefetch), "err", err)
+            }
 		}
 	}
 	// Invalidate journal because reverting across transactions is not allowed.

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -1402,10 +1402,6 @@ func (c *Config) buildNode() (*node.Config, error) {
 		cfg.P2P.ListenAddr = ""
 		cfg.P2P.NoDial = true
 		cfg.P2P.DiscoveryV5 = false
-
-		// enable JsonRPC HTTP API
-		c.JsonRPC.Http.Enabled = true
-		cfg.HTTPModules = []string{"admin", "debug", "eth", "miner", "net", "personal", "txpool", "web3", "bor"}
 	}
 
 	// enable jsonrpc endpoints


### PR DESCRIPTION
# Description

The active HTTP modules in dev-mode were hardcoded, thus discarding the user's choice of active HTTP modules.

I also remove an `log.Error` in the prefetcher, when the error is `errTerminated`

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Run
```bash
go run ./cmd/cli server --dev --http --http.api eth,debug
```

On master, it prints:
```
ERROR[06-24|13:59:01.553] Unavailable modules in HTTP API list     unavailable=[personal] available="[admin debug web3 eth txpool bor clique miner net]"
```

While there are no issues on this branch.