### PR TITLE
ethapi: include pre-Madhugiri state-sync logs in bor_getLogs

### DIFF
--- a/internal/ethapi/bor_api.go
+++ b/internal/ethapi/bor_api.go
@@ -1220,6 +1220,17 @@ func (api *BorAPI) getBlockAndReceipts(ctx context.Context, blockNum uint64) (*t
 		return nil, nil, fmt.Errorf("failed to get receipts for block %d: %w", blockNum, err)
 	}
 
+	chainConfig := api.b.ChainConfig()
+	if chainConfig.Bor != nil && !chainConfig.Bor.IsMadhugiri(block.Number()) {
+		stateSyncReceipt, err := api.b.GetBorBlockReceipt(ctx, block.Hash())
+		if err != nil && !errors.Is(err, ethereum.NotFound) {
+			return nil, nil, fmt.Errorf("failed to get Bor receipt for block %d: %w", blockNum, err)
+		}
+		if stateSyncReceipt != nil {
+			receipts = append(receipts, stateSyncReceipt)
+		}
+	}
+
 	return block, receipts, nil
 }
 

--- a/internal/ethapi/bor_api_test.go
+++ b/internal/ethapi/bor_api_test.go
@@ -1411,6 +1411,26 @@ func (b *testBackendWithPreMadhuguriBorReceipt) ChainConfig() *params.ChainConfi
 	return &cfg
 }
 
+type testBackendWithPostMadhugiriBorReceipt struct {
+	*testBackend
+	borReceipt *types.Receipt
+}
+
+func (b *testBackendWithPostMadhugiriBorReceipt) GetBorBlockReceipt(_ context.Context, _ common.Hash) (*types.Receipt, error) {
+	return b.borReceipt, nil
+}
+
+func (b *testBackendWithPostMadhugiriBorReceipt) ChainConfig() *params.ChainConfig {
+	cfg := *params.AllEthashProtocolChanges
+	borCfg := params.BorConfig{}
+	if cfg.Bor != nil {
+		borCfg = *cfg.Bor
+	}
+	borCfg.MadhugiriBlock = big.NewInt(0)
+	cfg.Bor = &borCfg
+	return &cfg
+}
+
 func TestBorGetLogsByHashWithLogs(t *testing.T) {
 	t.Parallel()
 
@@ -1681,14 +1701,13 @@ func TestBorGetLogsByHashPreMadhugiri(t *testing.T) {
 	})
 }
 
-func TestBorGetLogsPreMadhugiriStateSyncLogs(t *testing.T) {
+func TestGetBlockAndReceiptsStateSyncReceipt(t *testing.T) {
 	t.Parallel()
 
 	var (
-		accs     = newAccounts(1)
-		logAddr  = common.HexToAddress("0x0000000000000000000000000000000000001010")
-		logTopic = common.HexToHash("0x1234")
-		genesis  = &core.Genesis{
+		accs    = newAccounts(1)
+		logAddr = common.HexToAddress("0x0000000000000000000000000000000000001010")
+		genesis = &core.Genesis{
 			Config: params.AllEthashProtocolChanges,
 			Alloc: types.GenesisAlloc{
 				accs[0].addr: {Balance: big.NewInt(params.Ether)},
@@ -1717,77 +1736,50 @@ func TestBorGetLogsPreMadhugiriStateSyncLogs(t *testing.T) {
 		t.Fatal("Could not get block 1")
 	}
 
+	normalReceipts, err := backend.GetReceipts(context.Background(), block.Hash())
+	require.NoError(t, err)
+
 	borReceipt := &types.Receipt{
 		Type:   types.StateSyncTxType,
 		Status: types.ReceiptStatusSuccessful,
 		Logs: []*types.Log{
 			{
 				Address: logAddr,
-				Topics:  []common.Hash{logTopic},
+				Topics:  []common.Hash{common.HexToHash("0x1234")},
 				Data:    []byte{1, 2, 3, 4},
 			},
 		},
 	}
 
-	api := NewBorAPI(&testBackendWithPreMadhuguriBorReceipt{
-		testBackend: backend,
-		borReceipt:  borReceipt,
+	t.Run("pre_madhugiri_appends_state_sync_receipt", func(t *testing.T) {
+		api := NewBorAPI(&testBackendWithPreMadhuguriBorReceipt{
+			testBackend: backend,
+			borReceipt:  borReceipt,
+		})
+
+		gotBlock, receipts, err := api.getBlockAndReceipts(context.Background(), block.NumberU64())
+		require.NoError(t, err)
+		require.NotNil(t, gotBlock)
+		require.Equal(t, block.Hash(), gotBlock.Hash())
+		require.Len(t, receipts, len(normalReceipts)+1)
+
+		last := receipts[len(receipts)-1]
+		require.EqualValues(t, types.StateSyncTxType, last.Type)
+		require.Len(t, last.Logs, 1)
+		require.Equal(t, logAddr, last.Logs[0].Address)
 	})
 
-	t.Run("get_logs_includes_state_sync_receipt", func(t *testing.T) {
-		blockHash := block.Hash()
-		crit := FilterCriteria{
-			BlockHash: &blockHash,
-			Addresses: []common.Address{logAddr},
-			Topics:    [][]common.Hash{{logTopic}},
-		}
+	t.Run("post_madhugiri_does_not_append_state_sync_receipt", func(t *testing.T) {
+		api := NewBorAPI(&testBackendWithPostMadhugiriBorReceipt{
+			testBackend: backend,
+			borReceipt:  borReceipt,
+		})
 
-		logs, err := api.GetLogs(context.Background(), crit)
-		if err != nil {
-			t.Fatalf("GetLogs() error = %v", err)
-		}
-		if len(logs) == 0 {
-			t.Fatal("GetLogs() returned 0 logs, want at least 1")
-		}
-
-		found := false
-		for _, log := range logs {
-			if log.Address == logAddr && len(log.Topics) > 0 && log.Topics[0] == logTopic {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("GetLogs() did not include the expected pre-Madhugiri state-sync log")
-		}
-	})
-
-	t.Run("get_latest_logs_includes_state_sync_receipt", func(t *testing.T) {
-		blockCount := uint64(1)
-		crit := FilterCriteria{
-			Addresses: []common.Address{logAddr},
-			Topics:    [][]common.Hash{{logTopic}},
-		}
-		opts := LogFilterOptions{BlockCount: &blockCount}
-
-		logs, err := api.GetLatestLogs(context.Background(), crit, opts)
-		if err != nil {
-			t.Fatalf("GetLatestLogs() error = %v", err)
-		}
-		if len(logs) == 0 {
-			t.Fatal("GetLatestLogs() returned 0 logs, want at least 1")
-		}
-
-		found := false
-		for _, log := range logs {
-			if log.Address == logAddr && len(log.Topics) > 0 && log.Topics[0] == logTopic {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("GetLatestLogs() did not include the expected pre-Madhugiri state-sync log")
-		}
+		gotBlock, receipts, err := api.getBlockAndReceipts(context.Background(), block.NumberU64())
+		require.NoError(t, err)
+		require.NotNil(t, gotBlock)
+		require.Equal(t, block.Hash(), gotBlock.Hash())
+		require.Len(t, receipts, len(normalReceipts))
 	})
 }
 

--- a/internal/ethapi/bor_api_test.go
+++ b/internal/ethapi/bor_api_test.go
@@ -1681,6 +1681,116 @@ func TestBorGetLogsByHashPreMadhugiri(t *testing.T) {
 	})
 }
 
+func TestBorGetLogsPreMadhugiriStateSyncLogs(t *testing.T) {
+	t.Parallel()
+
+	var (
+		accs     = newAccounts(1)
+		logAddr  = common.HexToAddress("0x0000000000000000000000000000000000001010")
+		logTopic = common.HexToHash("0x1234")
+		genesis  = &core.Genesis{
+			Config: params.AllEthashProtocolChanges,
+			Alloc: types.GenesisAlloc{
+				accs[0].addr: {Balance: big.NewInt(params.Ether)},
+			},
+		}
+	)
+
+	backend := newTestBackend(t, 1, genesis, ethash.NewFaker(), func(i int, b *core.BlockGen) {
+		if i == 0 {
+			tx, _ := types.SignTx(
+				types.NewTx(&types.LegacyTx{
+					Nonce:    b.TxNonce(accs[0].addr),
+					To:       &accs[0].addr,
+					Value:    big.NewInt(1000),
+					Gas:      params.TxGas,
+					GasPrice: big.NewInt(params.InitialBaseFee),
+				}),
+				types.LatestSigner(genesis.Config), accs[0].key,
+			)
+			b.AddTx(tx)
+		}
+	})
+
+	block := backend.chain.GetBlockByNumber(1)
+	if block == nil {
+		t.Fatal("Could not get block 1")
+	}
+
+	borReceipt := &types.Receipt{
+		Type:   types.StateSyncTxType,
+		Status: types.ReceiptStatusSuccessful,
+		Logs: []*types.Log{
+			{
+				Address: logAddr,
+				Topics:  []common.Hash{logTopic},
+				Data:    []byte{1, 2, 3, 4},
+			},
+		},
+	}
+
+	api := NewBorAPI(&testBackendWithPreMadhuguriBorReceipt{
+		testBackend: backend,
+		borReceipt:  borReceipt,
+	})
+
+	t.Run("get_logs_includes_state_sync_receipt", func(t *testing.T) {
+		blockHash := block.Hash()
+		crit := FilterCriteria{
+			BlockHash: &blockHash,
+			Addresses: []common.Address{logAddr},
+			Topics:    [][]common.Hash{{logTopic}},
+		}
+
+		logs, err := api.GetLogs(context.Background(), crit)
+		if err != nil {
+			t.Fatalf("GetLogs() error = %v", err)
+		}
+		if len(logs) == 0 {
+			t.Fatal("GetLogs() returned 0 logs, want at least 1")
+		}
+
+		found := false
+		for _, log := range logs {
+			if log.Address == logAddr && len(log.Topics) > 0 && log.Topics[0] == logTopic {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("GetLogs() did not include the expected pre-Madhugiri state-sync log")
+		}
+	})
+
+	t.Run("get_latest_logs_includes_state_sync_receipt", func(t *testing.T) {
+		blockCount := uint64(1)
+		crit := FilterCriteria{
+			Addresses: []common.Address{logAddr},
+			Topics:    [][]common.Hash{{logTopic}},
+		}
+		opts := LogFilterOptions{BlockCount: &blockCount}
+
+		logs, err := api.GetLatestLogs(context.Background(), crit, opts)
+		if err != nil {
+			t.Fatalf("GetLatestLogs() error = %v", err)
+		}
+		if len(logs) == 0 {
+			t.Fatal("GetLatestLogs() returned 0 logs, want at least 1")
+		}
+
+		found := false
+		for _, log := range logs {
+			if log.Address == logAddr && len(log.Topics) > 0 && log.Topics[0] == logTopic {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("GetLatestLogs() did not include the expected pre-Madhugiri state-sync log")
+		}
+	})
+}
+
 func TestBorGetBlockByTimestamp(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Include pre-Madhugiri Bor state-sync receipts when collecting logs for bor_getLogs and bor_getLatestLogs, and add regression coverage for the historical state-sync log path.