### PR TITLE
eth/protocols/eth: increase queue limit by 5x for tx announcement

### DIFF
--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -43,10 +43,13 @@ const (
 	maxQueuedTxs = 4096
 
 	// maxQueuedTxAnns is the maximum number of transaction announcements to queue up
-	// before dropping older announcements.
-	maxQueuedTxAnns = 4096
+	// before dropping older announcements. 5x multipler used for better transaction
+	// dissemination during initial announcement (after a p2p handshake happens).
+	maxQueuedTxAnns = 5 * 4096
 
-	// maxQueuedTxAnnsTrusted is the maximum number of transaction announcements to queue up before dropping older announcements for trusted and static peers. Specific to Bor.
+	// maxQueuedTxAnnsTrusted is the maximum number of transaction announcements to
+	// queue up before dropping older announcements for trusted and static peers.
+	// Specific to Bor.
 	maxQueuedTxAnnsTrusted = 40960
 
 	// maxQueuedBlocks is the maximum number of block propagations to queue up before


### PR DESCRIPTION
# Description

5x increase the queue limit for better transaction dissemination during initial announcement which happens after p2p handshake. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
