### PR TITLE
core, eth, miner: interrupt block building during fill transactions incase of timeout

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -1596,7 +1597,7 @@ func (p *BlobPool) drop() {
 //
 // The transactions can also be pre-filtered by the dynamic fee components to
 // reduce allocations and load on downstream subsystems.
-func (p *BlobPool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
+func (p *BlobPool) Pending(filter txpool.PendingFilter, interrupt *atomic.Bool) map[common.Address][]*txpool.LazyTransaction {
 	// If only plain transactions are requested, this pool is unsuitable as it
 	// contains none, don't even bother.
 	if filter.OnlyPlainTxs {

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -1703,7 +1703,7 @@ func benchmarkPoolPending(b *testing.B, datacap uint64) {
 			MinTip:  uint256.NewInt(1),
 			BaseFee: chain.basefee,
 			BlobFee: chain.blobfee,
-		})
+		}, nil)
 		if len(p) != int(capacity) {
 			b.Fatalf("have %d want %d", len(p), capacity)
 		}

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -548,7 +548,7 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter, interrupt *atomic.B
 		if interrupt.Load() {
 			// We could send partial set of pending transactions but they'll anyways
 			// be rejected during commit transactions. Instead avoid sending anything.
-			return nil
+			return map[common.Address][]*txpool.LazyTransaction{}
 		}
 
 		txs := list.Flatten()

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -3021,7 +3021,7 @@ func BenchmarkPoolAccountMultiBatchInsertRace(b *testing.B) {
 		for {
 			select {
 			case <-t.C:
-				pending = pool.Pending(txpool.PendingFilter{})
+				pending = pool.Pending(txpool.PendingFilter{}, nil)
 			case <-done:
 				break loop
 			}
@@ -3076,7 +3076,7 @@ func BenchmarkPoolAccountMultiBatchInsertNoLockRace(b *testing.B) {
 		var pending map[common.Address][]*txpool.LazyTransaction
 
 		for range t.C {
-			pending = pool.Pending(txpool.PendingFilter{})
+			pending = pool.Pending(txpool.PendingFilter{}, nil)
 
 			if len(pending) >= b.N/2 {
 				close(done)
@@ -3152,7 +3152,7 @@ func BenchmarkPoolAccountsBatchInsertRace(b *testing.B) {
 		for {
 			select {
 			case <-t.C:
-				pending = pool.Pending(txpool.PendingFilter{})
+				pending = pool.Pending(txpool.PendingFilter{}, nil)
 			case <-done:
 				break loop
 			}
@@ -3201,7 +3201,7 @@ func BenchmarkPoolAccountsBatchInsertNoLockRace(b *testing.B) {
 		var pending map[common.Address][]*txpool.LazyTransaction
 
 		for range t.C {
-			pending = pool.Pending(txpool.PendingFilter{})
+			pending = pool.Pending(txpool.PendingFilter{}, nil)
 
 			if len(pending) >= b.N/2 {
 				close(done)
@@ -3250,7 +3250,7 @@ func TestPoolMultiAccountBatchInsertRace(t *testing.T) {
 		)
 
 		for range t.C {
-			pending = pool.Pending(txpool.PendingFilter{})
+			pending = pool.Pending(txpool.PendingFilter{}, nil)
 			total = len(pending)
 
 			if total >= n {

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -18,6 +18,7 @@ package txpool
 
 import (
 	"math/big"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -153,8 +154,9 @@ type SubPool interface {
 	// account and sorted by nonce.
 	//
 	// The transactions can also be pre-filtered by the dynamic fee components to
-	// reduce allocations and load on downstream subsystems.
-	Pending(filter PendingFilter) map[common.Address][]*LazyTransaction
+	// reduce allocations and load on downstream subsystems. The retrieval is halted
+	// if interrupt is set (during block building timeout).
+	Pending(filter PendingFilter, interrupt *atomic.Bool) map[common.Address][]*LazyTransaction
 
 	// SubscribeTransactions subscribes to new transaction events. The subscriber
 	// can decide whether to receive notifications only for newly seen transactions

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -379,7 +379,7 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 }
 
 func (b *EthAPIBackend) GetPoolTransactions() (types.Transactions, error) {
-	pending := b.eth.txPool.Pending(txpool.PendingFilter{})
+	pending := b.eth.txPool.Pending(txpool.PendingFilter{}, nil)
 
 	var txs types.Transactions
 

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -324,7 +324,7 @@ func (c *SimulatedBeacon) Rollback() {
 func (c *SimulatedBeacon) Fork(parentHash common.Hash) error {
 	// Ensure no pending transactions.
 	c.eth.TxPool().Sync()
-	if len(c.eth.TxPool().Pending(txpool.PendingFilter{})) != 0 {
+	if len(c.eth.TxPool().Pending(txpool.PendingFilter{}, nil)) != 0 {
 		return errors.New("pending block dirty")
 	}
 
@@ -338,7 +338,7 @@ func (c *SimulatedBeacon) Fork(parentHash common.Hash) error {
 
 // AdjustTime creates a new block with an adjusted timestamp.
 func (c *SimulatedBeacon) AdjustTime(adjustment time.Duration) error {
-	if len(c.eth.TxPool().Pending(txpool.PendingFilter{})) != 0 {
+	if len(c.eth.TxPool().Pending(txpool.PendingFilter{}, nil)) != 0 {
 		return errors.New("could not adjust time on non-empty block")
 	}
 	parent := c.eth.BlockChain().CurrentBlock()

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -82,7 +82,7 @@ type txPool interface {
 
 	// Pending should return pending transactions.
 	// The slice should be modifiable by the caller.
-	Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction
+	Pending(filter txpool.PendingFilter, interrupt *atomic.Bool) map[common.Address][]*txpool.LazyTransaction
 
 	// SubscribeTransactions subscribes to new transaction events. The subscriber
 	// can decide whether to receive notifications only for newly seen transactions

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
@@ -123,7 +124,7 @@ func (p *testTxPool) Add(txs []*types.Transaction, sync bool) []error {
 }
 
 // Pending returns all the transactions known to the pool
-func (p *testTxPool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
+func (p *testTxPool) Pending(filter txpool.PendingFilter, interrupt *atomic.Bool) map[common.Address][]*txpool.LazyTransaction {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -37,7 +37,7 @@ const (
 // syncTransactions starts sending all currently pending transactions to the given peer.
 func (h *handler) syncTransactions(p *eth.Peer) {
 	var hashes []common.Hash
-	for _, batch := range h.txpool.Pending(txpool.PendingFilter{OnlyPlainTxs: true}) {
+	for _, batch := range h.txpool.Pending(txpool.PendingFilter{OnlyPlainTxs: true}, nil) {
 		for _, tx := range batch {
 			hashes = append(hashes, tx.Hash)
 		}

--- a/miner/ordering_test.go
+++ b/miner/ordering_test.go
@@ -102,7 +102,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 		expectedCount += count
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := newTransactionsByPriceAndNonce(signer, groups, baseFee)
+	txset := newTransactionsByPriceAndNonce(signer, groups, baseFee, nil)
 
 	txs := types.Transactions{}
 	for tx, _ := txset.Peek(); tx != nil; tx, _ = txset.Peek() {
@@ -168,7 +168,7 @@ func TestTransactionTimeSort(t *testing.T) {
 		})
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := newTransactionsByPriceAndNonce(signer, groups, nil)
+	txset := newTransactionsByPriceAndNonce(signer, groups, nil, nil)
 
 	txs := types.Transactions{}
 	for tx, _ := txset.Peek(); tx != nil; tx, _ = txset.Peek() {
@@ -193,4 +193,11 @@ func TestTransactionTimeSort(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestManav(t *testing.T) {
+	a := newTransactionsByPriceAndNonce(types.NewPragueSigner(big.NewInt(17)), map[common.Address][]*txpool.LazyTransaction{}, common.Big0, nil)
+	tx, b := a.Peek()
+	t.Log(tx)
+	t.Log(b)
 }

--- a/miner/ordering_test.go
+++ b/miner/ordering_test.go
@@ -194,10 +194,3 @@ func TestTransactionTimeSort(t *testing.T) {
 		}
 	}
 }
-
-func TestManav(t *testing.T) {
-	a := newTransactionsByPriceAndNonce(types.NewPragueSigner(big.NewInt(17)), map[common.Address][]*txpool.LazyTransaction{}, common.Big0, nil)
-	tx, b := a.Peek()
-	t.Log(tx)
-	t.Log(b)
-}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -641,15 +641,17 @@ func (w *worker) mainLoop() {
 						BlobGas:   tx.BlobGas(),
 					})
 				}
-				plainTxs := newTransactionsByPriceAndNonce(w.current.signer, txs, w.current.header.BaseFee) // Mixed bag of everrything, yolo
-				blobTxs := newTransactionsByPriceAndNonce(w.current.signer, nil, w.current.header.BaseFee)  // Empty bag, don't bother optimising
-
-				tcount := w.current.tcount
 
 				stopFn := func() {}
 				if w.interruptCommitFlag {
 					stopFn = createInterruptTimer(w.current.header.Number.Uint64(), w.current.header.Time, &w.interruptBlockBuilding)
 				}
+
+				plainTxs := newTransactionsByPriceAndNonce(w.current.signer, txs, w.current.header.BaseFee, &w.interruptBlockBuilding) // Mixed bag of everrything, yolo
+				blobTxs := newTransactionsByPriceAndNonce(w.current.signer, nil, w.current.header.BaseFee, &w.interruptBlockBuilding)  // Empty bag, don't bother optimising
+
+				tcount := w.current.tcount
+
 				w.commitTransactions(w.current, plainTxs, blobTxs, nil, new(uint256.Int))
 				stopFn()
 
@@ -1316,60 +1318,29 @@ func (w *worker) fillTransactions(interrupt *atomic.Int32, env *environment) err
 		filter.BaseFee = uint256.MustFromBig(env.header.BaseFee)
 	}
 
-	if env.header.ExcessBlobGas != nil {
-		filter.BlobFee = uint256.MustFromBig(eip4844.CalcBlobFee(w.chainConfig, env.header))
-	}
-
-	// bor: kept for reference, can remove later
-	/*
-		var (
-			localPlainTxs, remotePlainTxs, localBlobTxs, remoteBlobTxs map[common.Address][]*txpool.LazyTransaction
-		)
-	*/
-
 	filter.OnlyPlainTxs, filter.OnlyBlobTxs = true, false
-	pendingPlainTxs := w.eth.TxPool().Pending(filter)
-
-	filter.OnlyPlainTxs, filter.OnlyBlobTxs = false, true
-	pendingBlobTxs := w.eth.TxPool().Pending(filter)
+	pendingPlainTxs := w.eth.TxPool().Pending(filter, &w.interruptBlockBuilding)
 
 	// Split the pending transactions into locals and remotes.
 	prioPlainTxs, normalPlainTxs := make(map[common.Address][]*txpool.LazyTransaction), pendingPlainTxs
-	prioBlobTxs, normalBlobTxs := make(map[common.Address][]*txpool.LazyTransaction), pendingBlobTxs
 
 	for _, account := range prio {
 		if txs := normalPlainTxs[account]; len(txs) > 0 {
 			delete(normalPlainTxs, account)
 			prioPlainTxs[account] = txs
 		}
-		if txs := normalBlobTxs[account]; len(txs) > 0 {
-			delete(normalBlobTxs, account)
-			prioBlobTxs[account] = txs
-		}
 	}
 
 	// Fill the block with all available pending transactions.
-	if len(prioPlainTxs) > 0 || len(prioBlobTxs) > 0 {
-		plainTxs := newTransactionsByPriceAndNonce(env.signer, prioPlainTxs, env.header.BaseFee)
-		blobTxs := newTransactionsByPriceAndNonce(env.signer, prioBlobTxs, env.header.BaseFee)
-
-		// bor: kept for reference, can remove later
-		// plainTxs = newTransactionsByPriceAndNonce(env.signer, localPlainTxs, env.header.BaseFee)
-		// blobTxs = newTransactionsByPriceAndNonce(env.signer, localBlobTxs, env.header.BaseFee)
-
-		if err := w.commitTransactions(env, plainTxs, blobTxs, interrupt, new(uint256.Int)); err != nil {
+	if len(prioPlainTxs) > 0 {
+		plainTxs := newTransactionsByPriceAndNonce(env.signer, prioPlainTxs, env.header.BaseFee, &w.interruptBlockBuilding)
+		if err := w.commitTransactions(env, plainTxs, nil, interrupt, new(uint256.Int)); err != nil {
 			return err
 		}
 	}
-	if len(normalPlainTxs) > 0 || len(normalBlobTxs) > 0 {
-		plainTxs := newTransactionsByPriceAndNonce(env.signer, normalPlainTxs, env.header.BaseFee)
-		blobTxs := newTransactionsByPriceAndNonce(env.signer, normalBlobTxs, env.header.BaseFee)
-
-		// bor: kept for reference, can remove later
-		// plainTxs = newTransactionsByPriceAndNonce(env.signer, remotePlainTxs, env.header.BaseFee)
-		// blobTxs = newTransactionsByPriceAndNonce(env.signer, remoteBlobTxs, env.header.BaseFee)
-
-		if err := w.commitTransactions(env, plainTxs, blobTxs, interrupt, new(uint256.Int)); err != nil {
+	if len(normalPlainTxs) > 0 {
+		plainTxs := newTransactionsByPriceAndNonce(env.signer, normalPlainTxs, env.header.BaseFee, &w.interruptBlockBuilding)
+		if err := w.commitTransactions(env, plainTxs, nil, interrupt, new(uint256.Int)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
# Description

Use commit interrupt for fill transactions as well. 

We interrupt executing new transactions when the 2s block time mark is crossed. Although before execution, we call `Pending()` function of transaction pool which can be time consuming in some cases. If the 2s time limit is up, we'd like to interrupt that call as well to avoid spending any more time on doing any work for this block.

This PR passes the `interrupt` atomic boolean (which is used across the modules to trigger interrupt) when we're fetching the pending transactions and sorting them based on nonce and fee before executing. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
