### PR TITLE
Bump go version to 1.25.7

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # This file configures github.com/golangci/golangci-lint.
 version: '2'
 run:
-  go: 1.25.6
+  go: 1.25.7
   tests: true
 linters:
   default: none

--- a/cmd/keeper/go.mod
+++ b/cmd/keeper/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum/go-ethereum/cmd/keeper
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20260104020744-7268a54d0358

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/ethereum/go-ethereum
 
 // Note: Change the go image version in Dockerfile if you change this.
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/0xPolygon/crand v1.0.3


### PR DESCRIPTION
# Description

Bump Go from **1.25.6 → 1.25.7** to pick up upstream security fixes.

This upgrade addresses **GO-2026-4337**, a `crypto/tls` vulnerability in Go 1.25.6 that could allow unexpected TLS session resumption when TLS configs are mutated between handshakes.

The issue is fixed in Go **1.25.7** with no code changes required.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
