### PR TITLE
Support geth's log history flags

### DIFF
--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -91,6 +91,12 @@ type Config struct {
 	// Snapshot enables the snapshot database mode
 	Snapshot bool `hcl:"snapshot,optional" toml:"snapshot,optional"`
 
+	// Log indexer history
+	LogHistory uint64 `hcl:"loghistory,optional" toml:"loghistory,optional"`
+
+	// Disable log indexer
+	LogNoHistory bool `hcl:"lognohistory,optional" toml:"lognohistory,optional"`
+
 	// BorLogs enables bor log retrieval
 	BorLogs bool `hcl:"bor.logs,optional" toml:"bor.logs,optional"`
 
@@ -660,11 +666,13 @@ func DefaultConfig() *Config {
 			GRPCAddress: "",
 			WSAddress:   "",
 		},
-		SyncMode:    "full",
-		GcMode:      "full",
-		StateScheme: "path",
-		Snapshot:    true,
-		BorLogs:     false,
+		SyncMode:     "full",
+		GcMode:       "full",
+		StateScheme:  "path",
+		Snapshot:     true,
+		LogHistory:   2350000,
+		LogNoHistory: false,
+		BorLogs:      false,
 		TxPool: &TxPoolConfig{
 			Locals:       []string{},
 			NoLocals:     false,
@@ -951,6 +959,10 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 	n.RunHeimdallArgs = c.Heimdall.RunHeimdallArgs
 	n.UseHeimdallApp = c.Heimdall.UseHeimdallApp
 
+	// Log index
+	n.LogHistory = c.LogHistory
+	n.LogNoHistory = c.LogNoHistory
+
 	// Developer Fake Author for producing blocks without authorisation on bor consensus
 	n.DevFakeAuthor = c.DevFakeAuthor
 
@@ -1235,7 +1247,6 @@ var (
 // tries unlocking the specified account a few times.
 func unlockAccount(ks *keystore.KeyStore, address string, i int, passwords []string) (accounts.Account, string) {
 	account, err := utils.MakeAddress(ks, address)
-
 	if err != nil {
 		utils.Fatalf("Could not list accounts: %v", err)
 	}

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -116,6 +116,18 @@ func (c *Command) Flags(config *Config) *flagset.Flagset {
 		Value:   &c.cliConfig.Snapshot,
 		Default: c.cliConfig.Snapshot,
 	})
+	f.Uint64Flag(&flagset.Uint64Flag{
+		Name:    "history.log",
+		Usage:   `Number of recent blocks to maintain log search index for (default = about one year, 0 = entire chain)`,
+		Value:   &c.cliConfig.LogHistory,
+		Default: c.cliConfig.LogHistory,
+	})
+	f.BoolFlag(&flagset.BoolFlag{
+		Name:    "history.logs.disable",
+		Usage:   `Do not maintain log search index`,
+		Value:   &c.cliConfig.LogNoHistory,
+		Default: c.cliConfig.LogNoHistory,
+	})
 	f.BoolFlag(&flagset.BoolFlag{
 		Name:    "bor.logs",
 		Usage:   `Enables bor log retrieval`,


### PR DESCRIPTION
Bor 2.1.0 use Geth [1.15.6](https://github.com/ethereum/go-ethereum/releases/tag/v1.15.6)'s new log index. But as of now, we cannot control the settings using flags.