### PR TITLE
chore: bump alpine image in release dockerfile

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,16 +1,16 @@
-FROM alpine:3.14
+FROM alpine:latest
 
-ARG BOR_DIR=/var/lib/bor
+ARG BOR_DIR=/var/lib/bor/
 ENV BOR_DIR=$BOR_DIR
 
-RUN apk add --no-cache ca-certificates && \
-    mkdir -p ${BOR_DIR}
+RUN apk add --no-cache ca-certificates && mkdir -p ${BOR_DIR}
 
 WORKDIR ${BOR_DIR}
 COPY bor /usr/bin/
+COPY builder/files/genesis-amoy.json ${BOR_DIR}
 COPY builder/files/genesis-mainnet-v1.json ${BOR_DIR}
 COPY builder/files/genesis-testnet-v4.json ${BOR_DIR}
-COPY builder/files/genesis-amoy.json ${BOR_DIR}
 
 EXPOSE 8545 8546 8547 30303 30303/udp
+
 ENTRYPOINT ["bor"]


### PR DESCRIPTION
# Description

Bump alpine image to use `alpine:latest` in `Dockerfile.release`.