### PR TITLE
chore: use 2^25 as the MaxTxGas

### DIFF
--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -260,7 +260,7 @@ func TestStateProcessorErrors(t *testing.T) {
 				txs: []*types.Transaction{
 					makeTx(key1, 0, common.Address{}, big.NewInt(0), params.MaxTxGas+1, big.NewInt(875000000), nil),
 				},
-				want: "could not apply tx 0 [0x16505812a6da0b0150593e4d4eb90190ba64816a04b27d19ca926ebd6aff8aa0]: transaction gas limit too high (cap: 16777216, tx: 16777217)",
+				want: "could not apply tx 0 [0xc63b687cdc475aee795213665fdb96d458f09ec72cc61a184f84e6832aeb0e86]: transaction gas limit too high (cap: 33554432, tx: 33554433)",
 			},
 		} {
 			block := GenerateBadBlock(gspec.ToBlock(), beacon.New(ethash.NewFaker()), tt.txs, gspec.Config, false)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -28,7 +28,7 @@ const (
 	MaxGasLimit          uint64 = 0x7fffffffffffffff // Maximum the gas limit (2^63-1).
 	GenesisGasLimit      uint64 = 4712388            // Gas limit of the Genesis block.
 
-	MaxTxGas uint64 = 1 << 24 // Maximum transaction gas limit after eip-7825 (16,777,216).
+	MaxTxGas uint64 = 1 << 25 // Maximum transaction gas limit after eip-7825 (33,554,432).
 
 	MaximumExtraDataSize  uint64 = 32    // Maximum size extra data may be after Genesis.
 	ExpByteGas            uint64 = 10    // Times ceil(log256(exponent)) for the EXP instruction.


### PR DESCRIPTION
# Description

Changes the `MaxTxGas` to 2^25.