### PR TITLE
eth: handle integer underflow for reporting total delay in block tracking

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -1195,21 +1195,21 @@ func (f *BlockFetcher) importBlocks(peer string, block *types.Block, witness *st
 			// Log the insertion event
 			var (
 				msg         string
-				delayInMs   uint64
+				delayInMs   int64
 				prettyDelay common.PrettyDuration
 			)
 
 			if block.AnnouncedAt != nil {
 				msg = "[block tracker] Inserted new block with announcement"
-				delayInMs = uint64(time.Since(*block.AnnouncedAt).Milliseconds())
+				delayInMs = time.Since(*block.AnnouncedAt).Milliseconds()
 				prettyDelay = common.PrettyDuration(time.Since(*block.AnnouncedAt))
 			} else {
 				msg = "[block tracker] Inserted new block without announcement"
-				delayInMs = uint64(time.Since(block.ReceivedAt).Milliseconds())
+				delayInMs = time.Since(block.ReceivedAt).Milliseconds()
 				prettyDelay = common.PrettyDuration(time.Since(block.ReceivedAt))
 			}
 
-			totalDelayInMs := uint64(time.Now().UnixMilli()) - block.Time()*1000
+			totalDelayInMs := time.Now().UnixMilli() - int64(block.Time())*1000
 			totalDelay := common.PrettyDuration(time.Millisecond * time.Duration(totalDelayInMs))
 
 			log.Info(msg, "number", block.Number().Uint64(), "hash", hash, "delay", prettyDelay, "delayInMs", delayInMs, "totalDelay", totalDelay, "totalDelayInMs", totalDelayInMs)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -775,7 +775,7 @@ func (h *handler) minedBroadcastLoop() {
 	for obj := range h.minedBlockSub.Chan() {
 		if ev, ok := obj.Data.(core.NewMinedBlockEvent); ok {
 			if h.enableBlockTracking {
-				delayInMs := uint64(time.Now().UnixMilli()) - ev.Block.Time()*1000
+				delayInMs := time.Now().UnixMilli() - int64(ev.Block.Time())*1000
 				delay := common.PrettyDuration(time.Millisecond * time.Duration(delayInMs))
 				log.Info("[block tracker] Broadcasting mined block", "number", ev.Block.NumberU64(), "hash", ev.Block.Hash(), "blockTime", ev.Block.Time(), "now", time.Now().Unix(), "delay", delay, "delayInMs", delayInMs)
 			}


### PR DESCRIPTION
# Description

Avoid wraparound of total delay values when logging due to integer underflow. Switch to using int64 instead of uint64. The log initially assumed that current time would always be ahead of header's block time which is not true anymore (as blocks can be announced early) breaking this assumption. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
