### PR TITLE
core: add blocktime in bor receipt logs

### DIFF
--- a/core/rawdb/bor_receipt.go
+++ b/core/rawdb/bor_receipt.go
@@ -94,13 +94,13 @@ func ReadBorReceipt(db ethdb.Reader, hash common.Hash, number uint64, config *pa
 	// receipts are present as a block with only state-sync transaction can exist.
 	receipts := ReadRawReceipts(db, hash, number)
 
-	body := ReadBody(db, hash, number)
-	if body == nil {
-		log.Error("Missing body but have bor receipt", "hash", hash, "number", number)
+	header := ReadHeader(db, hash, number)
+	if header == nil {
+		log.Error("Missing header but have bor receipt", "hash", hash, "number", number)
 		return nil
 	}
 
-	if err := types.DeriveFieldsForBorReceipt(borReceipt, hash, number, receipts); err != nil {
+	if err := types.DeriveFieldsForBorReceipt(borReceipt, receipts, header); err != nil {
 		log.Error("Failed to derive bor receipt fields", "hash", hash, "number", number, "err", err)
 		return nil
 	}

--- a/core/types/bor_receipt.go
+++ b/core/types/bor_receipt.go
@@ -42,8 +42,10 @@ func NewBorTransaction() *Transaction {
 
 // DeriveFieldsForBorReceipt fills the receipts with their computed fields based on consensus
 // data and contextual infos like containing block and transactions.
-func DeriveFieldsForBorReceipt(receipt *Receipt, hash common.Hash, number uint64, receipts Receipts) error {
+func DeriveFieldsForBorReceipt(receipt *Receipt, receipts Receipts, header *Header) error {
 	// get derived tx hash
+	number := header.Number.Uint64()
+	hash := header.Hash()
 	txHash := GetDerivedBorTxHash(BorReceiptKey(number, hash))
 	txIndex := uint(len(receipts))
 
@@ -66,6 +68,7 @@ func DeriveFieldsForBorReceipt(receipt *Receipt, hash common.Hash, number uint64
 	for j := 0; j < len(receipt.Logs); j++ {
 		receipt.Logs[j].BlockNumber = number
 		receipt.Logs[j].BlockHash = hash
+		receipt.Logs[j].BlockTimestamp = header.Time
 		receipt.Logs[j].TxHash = txHash
 		receipt.Logs[j].TxIndex = txIndex
 		receipt.Logs[j].Index = uint(logIndex)


### PR DESCRIPTION
# Description

Block timestamp was not included when state-sync receipts were queried via rpc. This PR includes that when we're deriving fields for receipts. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
