### PR TITLE
p2p: add flag to disable snap/1 serving

### DIFF
--- a/docs/cli/default_config.toml
+++ b/docs/cli/default_config.toml
@@ -44,6 +44,7 @@ devfakeauthor = false
   txarrivalwait = "500ms"
   txannouncementonly = false
   disable-tx-propagation = false
+  nosnap = false
   [p2p.discovery]
     v4disc = true
     v5disc = true

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -304,6 +304,8 @@ The ```bor server``` command runs the Bor client.
 
 - ```nodiscover```: Disables the peer discovery mechanism (manual peer addition) (default: false)
 
+- ```p2p.nosnap```: Disable serving snap sync requests to peers (snap/1 protocol is not advertised) (default: false)
+
 - ```port```: Network listening port (default: 30303)
 
 - ```relay.bp-rpc-endpoints```: Comma separated rpc endpoints of all block producers

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -693,6 +693,11 @@ func (s *Ethereum) SetAuthorized(authorized bool) {
 // network protocols to start.
 func (s *Ethereum) Protocols() []p2p.Protocol {
 	protos := eth.MakeProtocols((*ethHandler)(s.handler), s.networkID, s.discmix)
+	// snap/1 is only registered when the snapshot cache is enabled and NoSnapServing is false.
+	// Setting NoSnapServing=true disables snap/1 entirely: the node will neither serve snap sync
+	// requests nor be able to sync state via snap/1 itself. The in-memory snapshot tree (used for
+	// fast local state reads) remains active regardless. Nodes that need to snap sync from peers
+	// must leave NoSnapServing=false (the default).
 	if s.config.SnapshotCache > 0 && !s.config.NoSnapServing {
 		protos = append(protos, snap.MakeProtocols((*snapHandler)(s.handler))...)
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -693,7 +693,7 @@ func (s *Ethereum) SetAuthorized(authorized bool) {
 // network protocols to start.
 func (s *Ethereum) Protocols() []p2p.Protocol {
 	protos := eth.MakeProtocols((*ethHandler)(s.handler), s.networkID, s.discmix)
-	if s.config.SnapshotCache > 0 {
+	if s.config.SnapshotCache > 0 && !s.config.NoSnapServing {
 		protos = append(protos, snap.MakeProtocols((*snapHandler)(s.handler))...)
 	}
 	if s.config.WitnessProtocol {

--- a/eth/backend_protocols_test.go
+++ b/eth/backend_protocols_test.go
@@ -1,0 +1,91 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/eth/protocols/snap"
+)
+
+// TestProtocolsSnapServing verifies that the snap/1 protocol is included or
+// excluded from the advertised protocol list based on SnapshotCache and
+// NoSnapServing config fields.
+func TestProtocolsSnapServing(t *testing.T) {
+	th := newTestHandlerWithBlocks(0)
+	defer th.close()
+
+	tests := []struct {
+		name          string
+		snapshotCache int
+		noSnapServing bool
+		wantSnap      bool
+	}{
+		{
+			name:          "snap served when snapshots enabled",
+			snapshotCache: 100,
+			noSnapServing: false,
+			wantSnap:      true,
+		},
+		{
+			name:          "snap not served when SnapshotCache is zero",
+			snapshotCache: 0,
+			noSnapServing: false,
+			wantSnap:      false,
+		},
+		{
+			name:          "snap not served when NoSnapServing is set",
+			snapshotCache: 100,
+			noSnapServing: true,
+			wantSnap:      false,
+		},
+		{
+			name:          "snap not served when both SnapshotCache zero and NoSnapServing set",
+			snapshotCache: 0,
+			noSnapServing: true,
+			wantSnap:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eth := &Ethereum{
+				handler:   th.handler,
+				networkID: 1,
+				config: &ethconfig.Config{
+					SnapshotCache: tt.snapshotCache,
+					NoSnapServing: tt.noSnapServing,
+				},
+			}
+
+			protos := eth.Protocols()
+
+			var hasSnap bool
+			for _, proto := range protos {
+				if proto.Name == snap.ProtocolName {
+					hasSnap = true
+					break
+				}
+			}
+
+			if hasSnap != tt.wantSnap {
+				t.Errorf("snap protocol advertised = %v, want %v", hasSnap, tt.wantSnap)
+			}
+		})
+	}
+}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -268,6 +268,11 @@ type Config struct {
 	// WitnessProtocol enabless the wit protocol
 	WitnessProtocol bool
 
+	// NoSnapServing disables the snap/1 sub-protocol, preventing this node from
+	// serving snap sync state to peers. Useful for block producers that should
+	// not spend resources on snap sync serving.
+	NoSnapServing bool
+
 	// SyncWithWitnesses enables syncing blocks with witnesses
 	SyncWithWitnesses bool
 

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -285,6 +285,9 @@ type P2PConfig struct {
 
 	// DisableTxPropagation disables transaction broadcast and announcement completely to its peers
 	DisableTxPropagation bool `hcl:"disable-tx-propagation,optional" toml:"disable-tx-propagation,optional"`
+
+	// NoSnapServing disables serving snap sync requests to peers (snap/1 protocol is not advertised)
+	NoSnapServing bool `hcl:"nosnap,optional" toml:"nosnap,optional"`
 }
 
 type P2PDiscovery struct {
@@ -837,6 +840,7 @@ func DefaultConfig() *Config {
 			TxArrivalWait:        500 * time.Millisecond,
 			TxAnnouncementOnly:   false,
 			DisableTxPropagation: false,
+			NoSnapServing:        false,
 			Discovery: &P2PDiscovery{
 				DiscoveryV4:  true,
 				DiscoveryV5:  true,
@@ -1657,6 +1661,7 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 	n.ParallelEVM.SpeculativeProcesses = c.ParallelEVM.SpeculativeProcesses
 	n.ParallelEVM.Enforce = c.ParallelEVM.Enforce
 
+	n.NoSnapServing = c.P2P.NoSnapServing
 	n.WitnessProtocol = c.Witness.Enable
 	if c.SyncMode == "stateless" {
 		if !c.Witness.Enable {

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -1059,6 +1059,13 @@ func (c *Command) Flags(config *Config) *flagset.Flagset {
 		Default: c.cliConfig.P2P.DisableTxPropagation,
 		Group:   "P2P",
 	})
+	f.BoolFlag(&flagset.BoolFlag{
+		Name:    "p2p.nosnap",
+		Usage:   "Disable serving snap sync requests to peers (snap/1 protocol is not advertised)",
+		Value:   &c.cliConfig.P2P.NoSnapServing,
+		Default: c.cliConfig.P2P.NoSnapServing,
+		Group:   "P2P",
+	})
 	f.SliceStringFlag(&flagset.SliceStringFlag{
 		Name:    "discovery.dns",
 		Usage:   "Comma separated list of enrtree:// URLs which will be queried for nodes to connect to",


### PR DESCRIPTION
## Changes

Adds a new `p2p.nosnap` config flag (`nosnap` in TOML under `[p2p]`) that decouples the snapshot tree from the `snap/1` p2p sub-protocol.

**The problem:** before this change, `--snapshot` and `snap/1` were hardcoded together — enabling the snapshot tree automatically registered snap/1. There was no way to have one without the other.

**Why BPs want the snapshot tree:** the flat snapshot accelerates state reads without trie traversal, benefiting both RPC queries and block building (every `SLOAD`, balance check, and storage read during EVM execution can hit the snapshot instead of walking the trie).

**Why BPs don't want to serve `snap/1`:** BPs are already fully synced and have no reason to be snap sync servers for other nodes. Serving snap/1 adds unnecessary network and CPU overhead.

**Important clarification — `snap/1` vs `--snapshot`:**
- `snap/1` is the p2p sub-protocol used for snap sync state transfer between nodes. Data is served from the flat snapshot, Merkle proofs from the trie DB on disk
- `--snapshot` / `SnapshotCache` is the in-memory flat snapshot tree used for fast local state reads

These are independent. `nosnap=true` disables `snap/1` entirely (the node neither serves nor consumes snap sync), while the snapshot tree remains fully active for local performance.

> **Note:** reducing `TriesInMemory` (dirty trie layers in memory) is a separate and independent optimization — it saves RAM by committing trie nodes to disk sooner. It does not affect `snap/1` serving, which reads from the flat snapshot, not trie layers.

## How it works

- New `NoSnapServing bool` field in `ethconfig.Config`
- Wired from `P2PConfig.NoSnapServing` (`hcl:"nosnap"` / `toml:"nosnap"`) through `buildEth`
- In `Protocols()`, `snap/1` is only registered if `SnapshotCache > 0 && !NoSnapServing` — previously the condition was `SnapshotCache > 0` alone, making snapshot and `snap/1` inseparable

## Testing

- Unit test in `eth/backend_protocols_test.go` covering both the default (snap served) and `NoSnapServing=true` (snap not served) cases
- Validated end-to-end in a local kurtosis devnet: nodes with `nosnap = true` started without advertising `snap/1`