### PR TITLE
chore: fix goreleaser-cross

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ geth-windows-amd64:
 	@ls -ld $(GOBIN)/geth-windows-* | grep amd64
 
 PACKAGE_NAME          := github.com/0xPolygon/bor
-GOLANG_CROSS_VERSION  ?= v1.25.4
+GOLANG_CROSS_VERSION  ?= v1.22.1
 
 .PHONY: release-dry-run
 release-dry-run:


### PR DESCRIPTION
# Description

Fix the goreleaser-cross by using a version which is compatible with the flags being used.