### PR TITLE
eth: fix canonical chain state inconsistency in checkpoint verifier

### DIFF
--- a/eth/bor_checkpoint_verifier.go
+++ b/eth/bor_checkpoint_verifier.go
@@ -150,9 +150,17 @@ func borVerify(ctx context.Context, eth *Ethereum, handler *ethHandler, start ui
 			if err != nil {
 				log.Warn("Failed to insert canonical chain", "err", err)
 				return hash, err
-			} else {
-				log.Info("Successfully inserted canonical chain")
 			}
+
+			// Then explicitly set the final block as canonical to ensure proper canonical mapping
+			finalBlock := canonicalChain[len(canonicalChain)-1]
+			_, err = eth.BlockChain().SetCanonical(finalBlock)
+			if err != nil {
+				log.Warn("Failed to set canonical head after insertion", "err", err, "block", finalBlock.NumberU64(), "hash", finalBlock.Hash())
+				return hash, err
+			}
+
+			log.Info("Successfully inserted canonical chain")
 		} else {
 			log.Warn("Failed to insert canonical chain", "length", len(canonicalChain), "expected", length)
 			return hash, errHashMismatch

--- a/params/version.go
+++ b/params/version.go
@@ -25,7 +25,7 @@ import (
 const (
 	VersionMajor = 2      // Major version component of the current release
 	VersionMinor = 2      // Minor version component of the current release
-	VersionPatch = 1      // Patch version component of the current release
+	VersionPatch = 2      // Patch version component of the current release
 	VersionMeta  = "beta" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
When checkpoint verifier inserts canonical chain after rewind, the fork choice logic in writeBlockAndSetHead() may determine that no reorg is needed, causing blocks to be inserted with SideStatTy instead of CanonStatTy. This prevents writeHeadBlock() from being called, leaving canonical hash mappings outdated.

The issue manifests as:
- "Successfully inserted canonical chain" log appears
- GetBlockByNumber() still returns old block hash
- Fork detection triggers false positives for whitelisted blocks
- Milestone reorg protection fails

Fix by explicitly calling SetCanonical() after InsertChain() to force canonical status and ensure proper canonical hash mapping updates.

# Description

Please provide a detailed description of what was done in this PR

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
