### PR TITLE
consensus/bor: prevent empty blocks when remaining build time is insufficient

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -58,6 +58,7 @@ const (
 	inmemorySnapshots  = 128             // Number of recent vote snapshots to keep in memory
 	inmemorySignatures = 4096            // Number of recent block signatures to keep in memory
 	veblopBlockTimeout = time.Second * 8 // Timeout for new span check. DO NOT CHANGE THIS VALUE.
+	minBlockBuildTime  = 1 * time.Second // Minimum remaining time before extending the block deadline to avoid empty blocks
 )
 
 // Bor protocol constants.
@@ -1093,14 +1094,17 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, w
 	}
 
 	now := time.Now()
-	if now.After(header.GetActualTime()) {
-		additionalBlockTime := time.Duration(c.config.CalculatePeriod(number)) * time.Second
+	blockTime := time.Duration(c.config.CalculatePeriod(number)) * time.Second
+	if c.blockTime > 0 && c.config.IsRio(header.Number) {
+		blockTime = c.blockTime
+	}
+	// Ensure minimum build time so the block has enough time to include transactions.
+	// The interrupt timer reserves 500ms for state root computation, so without
+	// sufficient remaining time the block would end up empty.
+	if time.Until(header.GetActualTime()) < minBlockBuildTime {
+		header.Time = uint64(now.Add(blockTime).Unix())
 		if c.blockTime > 0 && c.config.IsRio(header.Number) {
-			additionalBlockTime = c.blockTime
-		}
-		header.Time = uint64(now.Add(additionalBlockTime).Unix())
-		if c.blockTime > 0 && c.config.IsRio(header.Number) {
-			header.ActualTime = now.Add(additionalBlockTime)
+			header.ActualTime = now.Add(blockTime)
 		}
 	}
 

--- a/consensus/bor/bor_test.go
+++ b/consensus/bor/bor_test.go
@@ -1078,6 +1078,56 @@ func TestLateBlockTimestampFix(t *testing.T) {
 		require.False(t, header.ActualTime.IsZero())
 		require.GreaterOrEqual(t, header.ActualTime.Unix(), expectedMin)
 	})
+
+	t.Run("near-late block with insufficient build time gets extended", func(t *testing.T) {
+		// Scenario: remaining time is between 500ms and 1s — not technically late,
+		// but less than minBlockBuildTime (1s). Prepare should extend the deadline.
+		sp := &fakeSpanner{vals: []*valset.Validator{{Address: addr1, VotingPower: 1}}}
+		rioCfg := &params.BorConfig{
+			Sprint:   map[string]uint64{"0": 64},
+			Period:   map[string]uint64{"0": 2},
+			RioBlock: big.NewInt(0),
+		}
+		blockTime := 2 * time.Second
+
+		// Use a genesis time far enough in the past so the normal header time
+		// won't be in the future by more than 1s. We'll inject a precise
+		// parentActualTime via the cache to control the sub-second remaining time.
+		parentActualTime := time.Now().Add(-blockTime + 700*time.Millisecond)
+		genesisTime := uint64(parentActualTime.Unix())
+
+		chain, b := newChainAndBorForTest(t, sp, rioCfg, true, addr1, genesisTime)
+		b.blockTime = blockTime
+
+		genesis := chain.HeaderChain().GetHeaderByNumber(0)
+		parentHash := genesis.Hash()
+
+		// Inject a sub-second-precision parentActualTime into the cache.
+		// This makes actualNewBlockTime = parentActualTime + blockTime ≈ now + 700ms.
+		b.parentActualTimeCache.Add(parentHash, parentActualTime)
+
+		header := &types.Header{Number: big.NewInt(1), ParentHash: parentHash}
+
+		before := time.Now()
+		expectedTargetWithoutExtension := parentActualTime.Add(blockTime)
+		remaining := time.Until(expectedTargetWithoutExtension)
+
+		// Sanity: confirm remaining is in the 500ms–1s range before calling Prepare
+		require.Greater(t, remaining, 500*time.Millisecond, "test setup: remaining should be > 500ms")
+		require.Less(t, remaining, minBlockBuildTime, "test setup: remaining should be < minBlockBuildTime")
+
+		require.NoError(t, b.Prepare(chain.HeaderChain(), header, false))
+
+		// Prepare should have extended the deadline since remaining < minBlockBuildTime.
+		// The new ActualTime should be at least blockTime from before Prepare ran.
+		require.False(t, header.ActualTime.IsZero())
+		require.True(t, header.ActualTime.After(expectedTargetWithoutExtension),
+			"header.ActualTime should be extended beyond the original target")
+
+		expectedMin := before.Add(blockTime)
+		require.True(t, header.ActualTime.After(expectedMin) || header.ActualTime.Equal(expectedMin),
+			"header.ActualTime should be at least blockTime from now")
+	})
 }
 
 // setupFinalizeTest creates a test environment for FinalizeAndAssemble tests


### PR DESCRIPTION
# Description
The late-block check in Prepare only extended the block deadline when the current time was already past the target (now.After(header.GetActualTime())). This missed the case where remaining time was positive but too small to actually include any transactions — the interrupt timer in the worker would fire almost immediately, and after the 500ms state root reservation, zero time remained for transaction execution.

Example with blockTime=2s, parent ActualTime at T.

**Before**
- Target block time: T + 2s
- Prepare runs at T + 1.991s, remaining = 9ms
- Old code: 9ms > 0, so now.After(target) is false — no extension
- Worker starts interrupt timer with 9ms delay, which fires immediately
- Result: empty block with 0 transactions

**After**
- New code: 9ms < minBlockBuildTime (1s), so the check triggers
- Prepare extends header time to now + 2s, giving a full build window
- Worker gets ~2s for transaction execution
- Result: block includes transactions as expected

The fix introduces a minBlockBuildTime constant (1s) and changes the condition from "is past target" to "has less than minBlockBuildTime remaining", ensuring the miner always has enough time to fill the block. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
