### PR TITLE
fix(eth/peer/wit): concurrent data read/write cases

### DIFF
--- a/eth/fetcher/witness_manager.go
+++ b/eth/fetcher/witness_manager.go
@@ -516,7 +516,10 @@ func (m *witnessManager) tick() {
 func (m *witnessManager) fetchWitness(peer string, hash common.Hash, announce *blockAnnounce) {
 	resCh := make(chan *eth.Response)
 
+	m.mu.Lock()
 	announcedAt := announce.time // Capture the original 'ready-to-fetch' time for logging/timestamping
+	m.mu.Unlock()
+
 	witnessFetchMeter.Mark(1)
 
 	req, err := announce.fetchWitness(hash, resCh)

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -174,14 +174,14 @@ func (p *ethPeer) RequestWitnesses(hashes []common.Hash, dlResCh chan *eth.Respo
 	var mapsMu sync.RWMutex
 	var buildRequestMu sync.RWMutex
 
-	// non-blocking build first requests
-	witReqsWg.Add(1)
-	go func() {
-		p.buildWitnessRequests(hashes, &witReqs, &witReqsWg, witTotalPages, witTotalRequest, witReqResCh, witReqSem, &mapsMu, &buildRequestMu, failedRequests)
-		witReqsWg.Done()
-	}()
+	// Build all the initial requests synchronously.
+	buildWitReqErr := p.buildWitnessRequests(hashes, &witReqs, &witReqsWg, witTotalPages, witTotalRequest, witReqResCh, witReqSem, &mapsMu, &buildRequestMu, failedRequests)
+	if buildWitReqErr != nil {
+		p.witPeer.Peer.Log().Error("Error in building witness requests", "peer", p.ID(), "err", buildWitReqErr)
+		return nil, buildWitReqErr
+	}
 
-	// closes witResCh after all requests are done
+	// Close the witResCh after all the requests are done.
 	go func() {
 		defer close(witReqResCh)
 		witReqsWg.Wait()
@@ -332,7 +332,10 @@ func (p *ethPeer) receiveWitnessPage(
 			// non blocking call to avoid race condition because of semaphore
 			witReqsWg.Add(1) // protecting from not finishing before requests are built
 			go func() {
-				p.buildWitnessRequests(hashes, witReqs, witReqsWg, witTotalPages, witTotalRequest, witResCh, witReqSem, mapsMu, buildRequestMu, failedRequests)
+				buildWitReqErr := p.buildWitnessRequests(hashes, witReqs, witReqsWg, witTotalPages, witTotalRequest, witResCh, witReqSem, mapsMu, buildRequestMu, failedRequests)
+				if buildWitReqErr != nil {
+					p.witPeer.Peer.Log().Error("Error in building witness requests", "peer", p.ID(), "err", buildWitReqErr)
+				}
 				witReqsWg.Done()
 			}()
 		}
@@ -373,7 +376,10 @@ func (p *ethPeer) receiveWitnessPage(
 		// non blocking call to avoid race condition because of semaphore
 		witReqsWg.Add(1) // protecting from not finishing before requests are built
 		go func() {
-			p.buildWitnessRequests(hashes, witReqs, witReqsWg, witTotalPages, witTotalRequest, witResCh, witReqSem, mapsMu, buildRequestMu, failedRequests)
+			buildWitReqErr := p.buildWitnessRequests(hashes, witReqs, witReqsWg, witTotalPages, witTotalRequest, witResCh, witReqSem, mapsMu, buildRequestMu, failedRequests)
+			if buildWitReqErr != nil {
+				p.witPeer.Peer.Log().Error("Error in building witness requests", "peer", p.ID(), "err", buildWitReqErr)
+			}
 			witReqsWg.Done()
 		}()
 	}
@@ -481,7 +487,7 @@ func (p *ethPeer) doWitnessRequest(
 	request := []wit.WitnessPageRequest{{Hash: hash, Page: page}}
 	witReq, err := p.witPeer.Peer.RequestWitness(request, witResCh)
 	if err != nil {
-		p.witPeer.Peer.Log().Error("RequestWitnesses failed to make wit request", "peer", p.ID(), "err", err)
+		p.witPeer.Peer.Log().Error("Error in making wit request", "peer", p.ID(), "err", err)
 		return err
 	}
 	go func() {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/cespare/cp v1.1.1
 	github.com/cloudflare/cloudflare-go v0.97.0
 	github.com/cockroachdb/pebble v1.1.2
+	github.com/cometbft/cometbft v0.38.17
 	github.com/consensys/gnark-crypto v0.16.0
 	github.com/cosmos/cosmos-sdk v0.50.13
 	github.com/cosmos/gogoproto v1.7.0
@@ -222,7 +223,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cockroachdb/apd/v2 v2.0.2 // indirect
-	github.com/cometbft/cometbft v0.38.17 // indirect
 	github.com/cometbft/cometbft-db v0.14.1 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/cosmos-db v1.0.2 // indirect


### PR DESCRIPTION
Fixes #1729 and #1736 

# Description

Issue in #1729:

The original code had a data race between:
- READ: where we read `witReqs` to create `wrapperReq := &ethWitRequest{Request: ethReqShim, witReqs: witReqs}`.
- WRITE: where `doWitnessRequest()` does `*witReqs = append(*witReqs, witReq)`

The race occurred because `buildWitnessRequests` was called asynchronously in a goroutine, allowing the main goroutine to read witReqs while the background goroutine was still populating it via append operations.

By calling `buildWitnessRequests` synchronously, we ensure all initial witness requests are built and appended to `witReqs` BEFORE the main goroutine reads the slice, eliminating the possibility of concurrent read/write access.

Issue in #1736:

The original code had a data race between:
- READ: where we read `announce.time` for logging/timestamping
- WRITE: `handleWitnessFetchFailureExt()` where it does `state.announce.time = time.Now().Add(fetchTimeout)`

The race occurred because this read was unprotected while `handleWitnessFetchFailureExt()` was writing to the same `announce.time` field under mutex protection. Both operations access the same memory location but with different synchronisation. By protecting this read with the same mutex used by the writer, we ensure synchronised access to announce. time, eliminating the data race.