### PR TITLE
consensus/eip1559: add missing bhilai HF tests

### DIFF
--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -70,7 +70,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 	var (
 		num                            = new(big.Int)
 		denom                          = new(big.Int)
-		baseFeeChangeDenominatorUint64 = params.BaseFeeChangeDenominator(config.Bor, parent.Number)
+		baseFeeChangeDenominatorUint64 = baseFeeChangeDenominator(config, parent.Number)
 	)
 
 	if parent.GasUsed > parentGasTarget {
@@ -97,6 +97,25 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 			baseFee = common.Big0
 		}
 		return baseFee
+	}
+}
+
+// baseFeeChangeDenominator returns the denominator used to bound the amount the base fee can change between blocks.
+// The value varies based on the hard fork:
+// - Pre-Delhi: 8 (default)
+// - Post-Delhi: 16
+// - Post-Bhilai: 64
+// If borConfig is nil, returns the default value of 8.
+func baseFeeChangeDenominator(config *params.ChainConfig, number *big.Int) uint64 {
+	if config.Bor == nil {
+		return params.DefaultBaseFeeChangeDenominator
+	}
+	if config.Bor.IsBhilai(number) {
+		return params.BaseFeeChangeDenominatorPostBhilai
+	} else if config.Bor.IsDelhi(number) {
+		return params.BaseFeeChangeDenominatorPostDelhi
+	} else {
+		return params.DefaultBaseFeeChangeDenominator
 	}
 }
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -130,15 +130,14 @@ const (
 	// Introduced in Tangerine Whistle (Eip 150)
 	CreateBySelfdestructGas uint64 = 25000
 
-	BaseFeeChangeDenominatorPreDelhi   = 8  // Bounds the amount the base fee can change between blocks before Delhi Hard Fork.
+	DefaultBaseFeeChangeDenominator    = 8  // Bounds the amount the base fee can change between blocks.
 	BaseFeeChangeDenominatorPostDelhi  = 16 // Bounds the amount the base fee can change between blocks after Delhi Hard Fork.
 	BaseFeeChangeDenominatorPostBhilai = 64 // Bounds the amount the base fee can change between blocks after Bhilai Hard Fork.
 
-	ElasticityMultiplier = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
-	InitialBaseFee       = 1000000000 // Initial base fee for EIP-1559 blocks.
+	DefaultElasticityMultiplier = 2 // Bounds the maximum gas limit an EIP-1559 block may have.
+	ElasticityMultiplier        = 2 // Bounds the maximum gas limit an EIP-1559 block may have.
 
-	DefaultBaseFeeChangeDenominator = 8 // Bounds the amount the base fee can change between blocks.
-	DefaultElasticityMultiplier     = 2 // Bounds the maximum gas limit an EIP-1559 block may have.
+	InitialBaseFee = 1000000000 // Initial base fee for EIP-1559 blocks.
 
 	DefaultTargetGasPercentage     = 50 // Specifies target block gas as percentage of block gas limit for EIP-1559
 	TargetGasPercentagePostDandeli = 65 // Specifies target block gas as percentage of block gas limit for EIP-1559 after Dandeli hard fork
@@ -235,23 +234,3 @@ var (
 	ConsolidationQueueAddress = common.HexToAddress("0x0000BBdDc7CE488642fb579F8B00f3a590007251")
 	ConsolidationQueueCode    = common.FromHex("3373fffffffffffffffffffffffffffffffffffffffe1460d35760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1461019a57600182026001905f5b5f82111560685781019083028483029004916001019190604d565b9093900492505050366060146088573661019a573461019a575f5260205ff35b341061019a57600154600101600155600354806004026004013381556001015f358155600101602035815560010160403590553360601b5f5260605f60143760745fa0600101600355005b6003546002548082038060021160e7575060025b5f5b8181146101295782810160040260040181607402815460601b815260140181600101548152602001816002015481526020019060030154905260010160e9565b910180921461013b5790600255610146565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff141561017357505f5b6001546001828201116101885750505f61018e565b01600190035b5f555f6001556074025ff35b5f5ffd")
 )
-
-// BaseFeeChangeDenominator returns the denominator used to bound the amount the base fee can change between blocks.
-// The value varies based on the hard fork:
-// - Pre-Delhi: 8 (default)
-// - Post-Delhi: 16
-// - Post-Bhilai: 64
-// If borConfig is nil, returns the default value of 8.
-func BaseFeeChangeDenominator(borConfig *BorConfig, number *big.Int) uint64 {
-	// Handle cases where bor consensus isn't available to avoid panic
-	if borConfig == nil {
-		return DefaultBaseFeeChangeDenominator
-	}
-	if borConfig.IsBhilai(number) {
-		return BaseFeeChangeDenominatorPostBhilai
-	} else if borConfig.IsDelhi(number) {
-		return BaseFeeChangeDenominatorPostDelhi
-	} else {
-		return BaseFeeChangeDenominatorPreDelhi
-	}
-}


### PR DESCRIPTION
# Description

Eip 1559 tests for Bhilai HF (which changed the base fee denominator) were missing. This PR adds that and refactors the functions a bit for better readability. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
