### PR TITLE
Upload genesis as assets on releases

### DIFF
--- a/.github/workflows/amoy_deb_profiles.yml
+++ b/.github/workflows/amoy_deb_profiles.yml
@@ -390,3 +390,4 @@ jobs:
             packaging/deb/bor-pbss-amoy-**.deb 
             packaging/deb/bor-amoy-**.deb.checksum
             packaging/deb/bor-pbss-amoy-**.deb.checksum
+            builder/files/genesis-amoy.json

--- a/.github/workflows/mainnet_deb_profiles.yml
+++ b/.github/workflows/mainnet_deb_profiles.yml
@@ -400,3 +400,5 @@ jobs:
             packaging/deb/bor-pbss-mainnet-**.deb
             packaging/deb/bor-mainnet-**.deb.checksum
             packaging/deb/bor-pbss-mainnet-**.deb.checksum
+            builder/files/genesis-mainnet-v1.json
+            builder/files/genesis-amoy.json

--- a/.github/workflows/mainnet_deb_profiles.yml
+++ b/.github/workflows/mainnet_deb_profiles.yml
@@ -401,4 +401,3 @@ jobs:
             packaging/deb/bor-mainnet-**.deb.checksum
             packaging/deb/bor-pbss-mainnet-**.deb.checksum
             builder/files/genesis-mainnet-v1.json
-            builder/files/genesis-amoy.json


### PR DESCRIPTION
# Description

This PR aims to start uploading our genesis in our assets page so users can use it as the source of truth. Currently we faced an issue (https://github.com/maticnetwork/bor/issues/1618) where we updated the genesis and the hash mismatches the file on a tutorial. With this we can instruct users on trusting directly on the checksum from github.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
