### PR TITLE
Remove free disk step in CI

### DIFF
--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -25,12 +25,6 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      # This is needed because the job fails with "System.IO.IOException: No space left on device".
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # 2023/10/19
-        with:
-          tool-cache: true
-
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install build-essential


### PR DESCRIPTION
Remove this step since the runner has 600G of disk space. It will reduce roughly 10 to 20 minutes from stateless workflow.