### PR TITLE
ci: load kurtosis images from gcr instead of docker hub

### DIFF
--- a/.github/workflows/kurtosis-e2e.yml
+++ b/.github/workflows/kurtosis-e2e.yml
@@ -110,10 +110,16 @@ jobs:
           name: heimdall-v2-image
 
       - name: Load bor image
-        run: gunzip -c bor-image.tar.gz | docker load
+        run: |
+          gunzip -c bor-image.tar.gz | docker load
+          echo "Loaded bor image:"
+          docker images bor:local --format "{{.ID}} {{.CreatedAt}}"
 
       - name: Load heimdall-v2 image
-        run: gunzip -c heimdall-v2-image.tar.gz | docker load
+        run: |
+          gunzip -c heimdall-v2-image.tar.gz | docker load
+          echo "Loaded heimdall-v2 image:"
+          docker images heimdall-v2:local --format "{{.ID}} {{.CreatedAt}}"
 
       # Deploy kurtosis enclave
       - name: Kurtosis run

--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -111,10 +111,16 @@ jobs:
           name: heimdall-v2-image
 
       - name: Load bor image
-        run: gunzip -c bor-image.tar.gz | docker load
+        run: |
+          gunzip -c bor-image.tar.gz | docker load
+          echo "Loaded bor image:"
+          docker images bor:local --format "{{.ID}} {{.CreatedAt}}"
 
       - name: Load heimdall-v2 image
-        run: gunzip -c heimdall-v2-image.tar.gz | docker load
+        run: |
+          gunzip -c heimdall-v2-image.tar.gz | docker load
+          echo "Loaded heimdall-v2 image:"
+          docker images heimdall-v2:local --format "{{.ID}} {{.CreatedAt}}"
       
       # Deploy kurtosis enclave
       - name: Kurtosis run


### PR DESCRIPTION
- Reuse kurtosis-pos pre and post kurtosis actions instead of pos-workflows actions
  - It allows to rely on the most up to date versions of the actions
  - It also allows to pull most of the images directly from our GCR instead of Docker Hub, preventing rate limits
- Speed up the workflow by building bor and heimdall-v2 images in parallel
  - [Before](https://github.com/0xPolygon/bor/actions/runs/21390884915):  3m35s + 1m40s = 5m15s
  - [Now](https://github.com/0xPolygon/bor/actions/runs/21397274007): 3m55s
  - Note that the new workflow is slower than the previous workflow (20m21s vs 17m19s) because we spend around 4 minutes pre-pulling all the images from GCR in the "Pre kurtosis run" step