### PR TITLE
ci: bump upload-artifact to v6

### DIFF
--- a/.github/workflows/kurtosis-e2e.yml
+++ b/.github/workflows/kurtosis-e2e.yml
@@ -33,7 +33,7 @@ jobs:
         run: docker save bor:local | gzip > bor-image.tar.gz
 
       - name: Upload image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bor-image
           path: bor-image.tar.gz
@@ -56,7 +56,7 @@ jobs:
         run: docker save heimdall-v2:local | gzip > heimdall-v2-image.tar.gz
 
       - name: Upload image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: heimdall-v2-image
           path: heimdall-v2-image.tar.gz

--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -34,7 +34,7 @@ jobs:
         run: docker save bor:local | gzip > bor-image.tar.gz
 
       - name: Upload image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bor-image
           path: bor-image.tar.gz
@@ -57,7 +57,7 @@ jobs:
         run: docker save heimdall-v2:local | gzip > heimdall-v2-image.tar.gz
 
       - name: Upload image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: heimdall-v2-image
           path: heimdall-v2-image.tar.gz


### PR DESCRIPTION
Update actions/upload-artifact to v6 in CI workflows