### PR TITLE
Fix receipts and logs on stateless node

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2573,7 +2573,7 @@ func (bc *BlockChain) InsertChainStateless(chain types.Blocks, witnesses []*stat
 		statedb.SetWitness(witness)
 
 		// Write the block to the chain without committing state
-		if _, err := bc.writeBlockAndSetHead(block, nil, nil, statedb, false, true); err != nil {
+		if _, err := bc.writeBlockAndSetHead(block, res.Receipts, res.Logs, statedb, false, true); err != nil {
 			return processed, err
 		}
 


### PR DESCRIPTION
# Description

Receipts and logs were not being written with the block.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes