### PR TITLE
miner: fix deadlock and panic issues in block production

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -752,6 +752,13 @@ func (w *worker) resultLoop() {
 				continue
 			}
 
+			// Skip if the sealed block is behind current head (stale block from before reorg)
+			currentBlock := w.chain.CurrentBlock()
+			if currentBlock != nil && block.NumberU64() <= currentBlock.Number.Uint64() {
+				log.Info("Skipping stale sealed block", "sealed", block.NumberU64(), "current", currentBlock.Number.Uint64())
+				continue
+			}
+
 			oldBlock := w.chain.GetBlockByNumber(block.NumberU64())
 			if oldBlock != nil {
 				oldBlockAuthor, _ := w.chain.Engine().Author(oldBlock.Header())
@@ -1084,6 +1091,7 @@ mainloop:
 
 				if env.tcount > len(env.depsMVFullWriteList) {
 					log.Warn("blockstm - env.tcount > len(env.depsMVFullWriteList)", "env.tcount", env.tcount, "len(depsMVFullWriteList)", len(env.depsMVFullWriteList))
+					return errors.New("transaction count exceeds dependency list length")
 				}
 
 				temp := blockstm.TxDep{
@@ -1092,7 +1100,20 @@ mainloop:
 					FullWriteList: env.depsMVFullWriteList,
 				}
 
-				chDeps <- temp
+				// Send with timeout to prevent deadlock
+				select {
+				case chDeps <- temp:
+					// Successfully sent
+				case <-time.After(1 * time.Second):
+					// Timeout after 1 second - channel is blocked
+					log.Error("Transaction dependency channel blocked, aborting block building",
+						"txIndex", env.tcount-1,
+						"blockNumber", env.header.Number.Uint64())
+					once.Do(func() {
+						close(chDeps)
+					})
+					return errors.New("dependency channel timeout")
+				}
 			}
 
 			txs.Shift()


### PR DESCRIPTION
# Description

These fixes address production issues where mining nodes would deadlock for hours after milestone-triggered reorgs, unable to  process new blocks or respond to chain updates.

  - Skip stale sealed blocks that are behind current chain head to prevent resultLoop from attempting to write outdated blocks after reorgs
  - Add 1-second timeout to chDeps channel send to prevent indefinite blocking when receiver is dead or channel is full
  - Return error when transaction count exceeds dependency list length to prevent array index out of bounds panic



# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
