### PR TITLE
fix flaky TestPrivateTxSubmissionRetry timing races

### DIFF
--- a/eth/relay/multiclient.go
+++ b/eth/relay/multiclient.go
@@ -40,8 +40,9 @@ func isAlreadyKnownError(err error) bool {
 // multiClient holds multiple rpc client instances for each block producer
 // to perform certain queries across all of them and make a unified decision.
 type multiClient struct {
-	clients []*rpc.Client // rpc client instances dialed to each block producer
-	closed  atomic.Bool
+	clients       []*rpc.Client // rpc client instances dialed to each block producer
+	closed        atomic.Bool
+	retryInterval time.Duration // 0 means use privateTxRetryInterval; configurable for testing
 }
 
 func newMultiClient(urls []string) *multiClient {
@@ -156,7 +157,11 @@ func (mc *multiClient) submitPreconfTx(rawTx []byte) (bool, error) {
 	return false, firstErr
 }
 
-func (mc *multiClient) submitPrivateTx(rawTx []byte, hash common.Hash, retry bool, txGetter TxGetter) error {
+// submitPrivateTx submits a raw private transaction to all block producers. When retry is
+// true and some producers fail, a background goroutine retries those producers. The
+// returned channel (non-nil only when a retry goroutine is started) is closed when the
+// goroutine finishes, allowing callers to wait for completion deterministically.
+func (mc *multiClient) submitPrivateTx(rawTx []byte, hash common.Hash, retry bool, txGetter TxGetter) (error, <-chan struct{}) {
 	// Submit tx to all block producers in parallel (initial attempt)
 	hexTx := hexutil.Encode(rawTx)
 
@@ -205,17 +210,22 @@ func (mc *multiClient) submitPrivateTx(rawTx []byte, hash common.Hash, retry boo
 	// If all submissions successful, return immediately
 	if len(failedIndices) == 0 {
 		log.Debug("[tx-relay] Successfully submitted private tx to all producers", "hash", hash)
-		return nil
+		return nil, nil
 	}
 
 	if retry && !mc.closed.Load() {
 		// Some submissions failed, start background retry
 		log.Debug("[tx-relay] Failed to submit private tx to one or more block producers, starting retry",
 			"err", firstErr, "failed", len(failedIndices), "successful", len(successfulIndices), "total", len(mc.clients), "hash", hash)
-		go mc.retryPrivateTxSubmission(hexTx, hash, failedIndices, txGetter)
+		done := make(chan struct{})
+		go func() {
+			mc.retryPrivateTxSubmission(hexTx, hash, failedIndices, txGetter)
+			close(done)
+		}()
+		return firstErr, done
 	}
 
-	return firstErr
+	return firstErr, nil
 }
 
 // retryPrivateTxSubmission runs in background to retry private tx submission to producers
@@ -234,7 +244,11 @@ func (mc *multiClient) retryPrivateTxSubmission(hexTx string, hash common.Hash, 
 		}
 
 		// Sleep before retry
-		time.Sleep(privateTxRetryInterval)
+		interval := mc.retryInterval
+		if interval == 0 {
+			interval = privateTxRetryInterval
+		}
+		time.Sleep(interval)
 
 		log.Debug("[tx-relay] Retrying private tx submission", "producers", len(currentFailedIndices), "attempt", retry+1, "hash", hash)
 

--- a/eth/relay/multiclient_test.go
+++ b/eth/relay/multiclient_test.go
@@ -499,7 +499,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		mc := newMultiClient(urls)
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
 		require.NoError(t, err, "expected no error in submitting private tx to all healthy BPs")
 	})
 
@@ -508,7 +508,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		defer mc.close()
 
 		invalidRawTx := []byte{0x01, 0x02, 0x03}
-		err := mc.submitPrivateTx(invalidRawTx, common.Hash{}, false, nil)
+		err, _ := mc.submitPrivateTx(invalidRawTx, common.Hash{}, false, nil)
 		require.Error(t, err, "expected error in submitting invalid private tx")
 	})
 
@@ -521,7 +521,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		mc := newMultiClient(urls)
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
 		require.Error(t, err, "expected error when one BP fails")
 		require.ErrorContains(t, err, "internal server error", "expected internal server error")
 	})
@@ -539,7 +539,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		mc := newMultiClient(urls)
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
 		require.Error(t, err, "expected error when one BP times out")
 		require.ErrorContains(t, err, "context deadline exceeded", "expected context deadline exceeded error")
 	})
@@ -557,7 +557,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		defer mc.close()
 
 		start := time.Now()
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
 		elapsed := time.Since(start)
 
 		require.NoError(t, err, "expected no error in submitting private tx")
@@ -582,7 +582,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		mc := newMultiClient(urls)
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
 		require.Error(t, err, "expected error when multiple BPs fail")
 	})
 
@@ -597,7 +597,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		mc := newMultiClient(urls)
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
 		require.Error(t, err, "expected error when all BPs fail")
 		require.ErrorContains(t, err, "internal server error", "expected error message from failing BPs")
 	})
@@ -616,7 +616,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		mc := newMultiClient(urls)
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
 		require.NoError(t, err, "expected no error when one BP returns already known")
 	})
 
@@ -631,7 +631,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		mc := newMultiClient(urls)
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
 		require.NoError(t, err, "expected no error when all BPs return already known")
 	})
 
@@ -649,7 +649,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		mc := newMultiClient(urls)
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
 		require.Error(t, err, "expected error when one BP returns non-already-known error")
 		require.ErrorContains(t, err, "internal server error", "expected internal server error")
 	})
@@ -667,7 +667,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		// Close one server to simulate failure after initialization
 		rpcServers[0].close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
 		require.Error(t, err, "expected error when BP fails after initialization")
 	})
 
@@ -680,7 +680,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 		rpcServers[2].close()
 		rpcServers[3].close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), false, nil)
 		require.Error(t, err, "expected error when all BPs fail")
 	})
 }
@@ -913,13 +913,18 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 		}
 
 		mc := newMultiClient(urls)
+		mc.retryInterval = 10 * time.Millisecond
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
+		err, done := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
 		require.Error(t, err, "expected error on initial submission")
 
-		// Wait for retries to complete (2 retries * 2s interval + buffer)
-		time.Sleep(2*privateTxRetryInterval + 100*time.Millisecond)
+		// Wait for retries to complete deterministically
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("retry goroutine did not complete in time")
+		}
 
 		// Verify that failing servers were called multiple times including initial submission
 		require.Equal(t, int32(3), callCounts[0].Load(), "expected server 0 to be called 3 times")
@@ -947,6 +952,7 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 		}
 
 		mc := newMultiClient(urls)
+		mc.retryInterval = 10 * time.Millisecond
 		defer mc.close()
 
 		// Set up txGetter that will return the transaction as found (simulating it got included)
@@ -957,11 +963,15 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 			return false, nil, common.Hash{}, 0, 0
 		}
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), true, txGetter)
+		err, done := mc.submitPrivateTx(rawTx, tx1.Hash(), true, txGetter)
 		require.Error(t, err, "expected error on initial submission")
 
-		// Wait for one retry attempt
-		time.Sleep(privateTxRetryInterval + 100*time.Millisecond)
+		// Wait for retry goroutine to complete deterministically
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("retry goroutine did not complete in time")
+		}
 
 		// Since tx is found in local database, retry should stop early
 		// Server 0 should be called only once during initial submission (no retries)
@@ -990,13 +1000,18 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 		}
 
 		mc := newMultiClient(urls)
+		mc.retryInterval = 10 * time.Millisecond
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
+		err, done := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
 		require.Error(t, err, "expected error on initial submission")
 
-		// Wait for all retries to complete (5 retries * 2s interval + buffer)
-		time.Sleep(5*privateTxRetryInterval + 100*time.Millisecond)
+		// Wait for all retries to complete deterministically
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("retry goroutine did not complete in time")
+		}
 
 		// Server 0 should be called 6 times (1 for initial submission and 5 retries)
 		require.Equal(t, int32(6), callCounts[0].Load(), "expected server 0 to be called 6 times (1 initial + 5 retries)")
@@ -1033,13 +1048,18 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 		}
 
 		mc := newMultiClient(urls)
+		mc.retryInterval = 10 * time.Millisecond
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
+		err, done := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
 		require.Error(t, err, "expected error on initial submission")
 
-		// Wait for all retries to complete (5 retries * 2s interval + buffer)
-		time.Sleep(5*privateTxRetryInterval + 100*time.Millisecond)
+		// Wait for all retries to complete deterministically
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("retry goroutine did not complete in time")
+		}
 
 		// Server 0 should be called twice (initial + 1 retry that succeeds)
 		require.Equal(t, int32(2), callCounts[0].Load(), "expected server 0 to succeed on second attempt")
@@ -1068,13 +1088,18 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 		}
 
 		mc := newMultiClient(urls)
+		mc.retryInterval = 10 * time.Millisecond
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
+		err, done := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
 		require.Error(t, err, "expected error on initial submission when all BPs fail")
 
-		// Wait for retry to complete
-		time.Sleep(privateTxRetryInterval + 100*time.Millisecond)
+		// Wait for retry to complete deterministically
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("retry goroutine did not complete in time")
+		}
 
 		// All servers should be called exactly twice (initial + 1 successful retry)
 		for i := 0; i < 4; i++ {
@@ -1102,14 +1127,19 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 		}
 
 		mc := newMultiClient(urls)
+		mc.retryInterval = 10 * time.Millisecond
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
+		err, done := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
 		require.Error(t, err, "expected timeout error on initial submission")
 		require.ErrorContains(t, err, "context deadline exceeded", "expected timeout error")
 
-		// Wait for retry
-		time.Sleep(privateTxRetryInterval + 100*time.Millisecond)
+		// Wait for retry to complete deterministically
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("retry goroutine did not complete in time")
+		}
 
 		// Server 0 should be retried and succeed
 		require.Equal(t, int32(2), callCounts[0].Load(), "expected server 0 to be retried after timeout")
@@ -1141,19 +1171,22 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 		}
 
 		mc := newMultiClient(urls)
+		mc.retryInterval = 10 * time.Millisecond
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
+		err, done := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
 		require.Error(t, err, "expected error on initial submission")
 
-		// Wait for one retry attempt
-		time.Sleep(privateTxRetryInterval + 100*time.Millisecond)
+		// Wait for retry goroutine to complete deterministically
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("retry goroutine did not complete in time")
+		}
 
 		// Server 0 should be called twice (initial + 1 retry with already known)
 		require.Equal(t, int32(2), callCounts[0].Load(), "expected server 0 to be called twice")
-
-		// No further retries should happen after already known
-		time.Sleep(privateTxRetryInterval)
+		// Goroutine is done (confirmed by <-done above), so no further retries are possible
 		require.Equal(t, int32(2), callCounts[0].Load(), "expected no further retries after already known")
 	})
 
@@ -1181,13 +1214,18 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 		}
 
 		mc := newMultiClient(urls)
+		mc.retryInterval = 10 * time.Millisecond
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
+		err, done := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
 		require.Error(t, err, "expected error on initial submission")
 
-		// Wait for retry
-		time.Sleep(privateTxRetryInterval + 100*time.Millisecond)
+		// Wait for retry to complete deterministically
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("retry goroutine did not complete in time")
+		}
 
 		// Servers 0 and 1 should be called twice (initial + retry)
 		require.Equal(t, int32(2), callCounts[0].Load(), "expected server 0 to be called twice")
@@ -1214,15 +1252,15 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 		}
 
 		mc := newMultiClient(urls)
+		mc.retryInterval = 10 * time.Millisecond
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
+		// When "already known" is returned on the initial submission, it counts as success,
+		// so no retry goroutine is started and the done channel will be nil.
+		err, _ := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
 		require.NoError(t, err, "expected no error when all submissions succeed or return already known")
 
-		// Wait to ensure no retries happen
-		time.Sleep(privateTxRetryInterval + 100*time.Millisecond)
-
-		// Server 0 should be called only once (no retry needed as already known treated as success)
+		// No retry goroutine was started (no failed indices), assert directly
 		require.Equal(t, int32(1), callCounts[0].Load(), "expected server 0 to be called only once")
 	})
 
@@ -1257,19 +1295,23 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 		}
 
 		mc := newMultiClient(urls)
+		mc.retryInterval = 10 * time.Millisecond
 		defer mc.close()
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
+		err, done := mc.submitPrivateTx(rawTx, tx1.Hash(), true, nil)
 		require.Error(t, err, "expected error on initial submission")
 
-		// Wait for retry
-		time.Sleep(privateTxRetryInterval + 100*time.Millisecond)
+		// Wait for retry to complete deterministically
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("retry goroutine did not complete in time")
+		}
 
 		// Both servers 0 and 1 should be called twice
 		require.Equal(t, int32(2), callCounts[0].Load(), "expected server 0 to be called twice")
 		require.Equal(t, int32(2), callCounts[1].Load(), "expected server 1 to be called twice")
-		// No further retries should happen
-		time.Sleep(privateTxRetryInterval)
+		// Goroutine is done (confirmed by <-done above), so no further retries are possible
 		require.Equal(t, int32(2), callCounts[0].Load(), "expected no further retries")
 		require.Equal(t, int32(2), callCounts[1].Load(), "expected no further retries")
 	})
@@ -1291,6 +1333,7 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 		}
 
 		mc := newMultiClient(urls)
+		mc.retryInterval = 10 * time.Millisecond
 		defer mc.close()
 
 		// Set up txGetter that doesn't find the transaction
@@ -1300,11 +1343,15 @@ func TestPrivateTxSubmissionRetry(t *testing.T) {
 			return false, nil, common.Hash{}, 0, 0
 		}
 
-		err := mc.submitPrivateTx(rawTx, tx1.Hash(), true, txGetter)
+		err, done := mc.submitPrivateTx(rawTx, tx1.Hash(), true, txGetter)
 		require.Error(t, err, "expected error on initial submission")
 
-		// Wait for all retries to complete
-		time.Sleep(5*privateTxRetryInterval + 100*time.Millisecond)
+		// Wait for all retries to complete deterministically
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("retry goroutine did not complete in time")
+		}
 
 		// Server 0 should be called 6 times (1 initial + 5 retries)
 		require.Equal(t, int32(6), callCounts[0].Load(), "expected server 0 to be called 6 times")

--- a/eth/relay/service.go
+++ b/eth/relay/service.go
@@ -285,7 +285,7 @@ func (s *Service) SubmitPrivateTx(tx *types.Transaction, retry bool) error {
 
 	uniquePrivateTxRequestMeter.Mark(1)
 	start := time.Now()
-	err = s.multiclient.submitPrivateTx(rawTx, tx.Hash(), retry, s.txGetter)
+	err, _ = s.multiclient.submitPrivateTx(rawTx, tx.Hash(), retry, s.txGetter)
 	privateTxSubmitTimer.UpdateSince(start)
 	if err != nil {
 		privateTxSubmissionFailureMeter.Mark(1)


### PR DESCRIPTION
# Description


### Problem

Two subtests in `TestPrivateTxSubmissionRetry` failed intermittently [on CI](https://github.com/0xPolygon/bor/actions/runs/22419960129/job/64915099111?pr=2088#step:7:120):

```
--- FAIL: TestPrivateTxSubmissionRetry/retry_succeeds_after_N_attempts (4.10s)
    multiclient_test.go:925: expected server 0 to be called 3 times
                             expected: 3, actual: 2

--- FAIL: TestPrivateTxSubmissionRetry/retry_stops_when_tx_found_in_local_database (2.10s)
    multiclient_test.go:968: expected server 0 to be called only once, no retries after tx found
                             expected: 1, actual: 2
```

The tests passed consistently on a developer laptop but failed on CI runners, making the root cause non-obvious.

### Root Cause

There were two interrelated timing races, both stemming from the same pattern: the tests used `time.Sleep(N × retryInterval + 100ms)` to wait for background retry goroutines to complete, then immediately asserted on call counts.

**Race 1 — insufficient buffer** (`retry_succeeds_after_N_attempts`):

`retryPrivateTxSubmission` sleeps `privateTxRetryInterval` (2s) before each attempt. After its second sleep the goroutine wakes at `t ≈ 4s` and spawns concurrent HTTP call goroutines. The test asserts at `t = 4.1s` — only 100ms later. On a loaded CI runner, those HTTP calls took longer than 100ms to complete, so the assertion ran before the third call was recorded:

```
t=0s    initial submission → counts[0]=1, retry goroutine spawned
t=2s    retry 1 → counts[0]=2, goroutine starts second 2s sleep
t=4s    goroutine wakes, spawns HTTP goroutines for retry 2
t=4.1s  test assertion → sees counts[0]=2  ← RACE: retry 2 not done yet
t=4s+ε  retry 2 goroutines complete → counts[0]=3   (too late)
```

**Race 2 — cross-subtest goroutine leakage** (`retry_stops_when_tx_found_in_local_database`):

All subtests share the same `rpcServers` array. Subtest 1's retry goroutine outlived subtest 1: when the test assertion at `t=4.1s` raced subtest 1's second retry (still in progress), the test ended and subtest 2 immediately installed new handlers on the shared servers. Subtest 1's still-running HTTP goroutines then landed on subtest 2's server 0 handler, spuriously incrementing subtest 2's `callCounts[0]` from 1 to 2.

### Reproducing Consistently

The failure only appeared on loaded machines because the 100ms buffer was tight. To reproduce it locally we temporarily injected a 150ms sleep inside the retry goroutine's HTTP call to simulate CI scheduler overhead:

```go
go func(client *rpc.Client, idx int) {
    defer retryWg.Done()
    time.Sleep(150 * time.Millisecond) // simulate CI latency
    err := client.CallContext(...)
```

With this, both subtests failed 3/3 runs with the exact same error messages as CI. After removing the sleep and applying the fix, both subtests passed 3/3 under the same simulated conditions.

### Fix

**`multiclient.go`** — two changes:

1. Added `retryInterval time.Duration` field to `multiClient` (zero value falls back to the 2s production constant). This lets tests set a short interval (10ms) so the retry goroutine completes near-instantly, eliminating the slow sleeping from the test timeline entirely.

2. `submitPrivateTx` now returns `(error, <-chan struct{})`. When a retry goroutine is started, the channel is closed when the goroutine finishes. This gives callers a deterministic signal instead of forcing them to guess how long to sleep.

**`service.go`** — updated the single production call site to discard the done channel (`err, _ = ...`), as the service has no use for it.

**`multiclient_test.go`** — all retry subtests updated to:
- Set `mc.retryInterval = 10 * time.Millisecond` after construction
- Replace every `time.Sleep(N × retryInterval + 100ms)` with `select { case <-done: case <-time.After(5s): t.Fatal(...) }`

This eliminates both races: `<-done` guarantees the goroutine has fully completed before any assertion runs, and since subtest N's goroutine is provably done before subtest N+1 installs new handlers, there is no cross-subtest leakage.

### Result

- `TestPrivateTxSubmissionRetry` was previously taking ~55s per run (dominated by 2s sleep intervals) and failing intermittently. It now runs in ~2.3s total and passes 10/10 with `-race`.
- No behavioural change to production retry logic — only the retry interval is now injectable for testing.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
