### PR TITLE
Improve stateless sync

### DIFF
--- a/consensus/bor/heimdallws/client.go
+++ b/consensus/bor/heimdallws/client.go
@@ -153,6 +153,9 @@ func (c *HeimdallWSClient) readMessages(ctx context.Context) {
 		if timestamp, err := strconv.ParseUint(attrs["timestamp"], 10, 64); err == nil {
 			m.Timestamp = timestamp
 		}
+		if totalDifficulty, err := strconv.ParseUint(attrs["total_difficulty"], 10, 64); err == nil {
+			m.TotalDifficulty = totalDifficulty
+		}
 
 		// Deliver the milestone event, respecting context cancellation.
 		select {

--- a/consensus/bor/valset/validator_set.go
+++ b/consensus/bor/valset/validator_set.go
@@ -50,6 +50,21 @@ type ValidatorSet struct {
 	validatorsMap    map[common.Address]int // address -> index
 }
 
+func (vals *ValidatorSet) ValidatorMapString() string {
+	// Sort the map by index
+	validatorMap := make(map[int]common.Address)
+	for address, index := range vals.validatorsMap {
+		validatorMap[index] = address
+	}
+
+	validatorMapString := ""
+	for i := 0; i < len(vals.Validators); i++ {
+		validatorMapString += fmt.Sprintf("%s: %d, ", validatorMap[i].String(), i)
+	}
+
+	return validatorMapString
+}
+
 // NewValidatorSet initializes a ValidatorSet by copying over the
 // values from `valz`, a list of Validators. If valz is nil or empty,
 // the new ValidatorSet will have an empty list of Validators.

--- a/core/stateless/witness.go
+++ b/core/stateless/witness.go
@@ -124,3 +124,9 @@ func (w *Witness) Root() common.Hash {
 func (w *Witness) Header() *types.Header {
 	return w.context
 }
+
+func (w *Witness) SetHeader(header *types.Header) {
+	if w != nil {
+		w.context = header
+	}
+}

--- a/eth/downloader/bor_downloader.go
+++ b/eth/downloader/bor_downloader.go
@@ -2215,7 +2215,7 @@ func (d *Downloader) GetOrWaitFastForwardBlock() uint64 {
 	}
 
 	distance := (int64(fastForwardBlock) - int64(localHeight))
-	if distance > int64(d.FastForwardThreshold) || localHeight == 0 {
+	if distance > int64(d.FastForwardThreshold) {
 		log.Info("StatelessSync: FastForwarding", "fastForwardBlock", fastForwardBlock)
 		return fastForwardBlock
 	} else {

--- a/eth/downloader/bor_fetchers_concurrent.go
+++ b/eth/downloader/bor_fetchers_concurrent.go
@@ -349,9 +349,6 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 			}
 
 		case res := <-responses:
-			if reflect.TypeOf(queue) == reflect.TypeOf(&witnessQueue{}) {
-				log.Debug("Received response", "queue type", reflect.TypeOf(queue), "res", res)
-			}
 			// Response arrived, it may be for an existing or an already timed
 			// out request. If the former, update the timeout heap and perhaps
 			// reschedule the timeout timer.
@@ -378,13 +375,7 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 
 			// Signal the dispatcher that the round trip is done. We'll drop the
 			// peer if the data turns out to be junk.
-			if reflect.TypeOf(queue) == reflect.TypeOf(&witnessQueue{}) {
-				log.Debug("Signal dispatcher", "queue type", reflect.TypeOf(queue), "res", res)
-			}
 			res.Done <- nil
-			if reflect.TypeOf(queue) == reflect.TypeOf(&witnessQueue{}) {
-				log.Debug("Close request", "queue type", reflect.TypeOf(queue), "res", res)
-			}
 			res.Req.Close()
 
 			if reflect.TypeOf(queue) == reflect.TypeOf(&witnessQueue{}) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -837,6 +837,10 @@ func (w *worker) resultLoop() {
 			log.Info("Successfully sealed new block", "number", block.Number(), "sealhash", sealhash, "hash", hash,
 				"elapsed", common.PrettyDuration(time.Since(task.createdAt)))
 
+			if witness != nil {
+				witness.SetHeader(block.Header())
+			}
+
 			// Broadcast the block and announce chain insertion event
 			w.mux.Post(core.NewMinedBlockEvent{Block: block, Witness: witness})
 


### PR DESCRIPTION
# Description

Improve stateless sync

This commit improves a few things about stateless sync:
 - Fix 'unknown ancestor' when a node is running in stateless sync mode
 - Extract all veblop snapshot logic to a separate function to make the code simpler. This also resolved a backward compatibility issue with non-veblop-enabled node.
 - Add witness cache to witness manager to handle the case when witness arrives before its corresponding block
 - Improve witness fetch reschedule event
 - Fix witness header hash when it is produced by a block producer

## Testing
Tested in kurtosis
