### PR TITLE
bind, params: fix bind/v2 tests and warn about invalid config/flag

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -31,6 +31,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
@@ -71,6 +73,7 @@ type SimulatedBackend struct {
 
 	database   ethdb.Database   // In memory database to store our testing data
 	blockchain *core.BlockChain // Ethereum blockchain to handle the consensus
+	engine     consensus.Engine // Consensus engine for block generation
 
 	mu              sync.Mutex
 	pendingBlock    *types.Block   // Currently pending block that will be imported on request
@@ -87,17 +90,32 @@ type SimulatedBackend struct {
 // and uses a simulated blockchain for testing purposes.
 // A simulated backend always uses chainID 1337.
 func NewSimulatedBackendWithDatabase(database ethdb.Database, alloc types.GenesisAlloc, gasLimit uint64) *SimulatedBackend {
+	return NewSimulatedBackendWithConfig(database, alloc, gasLimit, params.AllEthashProtocolChanges)
+}
+
+// NewSimulatedBackendWithConfig creates a new binding backend based on the given database
+// and chain config. Use this when you need features from newer EVM versions (e.g., PUSH0 from Shanghai).
+func NewSimulatedBackendWithConfig(database ethdb.Database, alloc types.GenesisAlloc, gasLimit uint64, config *params.ChainConfig) *SimulatedBackend {
 	genesis := core.Genesis{
-		Config:   params.AllEthashProtocolChanges,
+		Config:   config,
 		GasLimit: gasLimit,
 		Alloc:    alloc,
 	}
 
-	blockchain, _ := core.NewBlockChain(database, &genesis, ethash.NewFaker(), core.DefaultConfig())
+	// Use beacon.NewFaker() for post-merge configs (Shanghai+), ethash.NewFaker() otherwise
+	var engine consensus.Engine
+	if config.ShanghaiBlock != nil {
+		engine = beacon.NewFaker()
+	} else {
+		engine = ethash.NewFaker()
+	}
+
+	blockchain, _ := core.NewBlockChain(database, &genesis, engine, core.DefaultConfig())
 
 	backend := &SimulatedBackend{
 		database:   database,
 		blockchain: blockchain,
+		engine:     engine,
 		config:     genesis.Config,
 	}
 
@@ -155,7 +173,7 @@ func (b *SimulatedBackend) Rollback() {
 }
 
 func (b *SimulatedBackend) rollback(parent *types.Block) {
-	blocks, _ := core.GenerateChain(b.config, parent, ethash.NewFaker(), b.database, 1, func(int, *core.BlockGen) {})
+	blocks, _ := core.GenerateChain(b.config, parent, b.engine, b.database, 1, func(int, *core.BlockGen) {})
 
 	b.pendingBlock = blocks[0]
 	b.pendingState, _ = state.New(b.pendingBlock.Root(), b.blockchain.StateCache())
@@ -685,7 +703,8 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	}
 	// Ensure message is initialized properly.
 	if call.Gas == 0 {
-		call.Gas = 10 * header.GasLimit
+		// Use MaxTxGas as the cap for call gas to avoid exceeding protocol limits
+		call.Gas = params.MaxTxGas
 	}
 	if call.Value == nil {
 		call.Value = new(big.Int)
@@ -739,7 +758,7 @@ func (b *SimulatedBackend) SendTransaction(ctx context.Context, tx *types.Transa
 		return fmt.Errorf("invalid transaction nonce: got %d, want %d", tx.Nonce(), nonce)
 	}
 	// Include tx in chain
-	blocks, receipts := core.GenerateChain(b.config, block, ethash.NewFaker(), b.database, 1, func(number int, block *core.BlockGen) {
+	blocks, receipts := core.GenerateChain(b.config, block, b.engine, b.database, 1, func(number int, block *core.BlockGen) {
 		for _, tx := range b.pendingBlock.Transactions() {
 			block.AddTxWithChain(b.blockchain, tx)
 		}
@@ -770,7 +789,7 @@ func (b *SimulatedBackend) FilterLogs(ctx context.Context, query ethereum.Filter
 		if query.FromBlock != nil {
 			from = query.FromBlock.Int64()
 		}
-		to := int64(-1)
+		to := int64(rpc.LatestBlockNumber) // Use LatestBlockNumber (-2), not -1 which is PendingBlockNumber
 		if query.ToBlock != nil {
 			to = query.ToBlock.Int64()
 		}
@@ -865,7 +884,7 @@ func (b *SimulatedBackend) AdjustTime(adjustment time.Duration) error {
 		return errors.New("could not find parent")
 	}
 
-	blocks, _ := core.GenerateChain(b.config, block, ethash.NewFaker(), b.database, 1, func(number int, block *core.BlockGen) {
+	blocks, _ := core.GenerateChain(b.config, block, b.engine, b.database, 1, func(number int, block *core.BlockGen) {
 		block.OffsetTime(int64(adjustment.Seconds()))
 	})
 	stateDB, err := b.blockchain.State()
@@ -971,15 +990,19 @@ func (fb *filterBackend) ChainConfig() *params.ChainConfig {
 }
 
 func (fb *filterBackend) CurrentHeader() *types.Header {
-	panic("not supported")
+	return fb.bc.CurrentHeader()
 }
 
 func (fb *filterBackend) NewMatcherBackend() filtermaps.MatcherBackend {
-	panic("not supported")
+	return &simulatedMatcherBackend{bc: fb.bc}
 }
 
 func (fb *filterBackend) CurrentView() *filtermaps.ChainView {
-	panic("implement me")
+	header := fb.bc.CurrentHeader()
+	if header == nil {
+		return nil
+	}
+	return filtermaps.NewChainView(fb.bc, header.Number.Uint64(), header.Hash())
 }
 
 func (fb *filterBackend) HistoryPruningCutoff() uint64 {
@@ -992,3 +1015,41 @@ func nullSubscription() event.Subscription {
 		return nil
 	})
 }
+
+// simulatedMatcherBackend implements filtermaps.MatcherBackend for the simulated backend.
+// It returns empty indexed ranges to force unindexed (raw block iteration) search.
+type simulatedMatcherBackend struct {
+	bc *core.BlockChain
+}
+
+func (mb *simulatedMatcherBackend) GetParams() *filtermaps.Params {
+	return &filtermaps.Params{}
+}
+
+func (mb *simulatedMatcherBackend) GetBlockLvPointer(ctx context.Context, blockNumber uint64) (uint64, error) {
+	return 0, nil
+}
+
+func (mb *simulatedMatcherBackend) GetFilterMapRows(ctx context.Context, mapIndices []uint32, rowIndex uint32, baseLayerOnly bool) ([]filtermaps.FilterRow, error) {
+	return nil, nil
+}
+
+func (mb *simulatedMatcherBackend) GetLogByLvIndex(ctx context.Context, lvIndex uint64) (*types.Log, error) {
+	return nil, nil
+}
+
+func (mb *simulatedMatcherBackend) SyncLogIndex(ctx context.Context) (filtermaps.SyncRange, error) {
+	header := mb.bc.CurrentHeader()
+	if header == nil {
+		return filtermaps.SyncRange{}, errors.New("no current header")
+	}
+	cv := filtermaps.NewChainView(mb.bc, header.Number.Uint64(), header.Hash())
+	// Return empty IndexedBlocks to force unindexed search
+	return filtermaps.SyncRange{
+		IndexedView:   cv,
+		ValidBlocks:   common.NewRange(uint64(0), uint64(0)),
+		IndexedBlocks: common.NewRange(uint64(0), uint64(0)),
+	}, nil
+}
+
+func (mb *simulatedMatcherBackend) Close() {}

--- a/accounts/abi/bind/v2/lib_test.go
+++ b/accounts/abi/bind/v2/lib_test.go
@@ -28,53 +28,39 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2/internal/contracts/nested_libraries"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2/internal/contracts/solc_errors"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/ethclient/simulated"
-	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 )
 
 var testKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 var testAddr = crypto.PubkeyToAddress(testKey.PublicKey)
 
-func testSetup() (*backends.SimulatedBackend, error) {
-	backend := simulated.NewBackend(
+// testChainID is the chain ID used by MergedTestChainConfig
+var testChainID = big.NewInt(1)
+
+func testSetup() *backends.SimulatedBackend {
+	return backends.NewSimulatedBackendWithConfig(
+		rawdb.NewMemoryDatabase(),
 		types.GenesisAlloc{
 			testAddr: {Balance: big.NewInt(1000000000000000000)},
 		},
-		func(nodeConf *node.Config, ethConf *ethconfig.Config) {
-			ethConf.Genesis.Difficulty = big.NewInt(0)
-		},
+		60000000,
+		params.MergedTestChainConfig,
 	)
-
-	// we should just be able to use the backend directly, instead of using
-	// this deprecated interface. However, the simulated backend no longer
-	// implements backends.SimulatedBackend...
-	bindBackend := backends.SimulatedBackend{
-		Backend: backend,
-		Client:  backend.Client(),
-	}
-	return &bindBackend, nil
 }
 
-func makeTestDeployer(backend simulated.Client) func(input, deployer []byte) (common.Address, *types.Transaction, error) {
-	chainId, _ := backend.ChainID(context.Background())
-	return bind.DefaultDeployer(bind.NewKeyedTransactor(testKey, chainId), backend)
+func makeTestDeployer(backend *backends.SimulatedBackend) func(input, deployer []byte) (common.Address, *types.Transaction, error) {
+	return bind.DefaultDeployer(bind.NewKeyedTransactor(testKey, testChainID), backend)
 }
 
 // test that deploying a contract with library dependencies works,
 // verifying by calling method on the deployed contract.
 func TestDeploymentLibraries(t *testing.T) {
-	// TODO - bor: refactor and enable (task: POS-3046)
-	t.Skip("bor: Skipping all tests for now. To be fixed later")
-	bindBackend, err := testSetup()
-	if err != nil {
-		t.Fatalf("err setting up test: %v", err)
-	}
-	defer bindBackend.Backend.Close()
+	backend := testSetup()
+	defer backend.Close()
 
 	c := nested_libraries.NewC1()
 	constructorInput := c.PackConstructor(big.NewInt(42), big.NewInt(1))
@@ -82,17 +68,17 @@ func TestDeploymentLibraries(t *testing.T) {
 		Contracts: []*bind.MetaData{&nested_libraries.C1MetaData},
 		Inputs:    map[string][]byte{nested_libraries.C1MetaData.ID: constructorInput},
 	}
-	res, err := bind.LinkAndDeploy(deploymentParams, makeTestDeployer(bindBackend.Client))
+	res, err := bind.LinkAndDeploy(deploymentParams, makeTestDeployer(backend))
 	if err != nil {
 		t.Fatalf("err: %+v\n", err)
 	}
-	bindBackend.Commit()
+	backend.Commit()
 
 	if len(res.Addresses) != 5 {
 		t.Fatalf("deployment should have generated 5 addresses.  got %d", len(res.Addresses))
 	}
 	for _, tx := range res.Txs {
-		_, err = bind.WaitDeployed(t.Context(), bindBackend, tx.Hash())
+		_, err = bind.WaitDeployed(t.Context(), backend, tx.Hash())
 		if err != nil {
 			t.Fatalf("error deploying library: %+v", err)
 		}
@@ -101,7 +87,7 @@ func TestDeploymentLibraries(t *testing.T) {
 	doInput := c.PackDo(big.NewInt(1))
 	contractAddr := res.Addresses[nested_libraries.C1MetaData.ID]
 	callOpts := &bind.CallOpts{From: common.Address{}, Context: t.Context()}
-	instance := c.Instance(bindBackend, contractAddr)
+	instance := c.Instance(backend, contractAddr)
 	internalCallCount, err := bind.Call(instance, callOpts, doInput, c.UnpackDo)
 	if err != nil {
 		t.Fatalf("err unpacking result: %v", err)
@@ -114,29 +100,24 @@ func TestDeploymentLibraries(t *testing.T) {
 // Same as TestDeployment.  However, stagger the deployments with overrides:
 // first deploy the library deps and then the contract.
 func TestDeploymentWithOverrides(t *testing.T) {
-	// TODO - bor: refactor and enable (task: POS-3046)
-	t.Skip("bor: Skipping all tests for now. To be fixed later")
-	bindBackend, err := testSetup()
-	if err != nil {
-		t.Fatalf("err setting up test: %v", err)
-	}
-	defer bindBackend.Backend.Close()
+	backend := testSetup()
+	defer backend.Close()
 
 	// deploy all the library dependencies of our target contract, but not the target contract itself.
 	deploymentParams := &bind.DeploymentParams{
 		Contracts: nested_libraries.C1MetaData.Deps,
 	}
-	res, err := bind.LinkAndDeploy(deploymentParams, makeTestDeployer(bindBackend))
+	res, err := bind.LinkAndDeploy(deploymentParams, makeTestDeployer(backend))
 	if err != nil {
 		t.Fatalf("err: %+v\n", err)
 	}
-	bindBackend.Commit()
+	backend.Commit()
 
 	if len(res.Addresses) != 4 {
 		t.Fatalf("deployment should have generated 4 addresses.  got %d", len(res.Addresses))
 	}
 	for _, tx := range res.Txs {
-		_, err = bind.WaitDeployed(t.Context(), bindBackend, tx.Hash())
+		_, err = bind.WaitDeployed(t.Context(), backend, tx.Hash())
 		if err != nil {
 			t.Fatalf("error deploying library: %+v", err)
 		}
@@ -152,17 +133,17 @@ func TestDeploymentWithOverrides(t *testing.T) {
 		Inputs:    map[string][]byte{nested_libraries.C1MetaData.ID: constructorInput},
 		Overrides: overrides,
 	}
-	res, err = bind.LinkAndDeploy(deploymentParams, makeTestDeployer(bindBackend))
+	res, err = bind.LinkAndDeploy(deploymentParams, makeTestDeployer(backend))
 	if err != nil {
 		t.Fatalf("err: %+v\n", err)
 	}
-	bindBackend.Commit()
+	backend.Commit()
 
 	if len(res.Addresses) != 1 {
 		t.Fatalf("deployment should have generated 1 address.  got %d", len(res.Addresses))
 	}
 	for _, tx := range res.Txs {
-		_, err = bind.WaitDeployed(t.Context(), bindBackend, tx.Hash())
+		_, err = bind.WaitDeployed(t.Context(), backend, tx.Hash())
 		if err != nil {
 			t.Fatalf("error deploying library: %+v", err)
 		}
@@ -170,7 +151,7 @@ func TestDeploymentWithOverrides(t *testing.T) {
 
 	// call the deployed contract and make sure it returns the correct result
 	doInput := c.PackDo(big.NewInt(1))
-	instance := c.Instance(bindBackend, res.Addresses[nested_libraries.C1MetaData.ID])
+	instance := c.Instance(backend, res.Addresses[nested_libraries.C1MetaData.ID])
 	callOpts := new(bind.CallOpts)
 	internalCallCount, err := bind.Call(instance, callOpts, doInput, c.UnpackDo)
 	if err != nil {
@@ -183,7 +164,7 @@ func TestDeploymentWithOverrides(t *testing.T) {
 
 // returns transaction auth to send a basic transaction from testAddr
 func defaultTxAuth() *bind.TransactOpts {
-	signer := types.LatestSigner(params.AllDevChainProtocolChanges)
+	signer := types.LatestSigner(params.MergedTestChainConfig)
 	opts := &bind.TransactOpts{
 		From:  testAddr,
 		Nonce: nil,
@@ -204,13 +185,10 @@ func defaultTxAuth() *bind.TransactOpts {
 }
 
 func TestEvents(t *testing.T) {
-	// TODO - bor: refactor and enable (task: POS-3046)
-	t.Skip("bor: Skipping all tests for now. To be fixed later")
 	// test watch/filter logs method on a contract that emits various kinds of events (struct-containing, etc.)
-	backend, err := testSetup()
-	if err != nil {
-		t.Fatalf("error setting up testing env: %v", err)
-	}
+	backend := testSetup()
+	defer backend.Close()
+
 	deploymentParams := &bind.DeploymentParams{
 		Contracts: []*bind.MetaData{&events.CMetaData},
 	}
@@ -313,13 +291,10 @@ done:
 }
 
 func TestErrors(t *testing.T) {
-	// TODO - bor: refactor and enable (task: POS-3046)
-	t.Skip("bor: Skipping all tests for now. To be fixed later")
 	// test watch/filter logs method on a contract that emits various kinds of events (struct-containing, etc.)
-	backend, err := testSetup()
-	if err != nil {
-		t.Fatalf("error setting up testing env: %v", err)
-	}
+	backend := testSetup()
+	defer backend.Close()
+
 	deploymentParams := &bind.DeploymentParams{
 		Contracts: []*bind.MetaData{&solc_errors.CMetaData},
 	}
@@ -336,7 +311,7 @@ func TestErrors(t *testing.T) {
 	c := solc_errors.NewC()
 	instance := c.Instance(backend, res.Addresses[solc_errors.CMetaData.ID])
 	packedInput := c.PackFoo()
-	opts := &bind.CallOpts{From: res.Addresses[solc_errors.CMetaData.ID]}
+	opts := &bind.CallOpts{From: testAddr} // Use EOA, not contract address
 	_, err = bind.Call[struct{}](instance, opts, packedInput, nil)
 	if err == nil {
 		t.Fatalf("expected call to fail")

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -87,6 +87,7 @@ var tomlSettings = toml.Config{
 		if unicode.IsUpper(rune(rt.Name()[0])) && rt.PkgPath() != "main" {
 			link = fmt.Sprintf(", see https://godoc.org/%s#%s for available fields", rt.PkgPath(), rt.Name())
 		}
+		log.Warn(fmt.Sprintf("Unrecognized config option '%s' in %s%s", field, rt.String(), link))
 		return fmt.Errorf("field '%s' is not defined in %s%s", field, rt.String(), link)
 	},
 }

--- a/internal/cli/server/config_legacy.go
+++ b/internal/cli/server/config_legacy.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 func readLegacyConfig(path string) (*Config, error) {
@@ -17,8 +18,13 @@ func readLegacyConfig(path string) (*Config, error) {
 
 	conf := *DefaultConfig()
 
-	if _, err := toml.Decode(tomlData, &conf); err != nil {
+	meta, err := toml.Decode(tomlData, &conf)
+	if err != nil {
 		return nil, fmt.Errorf("failed to decode toml config file: %v", err)
+	}
+
+	for _, key := range meta.Undecoded() {
+		log.Warn("Unrecognised config value", "key", key.String())
 	}
 
 	if err := conf.fillBigInt(); err != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -670,6 +670,7 @@ var (
 
 	// MergedTestChainConfig contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers for testing purposes.
+	// Includes all Bor hard forks enabled from block 0.
 	MergedTestChainConfig = &ChainConfig{
 		ChainID:                 big.NewInt(1),
 		HomesteadBlock:          big.NewInt(0),
@@ -702,10 +703,29 @@ var (
 			Osaka:  DefaultOsakaBlobConfig,
 		},
 		Bor: &BorConfig{
-			Sprint: map[string]uint64{
-				"0": 4},
-			BurntContract: map[string]string{"0": "0x000000000000000000000000000000000000dead"},
+			// Bor hard forks - all enabled from block 0
+			JaipurBlock:       big.NewInt(0),
+			DelhiBlock:        big.NewInt(0),
+			IndoreBlock:       big.NewInt(0),
+			AhmedabadBlock:    big.NewInt(0),
+			BhilaiBlock:       big.NewInt(0),
+			RioBlock:          big.NewInt(0),
+			MadhugiriBlock:    big.NewInt(0),
+			MadhugiriProBlock: big.NewInt(0),
+			DandeliBlock:      big.NewInt(0),
+			// Bor consensus config
 			Period:        map[string]uint64{"0": 2},
+			ProducerDelay: map[string]uint64{"0": 2},
+			Sprint:        map[string]uint64{"0": 16},
+			BackupMultiplier: map[string]uint64{
+				"0": 2,
+			},
+			ValidatorContract:     "0x0000000000000000000000000000000000001000",
+			StateReceiverContract: "0x0000000000000000000000000000000000001001",
+			BurntContract:         map[string]string{"0": "0x000000000000000000000000000000000000dead"},
+			StateSyncConfirmationDelay: map[string]uint64{
+				"0": 128,
+			},
 		},
 	}
 


### PR DESCRIPTION
# Description

Fixes tests in `accounts/abi/bind/v2/lib_test.go` which were previously skipped. Adds a warning about an unrecognised config or flag value.