### PR TITLE
Fix "Prefetcher missed to load trie"

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1298,7 +1298,7 @@ func (c *Bor) checkAndCommitSpan(
 	headerNumber := header.Number.Uint64()
 
 	tempState := state.Inner().Copy()
-	tempState.SetPrefetcher(nil)
+	tempState.ResetPrefetcher()
 	tempState.StartPrefetcher("bor", state.Witness())
 
 	span, err := c.spanner.GetCurrentSpan(ctx, header.ParentHash, tempState)
@@ -1443,7 +1443,7 @@ func (c *Bor) CommitStates(
 	if c.config.IsIndore(header.Number) {
 		// Fetch the LastStateId from contract via current state instance
 		tempState := state.Inner().Copy()
-		tempState.SetPrefetcher(nil)
+		tempState.ResetPrefetcher()
 		tempState.StartPrefetcher("bor", state.Witness())
 
 		lastStateIDBig, err = c.GenesisContractsClient.LastStateId(tempState, number-1, header.ParentHash)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -525,8 +525,11 @@ func (s *StateDB) StopPrefetcher() {
 	}
 }
 
-func (s *StateDB) SetPrefetcher(prefetcher *triePrefetcher) {
-	s.prefetcher = prefetcher
+// ResetPrefetcher cleans the prefetcher from a State, commonly used in tempStates to track witness while no impacting block building
+// Do also remove mutations previously tracked to just look to the new ones
+func (s *StateDB) ResetPrefetcher() {
+	s.prefetcher = nil
+	s.mutations = make(map[common.Address]*mutation)
 }
 
 // setError remembers the first non-nil error it is called with.


### PR DESCRIPTION
# Description

Error `Prefetcher missed to load trie` was raised by trying to apply all the mutations from previous state on the temp state. By resetting mutations together with prefetcher we fix this issue.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
