### PR TITLE
fix(server): wire Identity config to node.UserIdent in buildNode

### DIFF
--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -1713,6 +1713,7 @@ func (c *Config) buildNode() (*node.Config, error) {
 
 	cfg := &node.Config{
 		Name:                  clientIdentifier,
+		UserIdent:             c.Identity,
 		DataDir:               c.DataDir,
 		DBEngine:              c.DBEngine,
 		KeyStoreDir:           c.KeyStoreDir,


### PR DESCRIPTION
# Description

Fix the `--identity` flag not being applied when using `bor server`.

## Problem

The `bor server` command accepts an `Identity` config field but `buildNode()` never sets `node.Config.UserIdent`, causing the identity to be silently ignored.

This means nodes running with `bor server --identity=xxx` always show the default client name in P2P communications, regardless of the `--identity` flag value.

Note: The legacy CLI (`bor --identity=xxx`) is unaffected as it uses `setNodeUserIdent()` inherited from go-ethereum.

## Root Cause

The `bor server` command uses a separate HCL-based configuration system (`internal/cli/server/`) that doesn't exist in upstream go-ethereum. The `buildNode()` function manually constructs a `node.Config` struct but was missing the `UserIdent` field:

```go
cfg := &node.Config{
    Name:    clientIdentifier,
    // UserIdent was missing here
    DataDir: c.DataDir,
    ...
}
```

## Fix

Add the missing field assignment in `buildNode()`:

```go
cfg := &node.Config{
    Name:      clientIdentifier,
    UserIdent: c.Identity,  // <-- Added
    DataDir:   c.DataDir,
    ...
}
```

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
- [ ] This PR requires changes to matic-cli

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

1. Start bor with identity: `bor server --identity=my-node ...`
2. Connect a peer and verify the client name includes "my-node"
3. Alternatively, use `polycli p2p ping <enode>` to observe the peer's client name