### PR TITLE
fix: prevent nil pointer dereference in eth_simulateV1

### DIFF
--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -234,13 +234,15 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		header.ExcessBlobGas = &excess
 	}
 	blockContext := core.NewEVMBlockContext(header, sim.newSimulatedChainContext(ctx, headers), nil)
-	if block.BlockOverrides.BlobBaseFee != nil {
+	if block.BlockOverrides != nil && block.BlockOverrides.BlobBaseFee != nil {
 		blockContext.BlobBaseFee = block.BlockOverrides.BlobBaseFee.ToInt()
 	}
 	precompiles := sim.activePrecompiles(sim.base)
 	// State overrides are applied prior to execution of a block
-	if err := block.StateOverrides.Apply(sim.state, precompiles); err != nil {
-		return nil, nil, nil, err
+	if block.StateOverrides != nil {
+		if err := block.StateOverrides.Apply(sim.state, precompiles); err != nil {
+			return nil, nil, nil, err
+		}
 	}
 	var (
 		gasUsed, blobGasUsed uint64


### PR DESCRIPTION
Add nil checks for `BlockOverrides` and `StateOverrides` before accessing their fields in `processBlock()`. This fixes a crash when `eth_simulateV1` is called with minimal parameters that don't include these overrides.

The panic occurred at lines 237 and 242 where the code attempted to access nested fields without checking if the parent objects were nil.

Here is how we can reproduce
```
curl -s http://localhost:8545 -H 'content-type: application/json' \
--data '{
  "jsonrpc":"2.0",
  "id":1,
  "method":"eth_simulateV1",
  "params":[
    {"blockStateCalls":[{"calls":[{"from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000000000","data":"0x"}]}]},
    "latest"
  ]
}'
# => -32603 "method handler crashed"
```

# Description

Please provide a detailed description of what was done in this PR

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
