### PR TITLE
eth: stop dialing before waiting on handler shutdown

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1029,10 +1029,10 @@ func (s *Ethereum) Stop() error {
 	// block processing.
 	s.engine.Close()
 	s.dropper.Stop()
-	s.handler.Stop()
 
 	// Stop the dial scheduler to suppress "Looking for peers" during shutdown.
 	s.p2pServer.StopDialing()
+	s.handler.Stop()
 
 	// Then stop everything else.
 	// Close all bg processes


### PR DESCRIPTION
Stop the dial scheduler before waiting on handler shutdown, and prevent "Looking for peers" from continuing during node stop.