### PR TITLE
fix: configure Docker daemon min API version for Pumba compatibility

### DIFF
--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -67,7 +67,7 @@ jobs:
     needs:
       - build-bor
       - build-heimdall-v2
-    runs-on: ubuntu24.04-16core-64GB-600SSD-bor
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     # These permissions are required to log in to GCR
     permissions:


### PR DESCRIPTION
# Description

Docker Engine 29 raised the minimum API version to 1.44, breaking pumba 0.10.1 which uses client API v1.42.