### PR TITLE
Stateless sync bytecode cache

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -182,6 +182,7 @@ type CacheConfig struct {
 	// This defines the cutoff block for history expiry.
 	// Blocks before this number may be unavailable in the chain database.
 	HistoryPruningCutoff uint64
+	Stateless            bool // Whether the node is in stateless mode
 }
 
 // triedbConfig derives the configures for trie database.
@@ -423,8 +424,8 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	head := bc.CurrentBlock()
 	// nolint:nestif
 
-	// If TriesInMemory is set to 0, we know the node is in stateless mode and will not load the state from disk
-	if !bc.HasState(head.Root) && bc.cacheConfig.TriesInMemory > 0 {
+	// If the node is in stateless mode, it should not load the state from disk
+	if !bc.HasState(head.Root) && !bc.cacheConfig.Stateless {
 		if head.Number.Uint64() == 0 {
 			// The genesis state is missing, which is only possible in the path-based
 			// scheme. This situation occurs when the initial state sync is not finished
@@ -997,11 +998,7 @@ func (bc *BlockChain) rewindHashHead(head *types.Header, root common.Hash) (*typ
 			logged = time.Now()
 			logger = log.Info
 		}
-		if bc.cacheConfig.TriesInMemory == 0 {
-			logger("Stateless mode: skipping state check", "number", head.Number, "hash", head.Hash(), "elapsed", common.PrettyDuration(time.Since(start)))
-		} else {
-			logger("Block state missing, rewinding further", "number", head.Number, "hash", head.Hash(), "elapsed", common.PrettyDuration(time.Since(start)))
-		}
+		logger("Block state missing, rewinding further", "number", head.Number, "hash", head.Hash(), "elapsed", common.PrettyDuration(time.Since(start)))
 
 		// If a root threshold was requested but not yet crossed, check
 		if !beyondRoot && head.Root == root {
@@ -1015,11 +1012,6 @@ func (bc *BlockChain) rewindHashHead(head *types.Header, root common.Hash) (*typ
 		}
 		// If the associated state is not reachable, continue searching
 		// backwards until an available state is found.
-		// Skip state checking for stateless nodes (TriesInMemory == 0)
-		if bc.cacheConfig.TriesInMemory == 0 {
-			// For stateless nodes, we can use any block as head without state checking
-			break
-		}
 		if !bc.HasState(head.Root) {
 			// If the chain is gapped in the middle, return the genesis
 			// block as the new chain head.
@@ -1046,13 +1038,6 @@ func (bc *BlockChain) rewindHashHead(head *types.Header, root common.Hash) (*typ
 		log.Debug("Skipping block with threshold state", "number", head.Number, "hash", head.Hash(), "root", head.Root)
 		head = bc.GetHeader(head.ParentHash, head.Number.Uint64()-1) // Keep rewinding
 	}
-	// If we exited the loop (e.g., for stateless nodes), return the current head
-	if bc.cacheConfig.TriesInMemory == 0 {
-		log.Info("Rewound to block (stateless mode)", "number", head.Number, "hash", head.Hash())
-	} else {
-		log.Info("Rewound to target block", "number", head.Number, "hash", head.Hash())
-	}
-	return head, rootNumber
 }
 
 // rewindPathHead implements the logic of rewindHead in the context of path scheme.
@@ -1067,8 +1052,7 @@ func (bc *BlockChain) rewindPathHead(head *types.Header, root common.Hash) (*typ
 
 		// noState represents if the target state requested for search
 		// is unavailable and impossible to be recovered.
-		// For stateless nodes, we don't check state availability
-		noState = bc.cacheConfig.TriesInMemory > 0 && !bc.HasState(root) && !bc.stateRecoverable(root)
+		noState = !bc.HasState(root) && !bc.stateRecoverable(root)
 
 		start  = time.Now() // Timestamp the rewinding is restarted
 		logged = time.Now() // Timestamp last progress log was printed
@@ -1080,11 +1064,7 @@ func (bc *BlockChain) rewindPathHead(head *types.Header, root common.Hash) (*typ
 			logged = time.Now()
 			logger = log.Info
 		}
-		if bc.cacheConfig.TriesInMemory == 0 {
-			logger("Stateless mode: skipping state check", "number", head.Number, "hash", head.Hash(), "elapsed", common.PrettyDuration(time.Since(start)))
-		} else {
-			logger("Block state missing, rewinding further", "number", head.Number, "hash", head.Hash(), "elapsed", common.PrettyDuration(time.Since(start)))
-		}
+		logger("Block state missing, rewinding further", "number", head.Number, "hash", head.Hash(), "elapsed", common.PrettyDuration(time.Since(start)))
 
 		// If a root threshold was requested but not yet crossed, check
 		if !beyondRoot && head.Root == root {
@@ -1093,20 +1073,13 @@ func (bc *BlockChain) rewindPathHead(head *types.Header, root common.Hash) (*typ
 		// If the root threshold hasn't been crossed but the available
 		// state is reached, quickly determine if the target state is
 		// possible to be reached or not.
-		// Skip this check for stateless nodes
-		if bc.cacheConfig.TriesInMemory > 0 && !beyondRoot && noState && bc.HasState(head.Root) {
+		if !beyondRoot && noState && bc.HasState(head.Root) {
 			beyondRoot = true
 			log.Info("Disable the search for unattainable state", "root", root)
 		}
 		// Check if the associated state is available or recoverable if
 		// the requested root has already been crossed.
-		// Skip state checking for stateless nodes (TriesInMemory == 0)
-		if bc.cacheConfig.TriesInMemory == 0 {
-			// For stateless nodes, we can use any block as head without state checking
-			if beyondRoot {
-				break
-			}
-		} else if beyondRoot && (bc.HasState(head.Root) || bc.stateRecoverable(head.Root)) {
+		if beyondRoot && (bc.HasState(head.Root) || bc.stateRecoverable(head.Root)) {
 			break
 		}
 		// If pivot block is reached, return the genesis block as the
@@ -1133,17 +1106,12 @@ func (bc *BlockChain) rewindPathHead(head *types.Header, root common.Hash) (*typ
 		}
 	}
 	// Recover if the target state if it's not available yet.
-	// Skip state recovery for stateless nodes (TriesInMemory == 0)
-	if bc.cacheConfig.TriesInMemory > 0 && !bc.HasState(head.Root) {
+	if !bc.HasState(head.Root) {
 		if err := bc.triedb.Recover(head.Root); err != nil {
 			log.Crit("Failed to rollback state", "err", err)
 		}
 	}
-	if bc.cacheConfig.TriesInMemory == 0 {
-		log.Info("Rewound to block (stateless mode)", "number", head.Number, "hash", head.Hash())
-	} else {
-		log.Info("Rewound to block with state", "number", head.Number, "hash", head.Hash())
-	}
+	log.Info("Rewound to block with state", "number", head.Number, "hash", head.Hash())
 	return head, rootNumber
 }
 
@@ -1196,7 +1164,12 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 		// nolint:nestif
 		if currentBlock := bc.CurrentBlock(); currentBlock != nil && header.Number.Uint64() <= currentBlock.Number.Uint64() {
 			var newHeadBlock *types.Header
-			newHeadBlock, rootNumber = bc.rewindHead(header, root)
+			if !bc.cacheConfig.Stateless {
+				newHeadBlock, rootNumber = bc.rewindHead(header, root)
+			} else {
+				newHeadBlock = header
+				rootNumber = header.Number.Uint64()
+			}
 			rawdb.WriteHeadBlockHash(db, newHeadBlock.Hash())
 
 			// Degrade the chain markers if they are explicitly reverted.
@@ -1211,8 +1184,8 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, time uint64, root common.Ha
 			// the pivot point. In this scenario, there is no possible recovery
 			// approach except for rerunning a snap sync. Do nothing here until the
 			// state syncer picks it up.
-			// Skip state checking for stateless nodes (TriesInMemory == 0)
-			if bc.cacheConfig.TriesInMemory > 0 && !bc.HasState(newHeadBlock.Root) {
+			// Skip state checking for stateless nodes
+			if !bc.cacheConfig.Stateless && !bc.HasState(newHeadBlock.Root) {
 				if newHeadBlock.Number.Uint64() != 0 {
 					log.Crit("Chain is stateless at a non-genesis block")
 				}
@@ -1515,7 +1488,7 @@ func (bc *BlockChain) Stop() {
 	}
 	if bc.triedb.Scheme() == rawdb.PathScheme {
 		// Ensure that the in-memory trie nodes are journaled to disk properly.
-		if bc.cacheConfig.TriesInMemory > 0 {
+		if !bc.cacheConfig.Stateless {
 			if err := bc.triedb.Journal(bc.CurrentBlock().Root); err != nil {
 				log.Info("Failed to journal in-memory trie nodes", "err", err)
 			}

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -220,7 +220,6 @@ func ReadBytecodeSyncLastBlock(db ethdb.KeyValueReader) uint64 {
 
 // WriteBytecodeSyncLastBlock stores the last block number up to which bytecodes were synced.
 func WriteBytecodeSyncLastBlock(db ethdb.KeyValueWriter, block uint64) {
-	log.Info("Writing bytecode sync last block", "block", block)
 	if err := db.Put(bytecodeSyncLastBlockKey, encodeBlockNumber(block)); err != nil {
 		log.Crit("Failed to store bytecode sync last block", "err", err)
 	}

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -201,3 +201,53 @@ func WriteTransitionStatus(db ethdb.KeyValueWriter, data []byte) {
 		log.Crit("Failed to store the eth2 transition status", "err", err)
 	}
 }
+
+// ReadBytecodeSyncLastBlock retrieves the last block number up to which bytecodes were synced.
+func ReadBytecodeSyncLastBlock(db ethdb.KeyValueReader) uint64 {
+	data, err := db.Get(bytecodeSyncLastBlockKey)
+	if err != nil {
+		log.Debug("Failed to read bytecode sync last block", "err", err)
+		return 0
+	}
+	if len(data) != 8 {
+		log.Debug("Invalid bytecode sync last block data", "len", len(data))
+		return 0
+	}
+	block := decodeNumber(data)
+	log.Debug("Read bytecode sync last block", "block", block)
+	return block
+}
+
+// WriteBytecodeSyncLastBlock stores the last block number up to which bytecodes were synced.
+func WriteBytecodeSyncLastBlock(db ethdb.KeyValueWriter, block uint64) {
+	log.Info("Writing bytecode sync last block", "block", block)
+	if err := db.Put(bytecodeSyncLastBlockKey, encodeBlockNumber(block)); err != nil {
+		log.Crit("Failed to store bytecode sync last block", "err", err)
+	}
+}
+
+// ReadBytecodeSyncStateRoot retrieves the state root at the last synced block for validation.
+func ReadBytecodeSyncStateRoot(db ethdb.KeyValueReader) common.Hash {
+	data, _ := db.Get(bytecodeSyncStateRootKey)
+	if len(data) != common.HashLength {
+		return common.Hash{}
+	}
+	return common.BytesToHash(data)
+}
+
+// WriteBytecodeSyncStateRoot stores the state root at the last synced block for validation.
+func WriteBytecodeSyncStateRoot(db ethdb.KeyValueWriter, root common.Hash) {
+	if err := db.Put(bytecodeSyncStateRootKey, root.Bytes()); err != nil {
+		log.Crit("Failed to store bytecode sync state root", "err", err)
+	}
+}
+
+// DeleteBytecodeSyncMetadata removes the bytecode sync metadata from the database.
+func DeleteBytecodeSyncMetadata(db ethdb.KeyValueWriter) {
+	if err := db.Delete(bytecodeSyncLastBlockKey); err != nil {
+		log.Crit("Failed to delete bytecode sync last block", "err", err)
+	}
+	if err := db.Delete(bytecodeSyncStateRootKey); err != nil {
+		log.Crit("Failed to delete bytecode sync state root", "err", err)
+	}
+}

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -102,6 +102,12 @@ var (
 	// snapSyncStatusFlagKey flags that status of snap sync.
 	snapSyncStatusFlagKey = []byte("SnapSyncStatus")
 
+	// bytecodeSyncLastBlockKey tracks the last block number up to which bytecodes were synced.
+	bytecodeSyncLastBlockKey = []byte("BytecodeSyncLastBlock")
+
+	// bytecodeSyncStateRootKey tracks the state root at the last synced block for validation.
+	bytecodeSyncStateRootKey = []byte("BytecodeSyncStateRoot")
+
 	// Data item prefixes (use single byte to avoid mixing data types, avoid `i`, used for indexes).
 	headerPrefix       = []byte("h") // headerPrefix + num (uint64 big endian) + hash -> header
 	headerTDSuffix     = []byte("t") // headerPrefix + num (uint64 big endian) + hash + headerTDSuffix -> td

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -992,10 +992,6 @@ func (s *StateDB) getStateObject(addr common.Address) *stateObject {
 			return nil
 		}
 		s.AccountReads += time.Since(start)
-		// Short circuit if the account is not found
-		if acct == nil {
-			return nil
-		}
 		// Independent of where we loaded the data from, add it to the prefetcher.
 		// Whilst this would be a bit weird if snapshots are disabled, but we still
 		// want the trie nodes to end up in the prefetcher too, so just push through.
@@ -1003,6 +999,10 @@ func (s *StateDB) getStateObject(addr common.Address) *stateObject {
 			if err = s.prefetcher.prefetch(common.Hash{}, s.originalRoot, common.Address{}, []common.Address{addr}, nil, true); err != nil {
 				log.Error("Failed to prefetch account", "addr", addr, "err", err)
 			}
+		}
+		// Short circuit if the account is not found
+		if acct == nil {
+			return nil
 		}
 		// Insert into the live set
 		obj := newObject(s, addr, acct)

--- a/core/stateless.go
+++ b/core/stateless.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
@@ -41,7 +42,7 @@ import (
 //   - It cannot be placed outside of core, because it needs to construct a dud headerchain
 //
 // TODO(karalabe): Would be nice to resolve both issues above somehow and move it.
-func ExecuteStateless(config *params.ChainConfig, vmconfig vm.Config, block *types.Block, witness *stateless.Witness, author *common.Address, consensus consensus.Engine) (common.Hash, common.Hash, error) {
+func ExecuteStateless(config *params.ChainConfig, vmconfig vm.Config, block *types.Block, witness *stateless.Witness, author *common.Address, consensus consensus.Engine, diskdb ethdb.Database) (common.Hash, common.Hash, *state.StateDB, error) {
 	// Sanity check if the supplied block accidentally contains a set root or
 	// receipt hash. If so, be very loud, but still continue.
 	if block.Root() != (common.Hash{}) {
@@ -51,10 +52,10 @@ func ExecuteStateless(config *params.ChainConfig, vmconfig vm.Config, block *typ
 		log.Error("stateless runner received receipt root it's expected to calculate (faulty consensus client)", "block", block.Number())
 	}
 	// Create and populate the state database to serve as the stateless backend
-	memdb := witness.MakeHashDB()
+	memdb := witness.MakeHashDB(diskdb)
 	db, err := state.New(witness.Root(), state.NewDatabase(triedb.NewDatabase(memdb, triedb.HashDefaults), nil))
 	if err != nil {
-		return common.Hash{}, common.Hash{}, err
+		return common.Hash{}, common.Hash{}, nil, err
 	}
 	// Create a blockchain that is idle, but can be used to access headers through
 	headerChain := &HeaderChain{
@@ -68,14 +69,14 @@ func ExecuteStateless(config *params.ChainConfig, vmconfig vm.Config, block *typ
 
 	res, err := processor.Process(block, db, vmconfig, author, context.Background())
 	if err != nil {
-		return common.Hash{}, common.Hash{}, err
+		return common.Hash{}, common.Hash{}, nil, err
 	}
 
 	if err = validator.ValidateState(block, db, res, true); err != nil {
-		return common.Hash{}, common.Hash{}, err
+		return common.Hash{}, common.Hash{}, nil, err
 	}
 	// Almost everything validated, but receipt and state root needs to be returned
 	receiptRoot := types.DeriveSha(res.Receipts, trie.NewStackTrie(nil))
 	stateRoot := db.IntermediateRoot(config.IsEIP158(block.Number()))
-	return stateRoot, receiptRoot, nil
+	return stateRoot, receiptRoot, db, nil
 }

--- a/core/stateless/database.go
+++ b/core/stateless/database.go
@@ -23,6 +23,81 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
+// CodeRoutingDB is a database that routes code reads/writes to the diskdb.
+type CodeRoutingDB struct {
+	ethdb.Database
+	diskdb ethdb.Database
+}
+
+func NewCodeRoutingDB(diskdb ethdb.Database) *CodeRoutingDB {
+	return &CodeRoutingDB{
+		Database: rawdb.NewMemoryDatabase(),
+		diskdb:   diskdb,
+	}
+}
+
+func (db *CodeRoutingDB) Get(key []byte) ([]byte, error) {
+	if ok, _ := rawdb.IsCodeKey(key); ok {
+		return db.diskdb.Get(key)
+	}
+	return db.Database.Get(key)
+}
+
+func (db *CodeRoutingDB) Has(key []byte) (bool, error) {
+	if ok, _ := rawdb.IsCodeKey(key); ok {
+		return db.diskdb.Has(key)
+	}
+	return db.Database.Has(key)
+}
+
+func (db *CodeRoutingDB) Put(key []byte, value []byte) error {
+	if ok, _ := rawdb.IsCodeKey(key); ok {
+		return db.diskdb.Put(key, value)
+	}
+	return db.Database.Put(key, value)
+}
+
+func (db *CodeRoutingDB) Delete(key []byte) error {
+	if ok, _ := rawdb.IsCodeKey(key); ok {
+		return db.diskdb.Delete(key)
+	}
+	return db.Database.Delete(key)
+}
+
+// CodeRoutingBatch is a batch that routes code writes to the diskdb
+type CodeRoutingBatch struct {
+	ethdb.Batch
+	diskdb ethdb.Database
+}
+
+func (b *CodeRoutingBatch) Put(key []byte, value []byte) error {
+	if ok, _ := rawdb.IsCodeKey(key); ok {
+		return b.diskdb.Put(key, value)
+	}
+	return b.Batch.Put(key, value)
+}
+
+func (b *CodeRoutingBatch) Delete(key []byte) error {
+	if ok, _ := rawdb.IsCodeKey(key); ok {
+		return b.diskdb.Delete(key)
+	}
+	return b.Batch.Delete(key)
+}
+
+func (db *CodeRoutingDB) NewBatch() ethdb.Batch {
+	return &CodeRoutingBatch{
+		Batch:  db.Database.NewBatch(),
+		diskdb: db.diskdb,
+	}
+}
+
+func (db *CodeRoutingDB) NewBatchWithSize(size int) ethdb.Batch {
+	return &CodeRoutingBatch{
+		Batch:  db.Database.NewBatchWithSize(size),
+		diskdb: db.diskdb,
+	}
+}
+
 // MakeHashDB imports tries, codes and block hashes from a witness into a new
 // hash-based memory db. We could eventually rewrite this into a pathdb, but
 // simple is better for now.
@@ -33,25 +108,15 @@ import (
 //   - Trie nodes are persisted keyed by hash, so trie expansion will error on junk
 //
 // Acceleration structures built would need to explicitly validate the witness.
-func (w *Witness) MakeHashDB() ethdb.Database {
+func (w *Witness) MakeHashDB(diskdb ethdb.Database) ethdb.Database {
 	var (
-		memdb  = rawdb.NewMemoryDatabase()
-		hasher = crypto.NewKeccakState()
-		hash   = make([]byte, 32)
+		routingDB = NewCodeRoutingDB(diskdb)
+		hasher    = crypto.NewKeccakState()
+		hash      = make([]byte, 32)
 	)
 	// Inject all the "block hashes" (i.e. headers) into the ephemeral database
 	for _, header := range w.Headers {
-		rawdb.WriteHeader(memdb, header)
-	}
-	// Inject all the bytecodes into the ephemeral database
-	for code := range w.Codes {
-		blob := []byte(code)
-
-		hasher.Reset()
-		hasher.Write(blob)
-		hasher.Read(hash)
-
-		rawdb.WriteCode(memdb, common.BytesToHash(hash), blob)
+		rawdb.WriteHeader(routingDB, header)
 	}
 	// Inject all the MPT trie nodes into the ephemeral database
 	for node := range w.State {
@@ -61,7 +126,7 @@ func (w *Witness) MakeHashDB() ethdb.Database {
 		hasher.Write(blob)
 		hasher.Read(hash)
 
-		rawdb.WriteLegacyTrieNode(memdb, common.BytesToHash(hash), blob)
+		rawdb.WriteLegacyTrieNode(routingDB, common.BytesToHash(hash), blob)
 	}
-	return memdb
+	return routingDB
 }

--- a/core/stateless/database_test.go
+++ b/core/stateless/database_test.go
@@ -1,0 +1,377 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package stateless
+
+import (
+	"bytes"
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// codeKey returns the database key for contract code using the same
+// format as rawdb (CodePrefix + hash)
+func makeCodeKey(hash common.Hash) []byte {
+	// CodePrefix is "c" as defined in rawdb/schema.go
+	return append([]byte("c"), hash.Bytes()...)
+}
+
+// TestCodeRoutingDB tests that CodeRoutingDB correctly routes code operations to diskdb
+func TestCodeRoutingDB(t *testing.T) {
+	diskdb := rawdb.NewMemoryDatabase()
+	routingDB := NewCodeRoutingDB(diskdb)
+
+	// Test data
+	codeHash := crypto.Keccak256Hash([]byte("test code"))
+	codeKey := makeCodeKey(codeHash)
+	codeData := []byte("contract bytecode")
+
+	nonCodeKey := []byte("not-a-code-key")
+	nonCodeData := []byte("some other data")
+
+	// Test Put operations
+	if err := routingDB.Put(codeKey, codeData); err != nil {
+		t.Fatalf("Failed to put code: %v", err)
+	}
+	if err := routingDB.Put(nonCodeKey, nonCodeData); err != nil {
+		t.Fatalf("Failed to put non-code data: %v", err)
+	}
+
+	// Verify code was stored in diskdb
+	if data, err := diskdb.Get(codeKey); err != nil {
+		t.Fatalf("Code not found in diskdb: %v", err)
+	} else if !bytes.Equal(data, codeData) {
+		t.Fatalf("Code data mismatch in diskdb: got %v, want %v", data, codeData)
+	}
+
+	// Verify non-code was stored in memory db
+	if _, err := diskdb.Get(nonCodeKey); err == nil {
+		t.Fatalf("Non-code data should not be in diskdb")
+	}
+
+	// Test Get operations
+	if data, err := routingDB.Get(codeKey); err != nil {
+		t.Fatalf("Failed to get code: %v", err)
+	} else if !bytes.Equal(data, codeData) {
+		t.Fatalf("Code data mismatch: got %v, want %v", data, codeData)
+	}
+
+	if data, err := routingDB.Get(nonCodeKey); err != nil {
+		t.Fatalf("Failed to get non-code data: %v", err)
+	} else if !bytes.Equal(data, nonCodeData) {
+		t.Fatalf("Non-code data mismatch: got %v, want %v", data, nonCodeData)
+	}
+
+	// Test Has operations
+	if has, err := routingDB.Has(codeKey); err != nil || !has {
+		t.Fatalf("Code should exist: err=%v, has=%v", err, has)
+	}
+	if has, err := routingDB.Has(nonCodeKey); err != nil || !has {
+		t.Fatalf("Non-code data should exist: err=%v, has=%v", err, has)
+	}
+
+	// Test Delete operations
+	if err := routingDB.Delete(codeKey); err != nil {
+		t.Fatalf("Failed to delete code: %v", err)
+	}
+	if has, err := diskdb.Has(codeKey); err != nil || has {
+		t.Fatalf("Code should be deleted from diskdb: err=%v, has=%v", err, has)
+	}
+}
+
+// TestCodeRoutingBatch tests that batch operations correctly route to diskdb
+func TestCodeRoutingBatch(t *testing.T) {
+	diskdb := rawdb.NewMemoryDatabase()
+	routingDB := NewCodeRoutingDB(diskdb)
+
+	// Test batch operations
+	batch := routingDB.NewBatch()
+
+	// Add multiple code and non-code entries
+	codes := make(map[common.Hash][]byte)
+	nonCodes := make(map[string][]byte)
+
+	for i := 0; i < 5; i++ {
+		// Code entries
+		code := []byte{byte(i), byte(i + 1), byte(i + 2)}
+		hash := crypto.Keccak256Hash(code)
+		codes[hash] = code
+		batch.Put(makeCodeKey(hash), code)
+
+		// Non-code entries
+		key := []byte{byte(i + 10)}
+		data := []byte{byte(i + 20)}
+		nonCodes[string(key)] = data
+		batch.Put(key, data)
+	}
+
+	// Write batch
+	if err := batch.Write(); err != nil {
+		t.Fatalf("Failed to write batch: %v", err)
+	}
+
+	// Verify codes are in diskdb
+	for hash, code := range codes {
+		if data, err := diskdb.Get(makeCodeKey(hash)); err != nil {
+			t.Fatalf("Code not found in diskdb: %v", err)
+		} else if !bytes.Equal(data, code) {
+			t.Fatalf("Code data mismatch in diskdb")
+		}
+	}
+
+	// Verify non-codes are not in diskdb
+	for key := range nonCodes {
+		if _, err := diskdb.Get([]byte(key)); err == nil {
+			t.Fatalf("Non-code data should not be in diskdb")
+		}
+	}
+}
+
+// TestCodeRoutingConcurrent tests concurrent access to CodeRoutingDB
+func TestCodeRoutingConcurrent(t *testing.T) {
+	diskdb := rawdb.NewMemoryDatabase()
+	routingDB := NewCodeRoutingDB(diskdb)
+
+	const goroutines = 10
+	const opsPerGoroutine = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	// Concurrent writes
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				// Write code
+				code := []byte{byte(id), byte(i)}
+				hash := crypto.Keccak256Hash(code)
+				if err := routingDB.Put(makeCodeKey(hash), code); err != nil {
+					t.Errorf("Failed to put code: %v", err)
+				}
+
+				// Write non-code
+				key := []byte{byte(id + 100), byte(i)}
+				data := []byte{byte(id + 200), byte(i)}
+				if err := routingDB.Put(key, data); err != nil {
+					t.Errorf("Failed to put non-code: %v", err)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Concurrent reads
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				// Read code
+				code := []byte{byte(id), byte(i)}
+				hash := crypto.Keccak256Hash(code)
+				if data, err := routingDB.Get(makeCodeKey(hash)); err != nil {
+					t.Errorf("Failed to get code: %v", err)
+				} else if !bytes.Equal(data, code) {
+					t.Errorf("Code data mismatch")
+				}
+
+				// Read non-code
+				key := []byte{byte(id + 100), byte(i)}
+				expectedData := []byte{byte(id + 200), byte(i)}
+				if data, err := routingDB.Get(key); err != nil {
+					t.Errorf("Failed to get non-code: %v", err)
+				} else if !bytes.Equal(data, expectedData) {
+					t.Errorf("Non-code data mismatch")
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// TestMakeHashDBWithDiskDB tests witness import with code routing to disk
+func TestMakeHashDBWithDiskDB(t *testing.T) {
+	// Create a disk database with some pre-existing codes
+	diskdb := rawdb.NewMemoryDatabase()
+
+	// Pre-populate diskdb with some codes
+	existingCode := []byte("existing contract code")
+	existingHash := crypto.Keccak256Hash(existingCode)
+	rawdb.WriteCode(diskdb, existingHash, existingCode)
+
+	// Create a witness with headers and state nodes
+	header := &types.Header{
+		Number:     big.NewInt(100),
+		ParentHash: common.HexToHash("0x1234"),
+		Root:       common.HexToHash("0x5678"),
+	}
+
+	witness, err := NewWitness(header, nil)
+	if err != nil {
+		t.Fatalf("Failed to create witness: %v", err)
+	}
+
+	// Add some headers
+	witness.Headers = []*types.Header{
+		header,
+		{
+			Number:     big.NewInt(99),
+			ParentHash: common.HexToHash("0xabcd"),
+			Root:       common.HexToHash("0xef01"),
+		},
+	}
+
+	// Add some state nodes
+	witness.State["node1"] = struct{}{}
+	witness.State["node2"] = struct{}{}
+
+	// Create hash DB from witness
+	hashDB := witness.MakeHashDB(diskdb)
+
+	// Verify headers were written
+	for _, hdr := range witness.Headers {
+		storedHeader := rawdb.ReadHeader(hashDB, hdr.Hash(), hdr.Number.Uint64())
+		if storedHeader == nil {
+			t.Fatalf("Header not found: %v", hdr.Hash())
+		}
+		if storedHeader.Number.Cmp(hdr.Number) != 0 {
+			t.Fatalf("Header number mismatch")
+		}
+	}
+
+	// Verify state nodes were written
+	hasher := crypto.NewKeccakState()
+	hash := make([]byte, 32)
+	for node := range witness.State {
+		blob := []byte(node)
+		hasher.Reset()
+		hasher.Write(blob)
+		hasher.Read(hash)
+
+		// Legacy trie nodes are stored directly by hash
+		if data, err := hashDB.Get(common.BytesToHash(hash).Bytes()); err != nil {
+			t.Fatalf("State node not found: %v", err)
+		} else if !bytes.Equal(data, blob) {
+			t.Fatalf("State node data mismatch")
+		}
+	}
+
+	// Verify pre-existing code is accessible through hashDB
+	if code := rawdb.ReadCode(hashDB, existingHash); code == nil {
+		t.Fatalf("Failed to get existing code")
+	} else if !bytes.Equal(code, existingCode) {
+		t.Fatalf("Existing code mismatch")
+	}
+
+	// Write new code through hashDB and verify it goes to diskdb
+	newCode := []byte("new contract code")
+	newHash := crypto.Keccak256Hash(newCode)
+	rawdb.WriteCode(hashDB, newHash, newCode)
+
+	// Verify new code is in diskdb
+	if code := rawdb.ReadCode(diskdb, newHash); code == nil {
+		t.Fatalf("New code not found in diskdb")
+	} else if !bytes.Equal(code, newCode) {
+		t.Fatalf("New code mismatch in diskdb")
+	}
+}
+
+// TestCodePersistenceAcrossWitnesses tests that codes persist across multiple witness imports
+func TestCodePersistenceAcrossWitnesses(t *testing.T) {
+	diskdb := rawdb.NewMemoryDatabase()
+
+	// First witness import - add some codes
+	witness1, _ := NewWitness(&types.Header{Number: big.NewInt(100)}, nil)
+	hashDB1 := witness1.MakeHashDB(diskdb)
+
+	code1 := []byte("contract1")
+	hash1 := crypto.Keccak256Hash(code1)
+	rawdb.WriteCode(hashDB1, hash1, code1)
+
+	// Second witness import - verify code1 is still accessible
+	witness2, _ := NewWitness(&types.Header{Number: big.NewInt(101)}, nil)
+	hashDB2 := witness2.MakeHashDB(diskdb)
+
+	// Verify code1 is accessible through new hashDB
+	if code := rawdb.ReadCode(hashDB2, hash1); code == nil {
+		t.Fatalf("Code1 not accessible in second import")
+	} else if !bytes.Equal(code, code1) {
+		t.Fatalf("Code1 data mismatch in second import")
+	}
+
+	// Add another code through second hashDB
+	code2 := []byte("contract2")
+	hash2 := crypto.Keccak256Hash(code2)
+	rawdb.WriteCode(hashDB2, hash2, code2)
+
+	// Third witness import - verify both codes are accessible
+	witness3, _ := NewWitness(&types.Header{Number: big.NewInt(102)}, nil)
+	hashDB3 := witness3.MakeHashDB(diskdb)
+
+	for hash, expectedCode := range map[common.Hash][]byte{hash1: code1, hash2: code2} {
+		if code := rawdb.ReadCode(hashDB3, hash); code == nil {
+			t.Fatalf("Code not accessible in third import")
+		} else if !bytes.Equal(code, expectedCode) {
+			t.Fatalf("Code data mismatch in third import")
+		}
+	}
+}
+
+// TestIsCodeKey tests the rawdb.IsCodeKey function with various inputs
+func TestIsCodeKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      []byte
+		expected bool
+	}{
+		{
+			name:     "Valid code key",
+			key:      makeCodeKey(common.HexToHash("0x1234")),
+			expected: true,
+		},
+		{
+			name:     "Header key",
+			key:      append(append([]byte("h"), make([]byte, 8)...), common.HexToHash("0x1234").Bytes()...),
+			expected: false,
+		},
+		{
+			name:     "Random key",
+			key:      []byte("random"),
+			expected: false,
+		},
+		{
+			name:     "Empty key",
+			key:      []byte{},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isCode, _ := rawdb.IsCodeKey(test.key)
+			if isCode != test.expected {
+				t.Errorf("IsCodeKey(%v) = %v, want %v", test.key, isCode, test.expected)
+			}
+		})
+	}
+}

--- a/core/stateless/encoding.go
+++ b/core/stateless/encoding.go
@@ -29,10 +29,6 @@ func (w *Witness) toExtWitness() *extWitness {
 		Context: w.context,
 		Headers: w.Headers,
 	}
-	ext.Codes = make([][]byte, 0, len(w.Codes))
-	for code := range w.Codes {
-		ext.Codes = append(ext.Codes, []byte(code))
-	}
 	ext.State = make([][]byte, 0, len(w.State))
 	for node := range w.State {
 		ext.State = append(ext.State, []byte(node))
@@ -44,11 +40,6 @@ func (w *Witness) toExtWitness() *extWitness {
 func (w *Witness) fromExtWitness(ext *extWitness) error {
 	w.context = ext.Context
 	w.Headers = ext.Headers
-
-	w.Codes = make(map[string]struct{}, len(ext.Codes))
-	for _, code := range ext.Codes {
-		w.Codes[string(code)] = struct{}{}
-	}
 	w.State = make(map[string]struct{}, len(ext.State))
 	for _, node := range ext.State {
 		w.State[string(node)] = struct{}{}
@@ -74,6 +65,5 @@ func (w *Witness) DecodeRLP(s *rlp.Stream) error {
 type extWitness struct {
 	Context *types.Header
 	Headers []*types.Header
-	Codes   [][]byte
 	State   [][]byte
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -245,6 +245,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 
 	if config.SyncMode == downloader.StatelessSync {
 		cacheConfig.TriesInMemory = 0
+		cacheConfig.Stateless = true
 	}
 
 	if config.VMTrace != "" {

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -1005,7 +1005,7 @@ func (api *ConsensusAPI) executeStatelessPayload(params engine.ExecutableData, v
 	api.lastNewPayloadLock.Unlock()
 
 	log.Trace("Executing block statelessly", "number", block.Number(), "hash", params.BlockHash)
-	stateRoot, receiptRoot, err := core.ExecuteStateless(api.eth.BlockChain().Config(), *api.eth.BlockChain().GetVMConfig(), block, witness, nil, api.eth.Engine())
+	stateRoot, receiptRoot, _, err := core.ExecuteStateless(api.eth.BlockChain().Config(), *api.eth.BlockChain().GetVMConfig(), block, witness, nil, api.eth.Engine(), nil)
 	if err != nil {
 		log.Warn("ExecuteStatelessPayload: execution failed", "err", err)
 		errorMsg := err.Error()

--- a/eth/downloader/bor_downloader.go
+++ b/eth/downloader/bor_downloader.go
@@ -588,7 +588,34 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 
 	var origin uint64
 	if mode == StatelessSync {
-		origin = d.GetOrWaitFastForwardBlock()
+		// Get the fast forward block first
+		fastForwardBlock := d.GetOrWaitFastForwardBlock()
+
+		// Check if we need to download bytecodes before starting stateless sync
+		if d.needsBytecodeSync(fastForwardBlock) {
+			log.Info("Starting bytecode-only snap sync before stateless sync", "fastForwardBlock", fastForwardBlock)
+
+			// We need the header at fastForwardBlock as the pivot for bytecode sync
+			// Request it from the peer since we might not have it locally
+			headers, _, err := d.fetchHeadersByNumber(p, fastForwardBlock, 1, 0, false)
+			if err != nil || len(headers) == 0 {
+				log.Warn("Failed to fetch fastForwardBlock header, using latest as fallback",
+					"fastForwardBlock", fastForwardBlock, "err", err)
+				// Fallback to latest if we can't get the specific block
+				headers = []*types.Header{latest}
+			}
+			pivotHeader := headers[0]
+
+			// Run bytecode-only snap sync
+			if err := d.runBytecodeOnlySnapSync(p, pivotHeader); err != nil {
+				log.Error("Bytecode-only snap sync failed", "err", err)
+				return fmt.Errorf("bytecode-only snap sync failed: %w", err)
+			}
+
+			log.Info("Bytecode-only snap sync completed, continuing with stateless sync")
+		}
+
+		origin = fastForwardBlock
 	} else if !beaconMode {
 		// In legacy mode, reach out to the network and find the ancestor
 		origin, err = d.findAncestor(p, latest)
@@ -2122,6 +2149,18 @@ func (d *Downloader) importBlockResultsStateless(results []*fetchResult) error {
 		log.Warn("Invalid block body", "index", index, "hash", blocks[index].Hash(), "err", err)
 		return errInvalidBody // Or a more specific error if possible
 	}
+
+	// Update bytecode sync last block to prevent re-triggering bytecode sync
+	// during active stateless sync when the fast forward block advances
+	if len(blocks) > 0 {
+		lastBlock := blocks[len(blocks)-1].NumberU64()
+		currentBytecodeSyncBlock := rawdb.ReadBytecodeSyncLastBlock(d.stateDB)
+		if lastBlock > currentBytecodeSyncBlock {
+			rawdb.WriteBytecodeSyncLastBlock(d.stateDB, lastBlock)
+			log.Debug("Updated bytecode sync last block during stateless sync", "block", lastBlock)
+		}
+	}
+
 	return nil
 }
 
@@ -2229,4 +2268,91 @@ func (d *Downloader) setFastForwardBlock(nextFastForward uint64) {
 	case d.fastForwardBlockCh <- d.fastForwardBlock:
 	default:
 	}
+}
+
+// needsBytecodeSync checks if bytecode-only snap sync is needed before stateless sync
+func (d *Downloader) needsBytecodeSync(fastForwardBlock uint64) bool {
+	if fastForwardBlock == 0 {
+		fastForwardBlock = d.GetOrWaitFastForwardBlock()
+	}
+
+	// Get the current fast forward block to compare against completed block
+	currentBlock := d.blockchain.CurrentBlock().Number.Uint64()
+
+	// Check if the gap between current block and fast forward block is less than threshold
+	// If so, we don't need bytecode sync regardless of previous sync state
+	gap := int64(fastForwardBlock) - int64(currentBlock)
+	if gap <= int64(d.FastForwardThreshold) {
+		log.Info("Bytecode sync skipped: gap less than FastForwardThreshold",
+			"currentBlock", currentBlock, "fastForwardBlock", fastForwardBlock,
+			"gap", gap, "threshold", d.FastForwardThreshold)
+		return false
+	}
+
+	// Read the last synced block from the database
+	lastSyncedBlock := rawdb.ReadBytecodeSyncLastBlock(d.stateDB)
+
+	// If we haven't synced any bytecodes yet and gap is significant, we need to sync
+	if lastSyncedBlock == 0 {
+		log.Info("Bytecode sync needed: no previous sync found",
+			"fastForwardBlock", fastForwardBlock, "currentBlock", currentBlock,
+			"gap", gap, "threshold", d.FastForwardThreshold)
+		return true
+	}
+
+	// If the fast forward block has moved beyond our last sync, we need to sync
+	if lastSyncedBlock < fastForwardBlock {
+		log.Info("Bytecode sync needed: fast forward block moved",
+			"lastSyncedBlock", lastSyncedBlock, "fastForwardBlock", fastForwardBlock,
+			"currentBlock", currentBlock, "gap", gap)
+		return true
+	}
+
+	// Bytecode sync is already complete up to or beyond the fast forward block
+	log.Debug("Bytecode sync not needed", "lastSyncedBlock", lastSyncedBlock, "fastForwardBlock", fastForwardBlock)
+	return false
+}
+
+// runBytecodeOnlySnapSync performs a bytecode-only snap sync before stateless sync
+func (d *Downloader) runBytecodeOnlySnapSync(p *peerConnection, pivot *types.Header) error {
+	// Save current mode to restore later
+	oldMode := d.getMode()
+
+	// Switch to bytecode-only snap sync mode
+	d.mode.Store(uint32(BytecodeOnlySnapSync))
+	defer d.mode.Store(uint32(oldMode)) // Restore mode on exit
+
+	// Set up the pivot for snap sync
+	d.pivotLock.Lock()
+	d.pivotHeader = pivot
+	d.pivotLock.Unlock()
+
+	// Write the pivot number to database
+	rawdb.WriteLastPivotNumber(d.stateDB, pivot.Number.Uint64())
+
+	log.Info("Starting bytecode-only snap sync", "pivot", pivot.Number, "hash", pivot.Hash())
+
+	// Configure the snap syncer for bytecode-only mode
+	d.SnapSyncer.SetBytecodeOnlyMode(true)
+	defer d.SnapSyncer.SetBytecodeOnlyMode(false)
+
+	// Mark snap sync as running (this tells the snap syncer we're in snap sync mode)
+	rawdb.WriteSnapSyncStatusFlag(d.stateDB, rawdb.StateSyncRunning)
+
+	// Start the state sync at the pivot root
+	sync := d.syncState(pivot.Root)
+
+	// Wait for sync to complete
+	if err := sync.Wait(); err != nil {
+		return fmt.Errorf("bytecode-only snap sync failed: %w", err)
+	}
+
+	// Mark bytecode-only sync as completed up to this pivot block
+	rawdb.WriteBytecodeSyncLastBlock(d.stateDB, pivot.Number.Uint64())
+	rawdb.WriteBytecodeSyncStateRoot(d.stateDB, pivot.Root)
+
+	// Verify the write was successful
+	verifyBlock := rawdb.ReadBytecodeSyncLastBlock(d.stateDB)
+	log.Info("Bytecode-only snap sync completed successfully", "completedBlock", pivot.Number.Uint64(), "verifiedBlock", verifyBlock)
+	return nil
 }

--- a/eth/downloader/modes.go
+++ b/eth/downloader/modes.go
@@ -23,13 +23,14 @@ import "fmt"
 type SyncMode uint32
 
 const (
-	FullSync      SyncMode = iota // Synchronise the entire blockchain history from full blocks
-	SnapSync                      // Download the chain and the state via compact snapshots
-	StatelessSync                 // Start syncing from an arbitrary block without requiring history
+	FullSync             SyncMode = iota // Synchronise the entire blockchain history from full blocks
+	SnapSync                             // Download the chain and the state via compact snapshots
+	StatelessSync                        // Start syncing from an arbitrary block without requiring history
+	BytecodeOnlySnapSync                 // Internal mode: Download only bytecodes via snap sync before stateless sync
 )
 
 func (mode SyncMode) IsValid() bool {
-	return mode == FullSync || mode == SnapSync || mode == StatelessSync
+	return mode == FullSync || mode == SnapSync || mode == StatelessSync || mode == BytecodeOnlySnapSync
 }
 
 // String implements the stringer interface.
@@ -41,6 +42,8 @@ func (mode SyncMode) String() string {
 		return "snap"
 	case StatelessSync:
 		return "stateless"
+	case BytecodeOnlySnapSync:
+		return "bytecode"
 	default:
 		return "unknown"
 	}
@@ -54,6 +57,8 @@ func (mode SyncMode) MarshalText() ([]byte, error) {
 		return []byte("snap"), nil
 	case StatelessSync:
 		return []byte("stateless"), nil
+	case BytecodeOnlySnapSync:
+		return []byte("bytecode"), nil
 	default:
 		return nil, fmt.Errorf("unknown sync mode %d", mode)
 	}
@@ -67,6 +72,8 @@ func (mode *SyncMode) UnmarshalText(text []byte) error {
 		*mode = SnapSync
 	case "stateless":
 		*mode = StatelessSync
+	case "bytecode":
+		*mode = BytecodeOnlySnapSync
 	default:
 		return fmt.Errorf(`unknown sync mode %q, want "full", "snap", or "stateless"`, text)
 	}

--- a/eth/fetcher/witness_manager_test.go
+++ b/eth/fetcher/witness_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/protocols/wit"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
@@ -671,6 +672,117 @@ func TestCleanupUnavailableCache(t *testing.T) {
 
 	if cacheSize != 1 {
 		t.Errorf("Expected cache size 1 after cleanup, got %d", cacheSize)
+	}
+}
+
+// TestWitnessFetchWithBlockNoLongerPending tests the new error handling when a block
+// is removed from pending during witness fetch
+func TestWitnessFetchWithBlockNoLongerPending(t *testing.T) {
+	quit := make(chan struct{})
+	defer close(quit)
+
+	dropPeer := peerDropFn(func(id string) {})
+	enqueueCh := make(chan *enqueueRequest, 10)
+	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
+	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
+	chainHeight := chainHeightFn(func() uint64 { return 100 })
+
+	manager := newWitnessManager(
+		quit,
+		dropPeer,
+		enqueueCh,
+		getBlock,
+		getHeader,
+		chainHeight,
+	)
+
+	block := createTestBlock(101)
+	blockHash := block.Hash()
+	witness := createTestWitnessForBlock(block)
+
+	// Create a channel to control witness fetch timing
+	fetchStarted := make(chan struct{})
+	responseSent := false
+
+	fetchWitness := func(hash common.Hash, responseCh chan *wit.Response) (*wit.Request, error) {
+		// Signal that fetch has started
+		close(fetchStarted)
+
+		// Send the response in a goroutine
+		go func() {
+			// Wait a bit to ensure we're in the middle of processing
+			time.Sleep(10 * time.Millisecond)
+
+			// Before sending response, remove block from pending
+			manager.mu.Lock()
+			delete(manager.pending, blockHash)
+			manager.mu.Unlock()
+
+			// Now send the response with the correct structure
+			witnessBytes, _ := rlp.EncodeToBytes(witness)
+			responseCh <- &wit.Response{
+				Res: &wit.WitnessPacketRLPPacket{
+					WitnessPacketResponse: wit.WitnessPacketResponse{rlp.RawValue(witnessBytes)},
+				},
+				Done: make(chan error, 1),
+			}
+			responseSent = true
+		}()
+
+		// Return successful request
+		req := &wit.Request{
+			Peer: "test-peer",
+			Sent: time.Now(),
+		}
+		return req, nil
+	}
+
+	// Create message to inject block that needs witness
+	msg := &injectBlockNeedWitnessMsg{
+		origin:       "test-peer",
+		block:        block,
+		time:         time.Now(),
+		fetchWitness: fetchWitness,
+	}
+
+	// Inject the block
+	manager.handleNeed(msg)
+
+	// Verify block is pending
+	manager.mu.Lock()
+	if _, exists := manager.pending[blockHash]; !exists {
+		t.Fatal("Block should be pending after handleNeed")
+	}
+	manager.mu.Unlock()
+
+	// Trigger tick to start witness fetch
+	manager.tick()
+
+	// Wait for fetch to start
+	<-fetchStarted
+
+	// Give time for the response to be processed
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify response was sent and block is no longer pending
+	if !responseSent {
+		t.Error("Response should have been sent")
+	}
+
+	manager.mu.Lock()
+	_, exists := manager.pending[blockHash]
+	manager.mu.Unlock()
+
+	if exists {
+		t.Error("Block should not be pending after being removed during fetch")
+	}
+
+	// Check that no enqueue occurred (since block was removed from pending)
+	select {
+	case <-enqueueCh:
+		t.Error("Should not enqueue block that was removed from pending")
+	default:
+		// Expected - no enqueue
 	}
 }
 
@@ -2035,5 +2147,134 @@ func TestConcurrentWitnessFetchFailure(t *testing.T) {
 
 	if failureCount != numGoroutines {
 		t.Errorf("Expected failure count %d, got %d", numGoroutines, failureCount)
+	}
+}
+
+// TestHandleWitnessFetchSuccessWithBlockNoLongerPending tests handleWitnessFetchSuccess
+// when block is no longer pending
+func TestHandleWitnessFetchSuccessWithBlockNoLongerPending(t *testing.T) {
+	quit := make(chan struct{})
+	defer close(quit)
+
+	dropPeer := peerDropFn(func(id string) {})
+	enqueueCh := make(chan *enqueueRequest, 10)
+	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
+	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
+	chainHeight := chainHeightFn(func() uint64 { return 100 })
+
+	manager := newWitnessManager(
+		quit,
+		dropPeer,
+		enqueueCh,
+		getBlock,
+		getHeader,
+		chainHeight,
+	)
+
+	// Create test data
+	block := createTestBlock(101)
+	hash := block.Hash()
+	witness := createTestWitnessForBlock(block)
+
+	// First add the block to pending
+	manager.mu.Lock()
+	manager.pending[hash] = &witnessRequestState{
+		op: &blockOrHeaderInject{
+			origin: "test-peer",
+			block:  block,
+		},
+		announce: &blockAnnounce{
+			origin: "test-peer",
+			hash:   hash,
+			number: block.NumberU64(),
+			time:   time.Now(),
+		},
+	}
+	manager.mu.Unlock()
+
+	// Remove it to simulate the scenario
+	manager.mu.Lock()
+	delete(manager.pending, hash)
+	manager.mu.Unlock()
+
+	// Call handleWitnessFetchSuccess - should handle gracefully
+	manager.handleWitnessFetchSuccess("test-peer", hash, witness, time.Now())
+
+	// Verify no enqueue occurred
+	select {
+	case <-enqueueCh:
+		t.Error("Should not enqueue when block is no longer pending")
+	default:
+		// Expected - no enqueue
+	}
+}
+
+// TestFetchWitnessWithBlockRemovedBeforeError tests that when a block is removed from pending
+// before a fetch error occurs, the peer is not penalized
+func TestFetchWitnessWithBlockRemovedBeforeError(t *testing.T) {
+	quit := make(chan struct{})
+	defer close(quit)
+
+	dropPeer := peerDropFn(func(id string) {})
+	enqueueCh := make(chan *enqueueRequest, 10)
+	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
+	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
+	chainHeight := chainHeightFn(func() uint64 { return 100 })
+
+	manager := newWitnessManager(
+		quit,
+		dropPeer,
+		enqueueCh,
+		getBlock,
+		getHeader,
+		chainHeight,
+	)
+
+	// Create test data
+	block := createTestBlock(101)
+	hash := block.Hash()
+
+	// Track original failure count
+	originalFailures := 0
+
+	// Create a mock fetchWitness that removes block from pending before error
+	fetchWitness := func(h common.Hash, resCh chan *wit.Response) (*wit.Request, error) {
+		// Remove block from pending before returning error
+		manager.mu.Lock()
+		delete(manager.pending, hash)
+		originalFailures = manager.failedWitnessAttempts["test-peer"]
+		manager.mu.Unlock()
+
+		// Return an error - this should trigger the check for pending status
+		return nil, errors.New("simulated fetch error")
+	}
+
+	// Add block to pending
+	manager.mu.Lock()
+	manager.pending[hash] = &witnessRequestState{
+		op: &blockOrHeaderInject{
+			origin: "test-peer",
+			block:  block,
+		},
+		announce: &blockAnnounce{
+			origin:       "test-peer",
+			hash:         hash,
+			number:       block.NumberU64(),
+			time:         time.Now().Add(-time.Second), // Make it ready to fetch
+			fetchWitness: fetchWitness,
+		},
+	}
+	manager.mu.Unlock()
+
+	// Call fetchWitness directly to simulate the fetch attempt
+	manager.fetchWitness("test-peer", hash, manager.pending[hash].announce)
+
+	// Verify peer was not penalized (failure count should not increase)
+	manager.mu.Lock()
+	currentFailures := manager.failedWitnessAttempts["test-peer"]
+	manager.mu.Unlock()
+
+	if currentFailures > originalFailures {
+		t.Errorf("Peer should not be penalized when block is no longer pending, failures increased from %d to %d", originalFailures, currentFailures)
 	}
 }

--- a/eth/fetcher/witness_manager_test.go
+++ b/eth/fetcher/witness_manager_test.go
@@ -2006,7 +2006,7 @@ func TestConcurrentWitnessFetchFailure(t *testing.T) {
 	)
 
 	// Start the manager
-	go manager.loop()
+	manager.start()
 	defer manager.stop()
 
 	hash := common.HexToHash("0x123")

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -18,6 +18,8 @@ package eth
 
 import (
 	"errors"
+	"math/rand"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
@@ -80,95 +82,123 @@ func (p *witPeer) info() *witPeerInfo {
 	}
 }
 
-// ethWitRequest wraps an eth.Request and holds the underlying wit.Request.
-// This allows the downloader to track the request lifecycle via the eth.Request
-// while allowing cancellation to be passed to the wit.Request.
-type ethWitRequest struct {
-	*eth.Request              // Embedded eth.Request (must be non-nil)
-	witReq       *wit.Request // The actual witness protocol request
+// witRequestAdapter implements the minimal interface needed by the downloader
+// while keeping witness requests completely separate from eth protocol tracking.
+type witRequestAdapter struct {
+	id     uint64        // Unique ID with high bit set
+	peerID string        // Peer identifier
+	cancel chan struct{} // Cancellation channel
+	sent   time.Time     // Timestamp when sent
+	witReq *wit.Request  // The actual witness request
 }
 
-// Close overrides the embedded eth.Request's Close to also close the wit.Request
-// and signal cancellation via the embedded request's cancel channel.
-func (r *ethWitRequest) Close() error {
-	// Signal cancellation on the embedded request's channel first.
-	// Note: This assumes r.Request and r.Request.cancel are non-nil.
-	// The channel is initialized in RequestWitnesses.
-	close(r.Request.Cancel)
+// Peer returns the peer ID (for downloader compatibility)
+func (r *witRequestAdapter) Peer() string {
+	return r.peerID
+}
 
-	// Then close the underlying witness request.
-	// The eth.Request shim doesn't need explicit closing here,
-	// as it's not registered with the eth dispatcher.
-	return r.witReq.Close()
+// Cancel returns the cancellation channel (for downloader compatibility)
+func (r *witRequestAdapter) Cancel() <-chan struct{} {
+	return r.cancel
+}
+
+// Sent returns when the request was sent (for timeout tracking)
+func (r *witRequestAdapter) Sent() time.Time {
+	return r.sent
+}
+
+// Close cancels the request
+func (r *witRequestAdapter) Close() error {
+	// Close our cancel channel
+	if r.cancel != nil {
+		select {
+		case <-r.cancel:
+			// Already closed
+		default:
+			close(r.cancel)
+		}
+	}
+	// Close the underlying witness request
+	if r.witReq != nil {
+		return r.witReq.Close()
+	}
+	return nil
 }
 
 // RequestWitnesses implements downloader.Peer.
 // It requests witnesses using the wit protocol for the given block hashes.
+// Unlike eth protocol requests, witness requests use their own tracking mechanism
+// to avoid ID collisions.
 func (p *ethPeer) RequestWitnesses(hashes []common.Hash, dlResCh chan *eth.Response) (*eth.Request, error) {
 	if p.witPeer == nil {
 		return nil, errors.New("witness peer not found")
 	}
-	p.witPeer.Log().Trace("RequestWitnesses called", "peer", p.ID(), "hashes", len(hashes))
-	// Create a channel for the underlying witness protocol responses.
+
+	// Generate a unique ID for this witness request
+	adapterID := rand.Uint64()
+
+	p.witPeer.Log().Trace("RequestWitnesses called", "peer", p.ID(), "hashes", len(hashes), "adapterID", adapterID)
+
+	// Create a channel for the underlying witness protocol responses
 	witResCh := make(chan *wit.Response)
 
-	// Make the actual request via the witness protocol peer.
+	// Make the actual request via the witness protocol peer
 	witReq, err := p.witPeer.Peer.RequestWitness(hashes, witResCh)
 	if err != nil {
 		p.witPeer.Log().Error("RequestWitnesses failed to make wit request", "peer", p.ID(), "err", err)
 		return nil, err
 	}
-	p.witPeer.Log().Trace("RequestWitnesses made wit request", "peer", p.ID(), "hashes", len(hashes))
 
-	// Create the wrapper request. Embed a minimal eth.Request shim.
-	// Its primary purpose is type compatibility for the return value.
-	// The ethWitRequest's Close method handles actual cancellation via witReq.
-	// *** Crucially, set the Peer field so the concurrent fetcher can find the peer ***
-	ethReqShim := &eth.Request{
-		Peer:   p.ID(),              // Set the Peer ID here
-		Cancel: make(chan struct{}), // Initialize the cancel channel
-	}
-	wrapperReq := &ethWitRequest{
-		Request: ethReqShim,
-		witReq:  witReq,
+	p.witPeer.Log().Trace("RequestWitnesses made wit request", "peer", p.ID(), "witReqID", witReq.ID())
+
+	// Create an adapter that satisfies the downloader interface without
+	// interfering with eth protocol tracking
+	adapter := &witRequestAdapter{
+		id:     adapterID,
+		peerID: p.ID(),
+		cancel: make(chan struct{}),
+		sent:   time.Now(),
+		witReq: witReq,
 	}
 
-	// Start a goroutine to adapt responses from the wit channel to the eth channel.
+	// Create a minimal eth.Request that wraps our adapter
+	// This is needed because the downloader expects *eth.Request specifically
+	ethReq := &eth.Request{
+		Peer:   adapter.peerID,
+		Cancel: adapter.cancel,
+		Sent:   adapter.sent,
+		// The id field remains unset (0) - it won't be used for tracking
+	}
+
+	// Start a goroutine to adapt responses from wit to eth format
 	go func() {
 		p.witPeer.Log().Trace("RequestWitnesses adapter goroutine started", "peer", p.ID())
 		defer p.witPeer.Log().Trace("RequestWitnesses adapter goroutine finished", "peer", p.ID())
 
 		for witRes := range witResCh {
 			p.witPeer.Log().Trace("RequestWitnesses adapter received wit response", "peer", p.ID())
-			// Adapt wit.Response to eth.Response.
-			// We can only copy exported fields. The unexported fields (id, recv, code)
-			// will have zero values in the ethRes sent to the caller.
-			// Correlation still works via the Req field.
+
+			// Create eth.Response that references our eth.Request
 			ethRes := &eth.Response{
-				Req:  wrapperReq.Request, // Point back to the embedded shim request.
+				Req:  ethReq,
 				Res:  witRes.Res,
 				Meta: witRes.Meta,
 				Time: witRes.Time,
 				Done: witRes.Done,
 			}
 
-			// Forward the adapted response to the downloader's channel,
-			// or stop if the request has been cancelled.
+			// Forward the response or exit if cancelled
 			select {
 			case dlResCh <- ethRes:
 				p.witPeer.Log().Trace("RequestWitnesses adapter forwarded eth response", "peer", p.ID())
-			case <-wrapperReq.Request.Cancel:
-				p.witPeer.Log().Trace("RequestWitnesses adapter cancelled before forwarding response", "peer", p.ID())
-				// If cancelled, exit the goroutine. The closing of witResCh
-				// will also eventually terminate the loop, but returning
-				// here ensures we don't block trying to send after cancellation.
+			case <-adapter.cancel:
+				p.witPeer.Log().Trace("RequestWitnesses adapter cancelled", "peer", p.ID())
 				return
 			}
 		}
 	}()
 
-	// Return the embedded *eth.Request part of the wrapper.
-	// This satisfies the function signature.
-	p.witPeer.Log().Trace("RequestWitnesses returning ethReq shim", "peer", p.ID())
-	return wrapperReq.Request, nil
+	// Return the eth.Request to satisfy the interface
+	p.witPeer.Log().Trace("RequestWitnesses returning eth request", "peer", p.ID(), "adapterID", adapterID)
+	return ethReq, nil
 }

--- a/eth/protocols/wit/dispatcher.go
+++ b/eth/protocols/wit/dispatcher.go
@@ -39,6 +39,11 @@ type Request struct {
 	Sent time.Time // Timestamp when the request was sent
 }
 
+// ID returns the request ID for logging purposes
+func (r *Request) ID() uint64 {
+	return r.id
+}
+
 // Close aborts an in-flight request. Although there's no way to notify the
 // remote peer about the cancellation, this method notifies the dispatcher to
 // discard any late responses.


### PR DESCRIPTION
# Description

This PR mainly adds the ability to download all historical bytecode before starting stateless sync.

Also included a few improvements and bug fixes for stateless sync. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli
