### PR TITLE
fix(shutdown): cancel in-flight Heimdall queries on engine shutdown

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -266,7 +266,7 @@ type Bor struct {
 	quit      chan struct{}
 	closeOnce sync.Once
 
-	// ctx is cancelled when Close() is called, allowing in-flight operations.
+	// ctx is cancelled when Close() is called, allowing in-flight operations to abort promptly.
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 }


### PR DESCRIPTION
# Description

During shutdown, header verification goroutines called `spanByBlockNumber` / `waitUntilHeimdallIsSynced` with `context.Background()`, which never cancels. When Heimdall is stopped first (e.g. kurtosis enclave stop), these goroutines block indefinitely on reconnection, preventing the `blockchain.Stop()` from flushing state to disk. Docker's `SIGKILL` then kills the process, causing an unclean shutdown and state rewind on restart.