### PR TITLE
Fix milestone whitelist delay on restart

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -803,8 +803,6 @@ func (s *Ethereum) fetchAndHandleWhitelistCheckpoint(ctx context.Context, ethHan
 
 type heimdallHandler func(ctx context.Context, ethHandler *ethHandler, bor *bor.Bor) error
 
-var lastSeenMilestoneBlockNumber uint64
-
 // fetchAndHandleMilestone handles the milestone mechanism.
 func (s *Ethereum) fetchAndHandleMilestone(ctx context.Context, ethHandler *ethHandler, bor *bor.Bor) error {
 	// Create a new bor verifier, which will be used to verify checkpoints and milestones

--- a/eth/handler_bor.go
+++ b/eth/handler_bor.go
@@ -159,12 +159,14 @@ func (h *ethHandler) handleMilestone(ctx context.Context, eth *Ethereum, milesto
 		return err
 	}
 
-	for lastSeenMilestoneBlockNumber < num {
-		lastSeenMilestoneBlockNumber += 1
-		block := eth.blockchain.GetBlockByNumber(lastSeenMilestoneBlockNumber)
+	start := milestone.StartBlock
+
+	for start <= milestone.EndBlock {
+		block := eth.blockchain.GetBlockByNumber(start)
 		if block != nil && block.Header() != nil {
 			MilestoneWhitelistedDelayTimer.UpdateSince(time.Unix(int64(block.Time()), 0))
 		}
+		start += 1
 	}
 
 	h.downloader.ProcessMilestone(num, hash)

--- a/params/version.go
+++ b/params/version.go
@@ -25,7 +25,7 @@ import (
 const (
 	VersionMajor = 2  // Major version component of the current release
 	VersionMinor = 2  // Minor version component of the current release
-	VersionPatch = 4  // Patch version component of the current release
+	VersionPatch = 5  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
# Description

This is to fix a problem when the node is stuck at a loop when it is initially started and trying to whitelist the first milestone. Instead of tracking all the block from the genesis, the metrics should just update the from the start block in the milestone.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
