### PR TITLE
Fix txs count in segment import report

### DIFF
--- a/core/blockchain_insert.go
+++ b/core/blockchain_insert.go
@@ -29,7 +29,6 @@ import (
 type insertStats struct {
 	queued, processed, ignored int
 	usedGas                    uint64
-	lastIndex                  int
 	startTime                  mclock.AbsTime
 }
 
@@ -48,9 +47,9 @@ func (st *insertStats) report(chain []*types.Block, index int, snapDiffItems, sn
 	)
 	// If we're at the last block of the batch or report period reached, log
 	if index == len(chain)-1 || elapsed >= statsReportLimit {
-		// Count the number of transactions in this segment
+		// Count the number of transactions processed in this segment
 		var txs int
-		for _, block := range chain[st.lastIndex : index+1] {
+		for _, block := range chain[(index+1)-st.processed : index+1] {
 			txs += len(block.Transactions())
 		}
 
@@ -94,7 +93,7 @@ func (st *insertStats) report(chain []*types.Block, index int, snapDiffItems, sn
 			}
 		}
 		// Bump the stats reported to the next section
-		*st = insertStats{startTime: now, lastIndex: index + 1}
+		*st = insertStats{startTime: now}
 	}
 }
 


### PR DESCRIPTION
# Description

We observed some inconsistencies on `Imported New Chain Segment` like in the image below:

<img width="1335" height="52" alt="image" src="https://github.com/user-attachments/assets/5ec4f989-7b21-4cbf-835b-b7300d48fda6" />

Both points 1 block, same number and hash but with different amount of txs (`0` and `110`). What happened was:

- The block has actually 0 txs: https://polygonscan.com/block/77,800,253
- The previous one has 110 txs: https://polygonscan.com/block/77,800,252

So the one who printed `txs=110` had on it's chain segment the block `77,800,252`, but it was previously already processed and ignored (but not on the tx count).


So the fix stop using `lastIndex` which was always 0 and started basing itself on the `st.processed` count to determine the count of txs.


# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

