### PR TITLE
Remove bloom filter from bor logs

### DIFF
--- a/eth/filters/bor_filter.go
+++ b/eth/filters/bor_filter.go
@@ -143,16 +143,8 @@ func (f *BorBlockLogsFilter) unindexedLogs(ctx context.Context, end uint64) ([]*
 
 // borBlockLogs returns the logs matching the filter criteria within a single block.
 func (f *BorBlockLogsFilter) borBlockLogs(_ context.Context, receipt *types.Receipt) (logs []*types.Log, err error) {
-	// After upstream merge from geth v1.16.1, range filters can depend on per-receipt bloom.
-	// Bor receipts written by tests (or older code) may omit Bloom.
-	// To keep compatibility, compute the Bloom on-the-fly, when missing.
-	bloom := receipt.Bloom
-	if (bloom == (types.Bloom{})) && len(receipt.Logs) > 0 {
-		bloom = types.CreateBloom(receipt)
-	}
-	if bloomFilter(bloom, f.addresses, f.topics) {
-		logs = filterLogs(receipt.Logs, nil, nil, f.addresses, f.topics)
-	}
+	// no bloom filter applied since bor logs has no effect on bloom
+	logs = filterLogs(receipt.Logs, nil, nil, f.addresses, f.topics)
 
 	return logs, nil
 }

--- a/eth/filters/bor_filter_test.go
+++ b/eth/filters/bor_filter_test.go
@@ -32,8 +32,6 @@ func newTestReceipt(contractAddr common.Address, topicAddress common.Hash) *type
 		},
 	}
 
-	receipt.Bloom = types.CreateBloom(receipt)
-
 	return receipt
 }
 


### PR DESCRIPTION
# Description

Bor logs has no impact on the bloom of a block. So this PR removes bloom filter on-the-fly creation since bloom filter aims just to performance boost. In this scenario we are doing the opposite so better make it directly.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
