### PR TITLE
consensus/bor, params: added OverrideStateSyncRecordsInRange to overwrite the state sync records for a range of blocks

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1473,10 +1473,19 @@ func (c *Bor) CommitStates(
 		return stateSyncs, nil
 	}
 
+	// This if statement checks if there are any state sync record overrides configured for the current block number.
+	// If there are, it truncates the eventRecords array to the specified number of records.
 	if c.config.OverrideStateSyncRecords != nil {
 		if val, ok := c.config.OverrideStateSyncRecords[strconv.FormatUint(number, 10)]; ok {
 			eventRecords = eventRecords[0:val]
 		}
+	}
+
+	// This if statement checks if there are any state sync record overrides configured for the current block number.
+	// If there are, it truncates the eventRecords array to the specified number of records.
+	overrideStateSyncRecord, ok := c.config.GetOverrideStateSyncRecord(number)
+	if ok {
+		eventRecords = eventRecords[0:overrideStateSyncRecord]
 	}
 
 	fetchTime := time.Since(fetchStart)

--- a/params/config.go
+++ b/params/config.go
@@ -808,23 +808,30 @@ func (c CliqueConfig) String() string {
 	return fmt.Sprintf("clique(period: %d, epoch: %d)", c.Period, c.Epoch)
 }
 
+type BlockRangeOverride struct {
+	StartBlock uint64 `json:"startBlock"`
+	EndBlock   uint64 `json:"endBlock"`
+	Value      int    `json:"value"`
+}
+
 // BorConfig is the consensus engine configs for Matic bor based sealing.
 type BorConfig struct {
-	Period                     map[string]uint64      `json:"period"`                   // Number of seconds between blocks to enforce
-	ProducerDelay              map[string]uint64      `json:"producerDelay"`            // Number of seconds delay between two producer interval
-	Sprint                     map[string]uint64      `json:"sprint"`                   // Epoch length to proposer
-	BackupMultiplier           map[string]uint64      `json:"backupMultiplier"`         // Backup multiplier to determine the wiggle time
-	ValidatorContract          string                 `json:"validatorContract"`        // Validator set contract
-	StateReceiverContract      string                 `json:"stateReceiverContract"`    // State receiver contract
-	OverrideStateSyncRecords   map[string]int         `json:"overrideStateSyncRecords"` // override state records count
-	BlockAlloc                 map[string]interface{} `json:"blockAlloc"`
-	BurntContract              map[string]string      `json:"burntContract"`              // governance contract where the token will be sent to and burnt in london fork
-	JaipurBlock                *big.Int               `json:"jaipurBlock"`                // Jaipur switch block (nil = no fork, 0 = already on jaipur)
-	DelhiBlock                 *big.Int               `json:"delhiBlock"`                 // Delhi switch block (nil = no fork, 0 = already on delhi)
-	IndoreBlock                *big.Int               `json:"indoreBlock"`                // Indore switch block (nil = no fork, 0 = already on indore)
-	StateSyncConfirmationDelay map[string]uint64      `json:"stateSyncConfirmationDelay"` // StateSync Confirmation Delay, in seconds, to calculate `to`
-	AhmedabadBlock             *big.Int               `json:"ahmedabadBlock"`             // Ahmedabad switch block (nil = no fork, 0 = already on ahmedabad)
-	BhilaiBlock                *big.Int               `json:"bhilaiBlock"`                // Bhilai switch block (nil = no fork, 0 = already on bhilai)
+	Period                          map[string]uint64      `json:"period"`                          // Number of seconds between blocks to enforce
+	ProducerDelay                   map[string]uint64      `json:"producerDelay"`                   // Number of seconds delay between two producer interval
+	Sprint                          map[string]uint64      `json:"sprint"`                          // Epoch length to proposer
+	BackupMultiplier                map[string]uint64      `json:"backupMultiplier"`                // Backup multiplier to determine the wiggle time
+	ValidatorContract               string                 `json:"validatorContract"`               // Validator set contract
+	StateReceiverContract           string                 `json:"stateReceiverContract"`           // State receiver contract
+	OverrideStateSyncRecords        map[string]int         `json:"overrideStateSyncRecords"`        // override state records count
+	OverrideStateSyncRecordsInRange []BlockRangeOverride   `json:"overrideStateSyncRecordsInRange"` // override state records count in a given block range
+	BlockAlloc                      map[string]interface{} `json:"blockAlloc"`
+	BurntContract                   map[string]string      `json:"burntContract"`              // governance contract where the token will be sent to and burnt in london fork
+	JaipurBlock                     *big.Int               `json:"jaipurBlock"`                // Jaipur switch block (nil = no fork, 0 = already on jaipur)
+	DelhiBlock                      *big.Int               `json:"delhiBlock"`                 // Delhi switch block (nil = no fork, 0 = already on delhi)
+	IndoreBlock                     *big.Int               `json:"indoreBlock"`                // Indore switch block (nil = no fork, 0 = already on indore)
+	StateSyncConfirmationDelay      map[string]uint64      `json:"stateSyncConfirmationDelay"` // StateSync Confirmation Delay, in seconds, to calculate `to`
+	AhmedabadBlock                  *big.Int               `json:"ahmedabadBlock"`             // Ahmedabad switch block (nil = no fork, 0 = already on ahmedabad)
+	BhilaiBlock                     *big.Int               `json:"bhilaiBlock"`                // Bhilai switch block (nil = no fork, 0 = already on bhilai)
 }
 
 // String implements the stringer interface, returning the consensus engine details.
@@ -915,6 +922,15 @@ func borKeyValueConfigHelper[T uint64 | string](field map[string]T, number uint6
 
 func (c *BorConfig) CalculateBurntContract(number uint64) string {
 	return borKeyValueConfigHelper(c.BurntContract, number)
+}
+
+func (c *BorConfig) GetOverrideStateSyncRecord(block uint64) (int, bool) {
+	for _, r := range c.OverrideStateSyncRecordsInRange {
+		if block >= r.StartBlock && block <= r.EndBlock {
+			return r.Value, true
+		}
+	}
+	return 0, false
 }
 
 // Description returns a human-readable description of ChainConfig.

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -17,6 +17,7 @@
 package params
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 	"reflect"
@@ -192,4 +193,384 @@ func TestBorKeyValueConfigHelper(t *testing.T) {
 	assert.Equal(t, borKeyValueConfigHelper(burntContract, 41824608-1), "0x70bcA57F4579f58670aB2d18Ef16e02C17553C38")
 	assert.Equal(t, borKeyValueConfigHelper(burntContract, 41824608), "0x617b94CCCC2511808A3C9478ebb96f455CF167aA")
 	assert.Equal(t, borKeyValueConfigHelper(burntContract, 41824608+1), "0x617b94CCCC2511808A3C9478ebb96f455CF167aA")
+}
+
+func TestOverrideStateSyncRecordsInRange(t *testing.T) {
+	t.Parallel()
+
+	// Test cases for GetOverrideStateSyncRecord method
+	tests := []struct {
+		name          string
+		config        *BorConfig
+		blockNumber   uint64
+		expectedValue int
+		expectedFound bool
+		description   string
+	}{
+		{
+			name: "Empty configuration",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{},
+			},
+			blockNumber:   100,
+			expectedValue: 0,
+			expectedFound: false,
+			description:   "Should return 0, false when no ranges are configured",
+		},
+		{
+			name: "Single range - block within range",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 200, Value: 5},
+				},
+			},
+			blockNumber:   150,
+			expectedValue: 5,
+			expectedFound: true,
+			description:   "Should return configured value when block is within range",
+		},
+		{
+			name: "Single range - block at start boundary",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 200, Value: 5},
+				},
+			},
+			blockNumber:   100,
+			expectedValue: 5,
+			expectedFound: true,
+			description:   "Should return configured value when block is at start boundary",
+		},
+		{
+			name: "Single range - block at end boundary",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 200, Value: 5},
+				},
+			},
+			blockNumber:   200,
+			expectedValue: 5,
+			expectedFound: true,
+			description:   "Should return configured value when block is at end boundary",
+		},
+		{
+			name: "Single range - block before range",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 200, Value: 5},
+				},
+			},
+			blockNumber:   50,
+			expectedValue: 0,
+			expectedFound: false,
+			description:   "Should return 0, false when block is before range",
+		},
+		{
+			name: "Single range - block after range",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 200, Value: 5},
+				},
+			},
+			blockNumber:   250,
+			expectedValue: 0,
+			expectedFound: false,
+			description:   "Should return 0, false when block is after range",
+		},
+		{
+			name: "Multiple ranges - block in first range",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 200, Value: 5},
+					{StartBlock: 300, EndBlock: 400, Value: 10},
+					{StartBlock: 500, EndBlock: 600, Value: 15},
+				},
+			},
+			blockNumber:   150,
+			expectedValue: 5,
+			expectedFound: true,
+			description:   "Should return value from first range when block is in first range",
+		},
+		{
+			name: "Multiple ranges - block in second range",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 200, Value: 5},
+					{StartBlock: 300, EndBlock: 400, Value: 10},
+					{StartBlock: 500, EndBlock: 600, Value: 15},
+				},
+			},
+			blockNumber:   350,
+			expectedValue: 10,
+			expectedFound: true,
+			description:   "Should return value from second range when block is in second range",
+		},
+		{
+			name: "Multiple ranges - block in third range",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 200, Value: 5},
+					{StartBlock: 300, EndBlock: 400, Value: 10},
+					{StartBlock: 500, EndBlock: 600, Value: 15},
+				},
+			},
+			blockNumber:   550,
+			expectedValue: 15,
+			expectedFound: true,
+			description:   "Should return value from third range when block is in third range",
+		},
+		{
+			name: "Multiple ranges - block between ranges",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 200, Value: 5},
+					{StartBlock: 300, EndBlock: 400, Value: 10},
+					{StartBlock: 500, EndBlock: 600, Value: 15},
+				},
+			},
+			blockNumber:   250,
+			expectedValue: 0,
+			expectedFound: false,
+			description:   "Should return 0, false when block is between ranges",
+		},
+		{
+			name: "Overlapping ranges - should return first match",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 300, Value: 5},
+					{StartBlock: 200, EndBlock: 400, Value: 10},
+				},
+			},
+			blockNumber:   250,
+			expectedValue: 5,
+			expectedFound: true,
+			description:   "Should return value from first matching range when ranges overlap",
+		},
+		{
+			name: "Zero value range",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 200, Value: 0},
+				},
+			},
+			blockNumber:   150,
+			expectedValue: 0,
+			expectedFound: true,
+			description:   "Should return 0, true when range value is 0",
+		},
+		{
+			name: "Negative value range",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 200, Value: -5},
+				},
+			},
+			blockNumber:   150,
+			expectedValue: -5,
+			expectedFound: true,
+			description:   "Should return negative value when range value is negative",
+		},
+		{
+			name: "Single block range",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 100, EndBlock: 100, Value: 5},
+				},
+			},
+			blockNumber:   100,
+			expectedValue: 5,
+			expectedFound: true,
+			description:   "Should work correctly with single block range",
+		},
+		{
+			name: "Large block numbers",
+			config: &BorConfig{
+				OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+					{StartBlock: 1000000, EndBlock: 2000000, Value: 25},
+				},
+			},
+			blockNumber:   1500000,
+			expectedValue: 25,
+			expectedFound: true,
+			description:   "Should work correctly with large block numbers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, found := tt.config.GetOverrideStateSyncRecord(tt.blockNumber)
+
+			if value != tt.expectedValue {
+				t.Errorf("GetOverrideStateSyncRecord(%d) returned value = %d, want %d",
+					tt.blockNumber, value, tt.expectedValue)
+			}
+
+			if found != tt.expectedFound {
+				t.Errorf("GetOverrideStateSyncRecord(%d) returned found = %v, want %v",
+					tt.blockNumber, found, tt.expectedFound)
+			}
+		})
+	}
+}
+
+func TestBlockRangeOverrideStruct(t *testing.T) {
+	t.Parallel()
+
+	// Test BlockRangeOverride struct creation and field access
+	override := BlockRangeOverride{
+		StartBlock: 100,
+		EndBlock:   200,
+		Value:      5,
+	}
+
+	if override.StartBlock != 100 {
+		t.Errorf("Expected StartBlock to be 100, got %d", override.StartBlock)
+	}
+
+	if override.EndBlock != 200 {
+		t.Errorf("Expected EndBlock to be 200, got %d", override.EndBlock)
+	}
+
+	if override.Value != 5 {
+		t.Errorf("Expected Value to be 5, got %d", override.Value)
+	}
+
+	// Test edge case where StartBlock equals EndBlock
+	singleBlockOverride := BlockRangeOverride{
+		StartBlock: 100,
+		EndBlock:   100,
+		Value:      10,
+	}
+
+	if singleBlockOverride.StartBlock != singleBlockOverride.EndBlock {
+		t.Errorf("Expected StartBlock and EndBlock to be equal for single block range")
+	}
+}
+
+func TestOverrideStateSyncRecordsInRangeIntegration(t *testing.T) {
+	t.Parallel()
+
+	// Test integration with actual BorConfig usage
+	borConfig := &BorConfig{
+		OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+			{StartBlock: 1000, EndBlock: 2000, Value: 3},
+			{StartBlock: 3000, EndBlock: 4000, Value: 7},
+			{StartBlock: 5000, EndBlock: 6000, Value: 0},
+		},
+	}
+
+	// Test various scenarios
+	testCases := []struct {
+		blockNumber   uint64
+		expectedValue int
+		expectedFound bool
+	}{
+		{500, 0, false},  // Before all ranges
+		{1000, 3, true},  // At start of first range
+		{1500, 3, true},  // Middle of first range
+		{2000, 3, true},  // At end of first range
+		{2500, 0, false}, // Between ranges
+		{3000, 7, true},  // At start of second range
+		{3500, 7, true},  // Middle of second range
+		{4000, 7, true},  // At end of second range
+		{4500, 0, false}, // Between ranges
+		{5000, 0, true},  // At start of third range (value is 0)
+		{5500, 0, true},  // Middle of third range (value is 0)
+		{6000, 0, true},  // At end of third range (value is 0)
+		{6500, 0, false}, // After all ranges
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Block_%d", tc.blockNumber), func(t *testing.T) {
+			value, found := borConfig.GetOverrideStateSyncRecord(tc.blockNumber)
+
+			if value != tc.expectedValue {
+				t.Errorf("Block %d: expected value %d, got %d",
+					tc.blockNumber, tc.expectedValue, value)
+			}
+
+			if found != tc.expectedFound {
+				t.Errorf("Block %d: expected found %v, got %v",
+					tc.blockNumber, tc.expectedFound, found)
+			}
+		})
+	}
+}
+
+func TestOverrideStateSyncRecordsInRangeExample(t *testing.T) {
+	t.Parallel()
+
+	// Example: Configure state sync record overrides for specific block ranges
+	// This simulates a real-world scenario where you want to limit state sync records
+	// for certain block ranges to control gas usage or processing time
+	borConfig := &BorConfig{
+		OverrideStateSyncRecordsInRange: []BlockRangeOverride{
+			// Limit to 5 state sync records for blocks 1000-2000
+			{StartBlock: 1000, EndBlock: 2000, Value: 5},
+			// Disable state sync records for blocks 3000-4000 (maintenance period)
+			{StartBlock: 3000, EndBlock: 4000, Value: 0},
+			// Allow up to 10 state sync records for blocks 5000-6000
+			{StartBlock: 5000, EndBlock: 6000, Value: 10},
+			// Normal operation resumes after block 6000 (no override)
+		},
+	}
+
+	// Test the configuration
+	testCases := []struct {
+		blockNumber   uint64
+		expectedValue int
+		expectedFound bool
+		scenario      string
+	}{
+		{500, 0, false, "Before any overrides - normal operation"},
+		{1000, 5, true, "Start of first override range - limit to 5 records"},
+		{1500, 5, true, "Middle of first override range - limit to 5 records"},
+		{2000, 5, true, "End of first override range - limit to 5 records"},
+		{2500, 0, false, "Between ranges - normal operation"},
+		{3000, 0, true, "Start of maintenance period - no state sync records"},
+		{3500, 0, true, "Middle of maintenance period - no state sync records"},
+		{4000, 0, true, "End of maintenance period - no state sync records"},
+		{4500, 0, false, "Between ranges - normal operation"},
+		{5000, 10, true, "Start of high-capacity range - allow up to 10 records"},
+		{5500, 10, true, "Middle of high-capacity range - allow up to 10 records"},
+		{6000, 10, true, "End of high-capacity range - allow up to 10 records"},
+		{6500, 0, false, "After all overrides - normal operation"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Block_%d_%s", tc.blockNumber, tc.scenario), func(t *testing.T) {
+			value, found := borConfig.GetOverrideStateSyncRecord(tc.blockNumber)
+
+			if value != tc.expectedValue {
+				t.Errorf("Block %d (%s): expected value %d, got %d",
+					tc.blockNumber, tc.scenario, tc.expectedValue, value)
+			}
+
+			if found != tc.expectedFound {
+				t.Errorf("Block %d (%s): expected found %v, got %v",
+					tc.blockNumber, tc.scenario, tc.expectedFound, found)
+			}
+		})
+	}
+
+	// Demonstrate how this would be used in practice
+	t.Run("Practical Usage Example", func(t *testing.T) {
+		// Simulate processing a block and checking for overrides
+		blockNumber := uint64(1500)
+		overrideValue, hasOverride := borConfig.GetOverrideStateSyncRecord(blockNumber)
+
+		if !hasOverride {
+			t.Fatal("Expected to find override for block 1500")
+		}
+
+		if overrideValue != 5 {
+			t.Fatalf("Expected override value 5, got %d", overrideValue)
+		}
+
+		// In practice, this value would be used to limit the number of state sync records
+		// processed for this block, e.g.:
+		// eventRecords = eventRecords[:overrideValue]
+		t.Logf("Block %d: Processing maximum %d state sync records due to override",
+			blockNumber, overrideValue)
+	})
 }


### PR DESCRIPTION
# Description

Added OverrideStateSyncRecordsInRange to overwrite the state sync records for a range of blocks.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
