### PR TITLE
Revert setting madhugiri HF block number for amoy

### DIFF
--- a/builder/files/genesis-amoy.json
+++ b/builder/files/genesis-amoy.json
@@ -23,14 +23,12 @@
       "ahmedabadBlock": 11865856,
       "bhilaiBlock": 22765056,
       "rioBlock": 26272256,
-      "madhugiriBlock": 28899616,
       "skipValidatorByteCheck": [26160367, 26161087, 26171567, 26173743, 26175647],
       "stateSyncConfirmationDelay": {
         "0": 128
       },
       "period": {
-        "0": 2,
-        "28899616": 1
+        "0": 2
       },
       "producerDelay": {
         "0": 4

--- a/internal/cli/server/chains/amoy.go
+++ b/internal/cli/server/chains/amoy.go
@@ -36,13 +36,11 @@ var amoyTestnet = &Chain{
 				AhmedabadBlock: big.NewInt(11865856),
 				BhilaiBlock:    big.NewInt(22765056),
 				RioBlock:       big.NewInt(26272256),
-				MadhugiriBlock: big.NewInt(28899616),
 				StateSyncConfirmationDelay: map[string]uint64{
 					"0": 128,
 				},
 				Period: map[string]uint64{
-					"0":        2,
-					"28899616": 1,
+					"0": 2,
 				},
 				ProducerDelay: map[string]uint64{
 					"0": 4,

--- a/params/config.go
+++ b/params/config.go
@@ -338,13 +338,11 @@ var (
 			AhmedabadBlock: big.NewInt(11865856),
 			BhilaiBlock:    big.NewInt(22765056),
 			RioBlock:       big.NewInt(26272256),
-			MadhugiriBlock: big.NewInt(28899616),
 			StateSyncConfirmationDelay: map[string]uint64{
 				"0": 128,
 			},
 			Period: map[string]uint64{
-				"0":        2,
-				"28899616": 1,
+				"0": 2,
 			},
 			ProducerDelay: map[string]uint64{
 				"0": 4,


### PR DESCRIPTION
This reverts commit https://github.com/0xPolygon/bor/commit/103f1f45406bb19f9a7d1c457a11720df0a40f81 which set the madhugiri HF block number for amoy. 