### PR TITLE
fix: add bor hfs to description and readheadertimeout in config

### DIFF
--- a/internal/cli/dumpconfig.go
+++ b/internal/cli/dumpconfig.go
@@ -54,6 +54,7 @@ func (c *DumpconfigCommand) Run(args []string) int {
 	// convert the big.Int and time.Duration fields to their corresponding Raw fields
 	userConfig.JsonRPC.RPCEVMTimeoutRaw = userConfig.JsonRPC.RPCEVMTimeout.String()
 	userConfig.JsonRPC.HttpTimeout.ReadTimeoutRaw = userConfig.JsonRPC.HttpTimeout.ReadTimeout.String()
+	userConfig.JsonRPC.HttpTimeout.ReadHeaderTimeoutRaw = userConfig.JsonRPC.HttpTimeout.ReadHeaderTimeout.String()
 	userConfig.JsonRPC.HttpTimeout.WriteTimeoutRaw = userConfig.JsonRPC.HttpTimeout.WriteTimeout.String()
 	userConfig.JsonRPC.HttpTimeout.IdleTimeoutRaw = userConfig.JsonRPC.HttpTimeout.IdleTimeout.String()
 	userConfig.JsonRPC.Http.ExecutionPoolRequestTimeoutRaw = userConfig.JsonRPC.Http.ExecutionPoolRequestTimeout.String()

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -521,6 +521,11 @@ type HttpTimeouts struct {
 	ReadTimeout    time.Duration `hcl:"-,optional" toml:"-"`
 	ReadTimeoutRaw string        `hcl:"read,optional" toml:"read,optional"`
 
+	// ReadHeaderTimeout is the amount of time allowed to read
+	// request headers.
+	ReadHeaderTimeout    time.Duration `hcl:"-,optional" toml:"-"`
+	ReadHeaderTimeoutRaw string        `hcl:"readheader,optional" toml:"readheader,optional"`
+
 	// WriteTimeout is the maximum duration before timing out
 	// writes of the response. It is reset whenever a new
 	// request's header is read. Like ReadTimeout, it does not
@@ -861,9 +866,10 @@ func DefaultConfig() *Config {
 				VHost:   []string{"localhost"},
 			},
 			HttpTimeout: &HttpTimeouts{
-				ReadTimeout:  10 * time.Second,
-				WriteTimeout: 30 * time.Second,
-				IdleTimeout:  120 * time.Second,
+				ReadTimeout:       10 * time.Second,
+				ReadHeaderTimeout: 30 * time.Second,
+				WriteTimeout:      30 * time.Second,
+				IdleTimeout:       120 * time.Second,
 			},
 			Auth: &AUTHConfig{
 				JWTSecret: "",
@@ -1014,6 +1020,7 @@ func (c *Config) fillTimeDurations() error {
 		{"miner.recommit", &c.Sealer.Recommit, &c.Sealer.RecommitRaw},
 		{"miner.blocktime", &c.Sealer.BlockTime, &c.Sealer.BlockTimeRaw},
 		{"jsonrpc.timeouts.read", &c.JsonRPC.HttpTimeout.ReadTimeout, &c.JsonRPC.HttpTimeout.ReadTimeoutRaw},
+		{"jsonrpc.timeouts.readheader", &c.JsonRPC.HttpTimeout.ReadHeaderTimeout, &c.JsonRPC.HttpTimeout.ReadHeaderTimeoutRaw},
 		{"jsonrpc.timeouts.write", &c.JsonRPC.HttpTimeout.WriteTimeout, &c.JsonRPC.HttpTimeout.WriteTimeoutRaw},
 		{"jsonrpc.timeouts.idle", &c.JsonRPC.HttpTimeout.IdleTimeout, &c.JsonRPC.HttpTimeout.IdleTimeoutRaw},
 		{"jsonrpc.ws.ep-requesttimeout", &c.JsonRPC.Ws.ExecutionPoolRequestTimeout, &c.JsonRPC.Ws.ExecutionPoolRequestTimeoutRaw},
@@ -1670,9 +1677,10 @@ func (c *Config) buildNode() (*node.Config, error) {
 		GraphQLCors:         c.JsonRPC.Graphql.Cors,
 		GraphQLVirtualHosts: c.JsonRPC.Graphql.VHost,
 		HTTPTimeouts: rpc.HTTPTimeouts{
-			ReadTimeout:  c.JsonRPC.HttpTimeout.ReadTimeout,
-			WriteTimeout: c.JsonRPC.HttpTimeout.WriteTimeout,
-			IdleTimeout:  c.JsonRPC.HttpTimeout.IdleTimeout,
+			ReadTimeout:       c.JsonRPC.HttpTimeout.ReadTimeout,
+			ReadHeaderTimeout: c.JsonRPC.HttpTimeout.ReadHeaderTimeout,
+			WriteTimeout:      c.JsonRPC.HttpTimeout.WriteTimeout,
+			IdleTimeout:       c.JsonRPC.HttpTimeout.IdleTimeout,
 		},
 		JWTSecret:                              c.JsonRPC.Auth.JWTSecret,
 		AuthPort:                               int(c.JsonRPC.Auth.Port),

--- a/params/config.go
+++ b/params/config.go
@@ -1042,6 +1042,39 @@ func (c *ChainConfig) Description() string {
 
 	banner += "\n"
 
+	// Bor-specific hard forks.
+	if c.Bor != nil {
+		banner += "Bor hard forks (block based):\n"
+		if c.Bor.JaipurBlock != nil {
+			banner += fmt.Sprintf(" - Jaipur:                      #%-8v\n", c.Bor.JaipurBlock)
+		}
+		if c.Bor.DelhiBlock != nil {
+			banner += fmt.Sprintf(" - Delhi:                       #%-8v\n", c.Bor.DelhiBlock)
+		}
+		if c.Bor.IndoreBlock != nil {
+			banner += fmt.Sprintf(" - Indore:                      #%-8v\n", c.Bor.IndoreBlock)
+		}
+		if c.Bor.AhmedabadBlock != nil {
+			banner += fmt.Sprintf(" - Ahmedabad:                   #%-8v\n", c.Bor.AhmedabadBlock)
+		}
+		if c.Bor.BhilaiBlock != nil {
+			banner += fmt.Sprintf(" - Bhilai:                      #%-8v\n", c.Bor.BhilaiBlock)
+		}
+		if c.Bor.RioBlock != nil {
+			banner += fmt.Sprintf(" - Rio:                         #%-8v\n", c.Bor.RioBlock)
+		}
+		if c.Bor.MadhugiriBlock != nil {
+			banner += fmt.Sprintf(" - Madhugiri:                   #%-8v\n", c.Bor.MadhugiriBlock)
+		}
+		if c.Bor.MadhugiriProBlock != nil {
+			banner += fmt.Sprintf(" - Madhugiri Pro:               #%-8v\n", c.Bor.MadhugiriProBlock)
+		}
+		if c.Bor.DandeliBlock != nil {
+			banner += fmt.Sprintf(" - Dandeli:                     #%-8v\n", c.Bor.DandeliBlock)
+		}
+		return banner
+	}
+
 	// Create a list of forks with a short description of them. Forks that only
 	// makes sense for mainnet should be optional at printing to avoid bloating
 	// the output for testnets and private networks.


### PR DESCRIPTION
# Description

Fixes the following warning by adding the missing flag value to the config:
```bash
WARN [01-22|07:21:00.778] Sanitizing invalid HTTP read header timeout provided=0s updated=30s 
```

And adds bor hardfork values instead of geth in the description:

```bash
INFO [01-22|07:45:02.568] Bor hard forks (block based):
INFO [01-22|07:45:02.568]  - Jaipur:                      #0       
INFO [01-22|07:45:02.568]  - Delhi:                       #0       
INFO [01-22|07:45:02.568]  - Indore:                      #0       
INFO [01-22|07:45:02.568]  - Ahmedabad:                   #0       
INFO [01-22|07:45:02.568]  - Bhilai:                      #0       
INFO [01-22|07:45:02.568]  - Rio:                         #256     
INFO [01-22|07:45:02.568]  - Madhugiri:                   #256     
INFO [01-22|07:45:02.568]  - Madhugiri Pro:               #256     
INFO [01-22|07:45:02.568]  - Dandeli:                     #256
```