### PR TITLE
consensus/bor: fix sub-second late block detection producing empty blocks

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1056,7 +1056,7 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header) e
 	}
 
 	now := time.Now()
-	if header.Time < uint64(now.Unix()) {
+	if now.After(header.GetActualTime()) {
 		additionalBlockTime := time.Duration(c.config.CalculatePeriod(number)) * time.Second
 		if c.blockTime > 0 {
 			additionalBlockTime = c.blockTime

--- a/consensus/bor/bor_test.go
+++ b/consensus/bor/bor_test.go
@@ -1486,3 +1486,117 @@ func TestRunMilestoneFetcher_BlockingCallRespectsTimeout(t *testing.T) {
 		t.Fatal("FetchMilestone blocked beyond the context timeout; goroutine would leak without the fix")
 	}
 }
+
+// TestSubSecondLateBlockTriggersTimeAdjustment verifies that when a block's target
+// time has already passed (even by sub-second), the late-block adjustment triggers
+// and pushes header.Time into the future to give the miner real build time.
+//
+// Without the fix, the integer comparison `header.Time < now.Unix()` misses the case
+// where header.Time == now.Unix() but the sub-second target has already passed. This
+// causes the interrupt timer to expire immediately and Pending() to return an empty
+// map, producing a block with 0 transactions.
+func TestSubSecondLateBlockTriggersTimeAdjustment(t *testing.T) {
+	t.Parallel()
+
+	addr1 := common.HexToAddress("0x1")
+
+	// waitForMidSecond spins until we're between 300ms-700ms into the current
+	// second. This ensures the 200ms sub-second offset used by the tests won't
+	// cross a second boundary, which would make the old integer comparison
+	// trigger regardless of the fix.
+	waitForMidSecond := func() {
+		for {
+			ms := time.Now().Nanosecond() / 1_000_000
+			if ms >= 300 && ms <= 700 {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	t.Run("default path without custom blockTime", func(t *testing.T) {
+		t.Parallel()
+
+		// Consensus period = 1s, no custom blockTime.
+		// This is the path where ActualTime is never set (stays zero)
+		// and GetActualTime() falls back to time.Unix(header.Time, 0).
+		sp := &fakeSpanner{vals: []*valset.Validator{{Address: addr1, VotingPower: 1}}}
+		borCfg := &params.BorConfig{
+			Sprint: map[string]uint64{"0": 64},
+			Period: map[string]uint64{"0": 1},
+		}
+
+		waitForMidSecond()
+		now := time.Now()
+
+		// Set genesis time so that header.Time = genesis.Time + period = now.Unix()
+		// (the block target is the start of the current second, already in the past).
+		genesisTime := uint64(now.Unix()) - 1
+		chain, b := newChainAndBorForTest(t, sp, borCfg, true, addr1, genesisTime)
+
+		genesis := chain.HeaderChain().GetHeaderByNumber(0)
+		require.NotNil(t, genesis)
+
+		header := &types.Header{
+			Number:     big.NewInt(1),
+			ParentHash: genesis.Hash(),
+		}
+
+		before := time.Now()
+		err := b.Prepare(chain.HeaderChain(), header)
+		require.NoError(t, err)
+
+		expectedMin := uint64(before.Add(1 * time.Second).Unix())
+		require.GreaterOrEqual(t, header.Time, expectedMin,
+			"header.Time should be at least now + period to provide build time")
+	})
+
+	t.Run("custom blockTime with Rio", func(t *testing.T) {
+		t.Parallel()
+
+		blockTimeDuration := 2 * time.Second
+		sp := &fakeSpanner{vals: []*valset.Validator{{Address: addr1, VotingPower: 1}}}
+		borCfg := &params.BorConfig{
+			Sprint:   map[string]uint64{"0": 64},
+			Period:   map[string]uint64{"0": 2},
+			RioBlock: big.NewInt(0),
+		}
+
+		waitForMidSecond()
+		now := time.Now()
+
+		// Set parent's cached ActualTime so that:
+		//   actualNewBlockTime = parentActualTime + blockTime = now - 200ms
+		// This is sub-second in the past, but truncated header.Time equals now.Unix().
+		parentActualTime := now.Add(-blockTimeDuration).Add(-200 * time.Millisecond)
+		genesisTime := uint64(parentActualTime.Unix())
+
+		chain, b := newChainAndBorForTest(t, sp, borCfg, true, addr1, genesisTime)
+		b.blockTime = blockTimeDuration
+
+		genesis := chain.HeaderChain().GetHeaderByNumber(0)
+		require.NotNil(t, genesis)
+
+		// Cache the parent ActualTime with sub-second precision
+		b.parentActualTimeCache.Add(genesis.Hash(), parentActualTime)
+
+		header := &types.Header{
+			Number:     big.NewInt(1),
+			ParentHash: genesis.Hash(),
+		}
+
+		before := time.Now()
+		err := b.Prepare(chain.HeaderChain(), header)
+		require.NoError(t, err)
+
+		require.False(t, header.ActualTime.IsZero(),
+			"ActualTime should be set for Rio with custom blockTime")
+		require.True(t, header.ActualTime.After(before),
+			"ActualTime should be in the future after adjustment, got %v which is before %v",
+			header.ActualTime, before)
+
+		expectedMin := before.Add(blockTimeDuration)
+		require.GreaterOrEqual(t, header.ActualTime.Unix(), expectedMin.Unix(),
+			"ActualTime should be at least now + blockTime to provide build time")
+	})
+}


### PR DESCRIPTION
# Description
The late-block adjustment in Prepare() uses an integer-second comparison (header.Time < now.Unix()) to detect when a block is behind schedule and needs additional build time. Because header.Time is an integer (seconds) while the actual target time can have sub-second precision, a block can be up to 999ms late without triggering the adjustment.

Example: with period=1s and parent.Time=T:

```
  header.Time        = T + 1                     (integer seconds)
  now                = T + 1.820                  (parent block is 820ms late)
  now.Unix()         = T + 1                      (truncated to seconds)
  header.Time < now.Unix() → false                (adjustment skipped!)
```

This affects both the default path (blockTime=0, where GetActualTime() falls back to time.Unix(header.Time, 0)) and the custom blockTime path (where ActualTime has sub-second precision from the parent cache chain).

With no adjustment, GetActualTime() returns a time already in the past. The interrupt timer in commitWork() expires immediately, which sets the interruptBlockBuilding flag before fillTransactions() runs. The txpool's Pending() checks this flag on every address iteration and returns an empty map, producing a block with 0 transactions even when the pool has pending transactions.

Fix by replacing the integer comparison with a direct time comparison against the block's actual target time:

```
  if now.After(header.GetActualTime()) {
```

GetActualTime() returns header.ActualTime when set (custom blockTime with Rio, sub-second precision), or time.Unix(header.Time, 0) as fallback (default path). This correctly detects lateness in both cases without over-triggering for on-time blocks, since on-time blocks have their target time in the future.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
