### PR TITLE
Start GRPC server after backend assignment

### DIFF
--- a/internal/cli/server/api_service.go
+++ b/internal/cli/server/api_service.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	protobor "github.com/maticnetwork/polyproto/bor"
@@ -45,16 +44,6 @@ func (s *Server) HeaderByNumber(ctx context.Context, req *protobor.GetHeaderByNu
 	if err != nil {
 		return nil, err
 	}
-	// START - remove this code
-	if s.backend == nil {
-		log.Info("[grpcdebug] s.backend == nil")
-		return nil, errors.New("s.backend == nil")
-	}
-	if s.backend.APIBackend == nil {
-		log.Info("[grpcdebug] s.backend.APIBackend == nil")
-		return nil, errors.New("s.backend.APIBackend == nil")
-	}
-	// END - remove this code
 	header, err := s.backend.APIBackend.HeaderByNumber(ctx, bN)
 	if err != nil {
 		return nil, err

--- a/internal/cli/server/api_service.go
+++ b/internal/cli/server/api_service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	protobor "github.com/maticnetwork/polyproto/bor"
@@ -61,6 +62,16 @@ func (s *Server) BlockByNumber(ctx context.Context, req *protobor.GetBlockByNumb
 	if err != nil {
 		return nil, err
 	}
+	// START - remove this code
+	if s.backend == nil {
+		log.Info("[grpcdebug] s.backend == nil")
+		return nil, errors.New("s.backend == nil")
+	}
+	if s.backend.APIBackend == nil {
+		log.Info("[grpcdebug] s.backend.APIBackend == nil")
+		return nil, errors.New("s.backend.APIBackend == nil")
+	}
+	// END - remove this code
 	block, err := s.backend.APIBackend.BlockByNumber(ctx, bN)
 	if err != nil {
 		return nil, err

--- a/internal/cli/server/api_service.go
+++ b/internal/cli/server/api_service.go
@@ -45,6 +45,16 @@ func (s *Server) HeaderByNumber(ctx context.Context, req *protobor.GetHeaderByNu
 	if err != nil {
 		return nil, err
 	}
+	// START - remove this code
+	if s.backend == nil {
+		log.Info("[grpcdebug] s.backend == nil")
+		return nil, errors.New("s.backend == nil")
+	}
+	if s.backend.APIBackend == nil {
+		log.Info("[grpcdebug] s.backend.APIBackend == nil")
+		return nil, errors.New("s.backend.APIBackend == nil")
+	}
+	// END - remove this code
 	header, err := s.backend.APIBackend.HeaderByNumber(ctx, bN)
 	if err != nil {
 		return nil, err
@@ -62,16 +72,6 @@ func (s *Server) BlockByNumber(ctx context.Context, req *protobor.GetBlockByNumb
 	if err != nil {
 		return nil, err
 	}
-	// START - remove this code
-	if s.backend == nil {
-		log.Info("[grpcdebug] s.backend == nil")
-		return nil, errors.New("s.backend == nil")
-	}
-	if s.backend.APIBackend == nil {
-		log.Info("[grpcdebug] s.backend.APIBackend == nil")
-		return nil, errors.New("s.backend.APIBackend == nil")
-	}
-	// END - remove this code
 	block, err := s.backend.APIBackend.BlockByNumber(ctx, bN)
 	if err != nil {
 		return nil, err

--- a/internal/cli/server/command.go
+++ b/internal/cli/server/command.go
@@ -243,7 +243,7 @@ func (c *Command) Run(args []string) int {
 		}()
 	}
 
-	srv, err := NewServer(c.config, WithGRPCAddress())
+	srv, err := NewServer(c.config)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/internal/cli/server/helper.go
+++ b/internal/cli/server/helper.go
@@ -15,7 +15,7 @@ func CreateMockServer(config *Config) (*Server, error) {
 	config.DBEngine = "leveldb"
 
 	// get grpc port and listener
-	grpcPort, gRPCListener, err := network.FindAvailablePort()
+	grpcPort, _, err := network.FindAvailablePort()
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func CreateMockServer(config *Config) (*Server, error) {
 	config.JsonRPC.Http.Port = 0 // It will choose a free/available port
 
 	// start the server
-	return NewServer(config, WithGRPCListener(gRPCListener))
+	return NewServer(config)
 }
 
 func CloseMockServer(server *Server) {

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"runtime/debug"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -458,6 +459,8 @@ func (s *Server) gRPCServerByListener(listener net.Listener) error {
 	}()
 
 	log.Info("GRPC Server started", "addr", listener.Addr())
+
+	log.Info("Stack call to startup of grpc", "stackTraceCaught", string(debug.Stack()))
 
 	return nil
 }

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"runtime/debug"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -464,8 +463,6 @@ func (s *Server) gRPCServerByListener(listener net.Listener) error {
 	}()
 
 	log.Info("GRPC Server started", "addr", listener.Addr())
-
-	log.Info("Stack call to startup of grpc", "stackTraceCaught", string(debug.Stack()))
 
 	return nil
 }

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -304,6 +304,11 @@ func NewServer(config *Config, opts ...serverOption) (*Server, error) {
 		return nil, err
 	}
 
+	// start the GRPC Server
+	if err := WithGRPCAddress()(srv, config); err != nil {
+		return nil, err
+	}
+
 	return srv, nil
 }
 


### PR DESCRIPTION
# Description

This PR fixes a bug of a time window at startup which `s.backend == nil`, which causes panic in any GRPC call if enabled by heimdall and queried right after starting bor.

It was reported on this [issue](https://github.com/maticnetwork/bor/issues/1632)

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
