### PR TITLE
[miner/worker] More strict interrupt to give some buffer for state root computation

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1610,6 +1610,11 @@ func (w *worker) commitWork(interrupt *atomic.Int32, noempty bool, timestamp int
 // and toggles the flag when the timer expires.
 func createInterruptTimer(number, timestamp uint64, interruptBlockBuilding *atomic.Bool) func() {
 	delay := time.Until(time.Unix(int64(timestamp), 0))
+
+	// Reduce the timeout by 500ms to give some buffer for state root computation
+	if delay > 1*time.Second {
+		delay -= 500 * time.Millisecond
+	}
 	interruptCtx, cancel := context.WithTimeout(context.Background(), delay)
 
 	// Reset the flag when timer starts for building a new block.

--- a/params/version.go
+++ b/params/version.go
@@ -23,10 +23,10 @@ import (
 )
 
 const (
-	VersionMajor = 2        // Major version component of the current release
-	VersionMinor = 3        // Minor version component of the current release
-	VersionPatch = 1        // Patch version component of the current release
-	VersionMeta  = "hotfix" // Version metadata to append to the version string
+	VersionMajor = 2         // Major version component of the current release
+	VersionMinor = 3         // Minor version component of the current release
+	VersionPatch = 1         // Patch version component of the current release
+	VersionMeta  = "hotfix2" // Version metadata to append to the version string
 )
 
 var (


### PR DESCRIPTION
# Description

This change allows the block producer to allocate more time for state root calculate. It reduces the chance of producing empty/late blocks.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

