### PR TITLE
Stop miner when reorg from milestone (#1635)

### DIFF
--- a/eth/bor_checkpoint_verifier.go
+++ b/eth/bor_checkpoint_verifier.go
@@ -154,30 +154,11 @@ func borVerify(ctx context.Context, eth *Ethereum, handler *ethHandler, start ui
 			canonicalChain[i], canonicalChain[j] = canonicalChain[j], canonicalChain[i]
 		}
 
-		rewindBack(eth, head, rewindTo)
-
-		if canonicalChain != nil && len(canonicalChain) == int(length) {
-			log.Info("Inserting canonical chain", "from", canonicalChain[0].NumberU64(), "hash", canonicalChain[0].Hash(), "to", canonicalChain[len(canonicalChain)-1].NumberU64(), "hash", canonicalChain[len(canonicalChain)-1].Hash())
-			_, err := eth.BlockChain().InsertChain(canonicalChain, eth.config.SyncAndProduceWitnesses)
-			if err != nil {
-				log.Warn("Failed to insert canonical chain", "err", err)
-				return hash, err
-			}
-
-			// Then explicitly set the final block as canonical to ensure proper canonical mapping
-			finalBlock := canonicalChain[len(canonicalChain)-1]
-			_, err = eth.BlockChain().SetCanonical(finalBlock)
-			if err != nil {
-				log.Warn("Failed to set canonical head after insertion", "err", err, "block", finalBlock.NumberU64(), "hash", finalBlock.Hash())
-				return hash, err
-			}
-
-			log.Info("Successfully inserted canonical chain")
-		} else {
-			log.Warn("Failed to insert canonical chain", "length", len(canonicalChain), "expected", length)
-			// If is okay if we can't find the canonical chain
-			return hash, nil
+		if len(canonicalChain) != int(length) {
+			canonicalChain = nil
 		}
+
+		reorgToFinalized(eth, head, rewindTo, canonicalChain)
 	}
 
 	// fetch the end block hash
@@ -192,19 +173,20 @@ func borVerify(ctx context.Context, eth *Ethereum, handler *ethHandler, start ui
 	return hash, nil
 }
 
-// Stop the miner if the mining process is running and rewind back the chain
-func rewindBack(eth *Ethereum, head uint64, rewindTo uint64) {
+// reorgToFinalized stops the miner if the mining process is running and rewinds back the chain
+// and inserts the chain finalized by checkpoint/milestone.
+func reorgToFinalized(eth *Ethereum, head uint64, rewindTo uint64, canonicalChain []*types.Block) {
 	if eth.Miner() != nil && eth.Miner().Mining() {
 		ch := make(chan struct{})
 		eth.Miner().Stop(ch)
 
 		<-ch
-		rewind(eth, head, rewindTo)
 
-		eth.Miner().Start()
-	} else {
-		rewind(eth, head, rewindTo)
+		defer eth.Miner().Start()
 	}
+
+	rewind(eth, head, rewindTo)
+	insertFinalized(eth, canonicalChain)
 }
 
 func rewind(eth *Ethereum, head uint64, rewindTo uint64) {
@@ -272,4 +254,29 @@ func findCommonAncestorWithFutureMilestones(eth *Ethereum, start uint64, end uin
 	}
 
 	return targetBlock
+}
+
+// insertFinalized inserts the chain finalized by checkpoint/milestone and ensures the final block is set as canonical.
+func insertFinalized(eth *Ethereum, canonicalChain []*types.Block) {
+	if len(canonicalChain) == 0 {
+		return
+	}
+
+	// Perform the canonical chain insertion
+	log.Info("Inserting canonical chain", "from", canonicalChain[0].NumberU64(), "hash", canonicalChain[0].Hash(), "to", canonicalChain[len(canonicalChain)-1].NumberU64(), "hash", canonicalChain[len(canonicalChain)-1].Hash())
+	_, err := eth.BlockChain().InsertChain(canonicalChain, eth.config.SyncAndProduceWitnesses)
+	if err != nil {
+		log.Warn("Failed to insert canonical chain", "err", err)
+		return
+	}
+
+	// Then explicitly set the final block as canonical to ensure proper canonical mapping
+	finalBlock := canonicalChain[len(canonicalChain)-1]
+	_, err = eth.BlockChain().SetCanonical(finalBlock)
+	if err != nil {
+		log.Warn("Failed to set canonical head after insertion", "err", err, "block", finalBlock.NumberU64(), "hash", finalBlock.Hash())
+		return
+	}
+
+	log.Info("Successfully inserted canonical chain")
 }


### PR DESCRIPTION
This resolved a possible race condition when a milestone reorg happens at the same time when a validator mines a new block. The miner should be completely stopped when setHead canonical head and inserting finalized chain.

# Description

Please provide a detailed description of what was done in this PR

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
