### PR TITLE
eth/protocols/eth: increase maxTxPacketSize from 100 KB to 1 MB

### DIFF
--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -24,9 +24,10 @@ import (
 )
 
 const (
-	// This is the target size for the packs of transactions or announcements. A
-	// pack can get larger than this if a single transactions exceeds this size.
-	maxTxPacketSize = 100 * 1024
+	// maxTxPacketSize is the target size for packs of transactions or announcements.
+	// A pack can get larger than this if a single transaction exceeds this size.
+	// Bor: increased from the go-ethereum default of 100 KB to 1 MB.
+	maxTxPacketSize = 1024 * 1024
 )
 
 // blockPropagation is a block propagation event, waiting for its turn in the


### PR DESCRIPTION
## Summary

Increases `maxTxPacketSize` in `eth/protocols/eth/broadcast.go` from the go-ethereum default of 100 KB to 1 MB to match Polygon mainnet's actual transaction throughput at high utilization.

## Background: what `maxTxPacketSize` controls

This constant is the flush threshold used in two places:

1. **Direct broadcast** (`broadcastTransactions`): the loop accumulates full transactions and flushes when the accumulated size hits the limit. Only `sqrt(peers)` receive direct txs.
2. **`GetPooledTransactions` responses**: when a peer fetches full txs after receiving hash announcements (the path used by the majority of peers), the response is also bounded by this limit.

Announcements (`NewPooledTransactionHashesPacket`) are unaffected — they carry only 32-byte hashes, so even a 440-tx block produces ~14 KB, negligible against any reasonable limit.

## Problem: 100 KB is severely undersized for Polygon

Sampling 11 Polygon mainnet blocks at high utilization (blocks 84665222–84665232, sampled 2026-03-25):

| Block | Txs | Gas Used | Gas Util | Tx Data | @ 1 MB |
|-------|-----|----------|----------|---------|--------|
| 84665222 | 277 | 86.7M | 72.2% | 365.0 KB | 1 msg |
| 84665223 | 249 | 60.9M | 50.7% | 261.4 KB | 1 msg |
| 84665224 | 374 | 116.6M | 97.1% | 505.4 KB | 1 msg |
| 84665225 | 437 | 120.0M | **100.0%** | **520.6 KB** | 1 msg |
| 84665226 | 351 | 118.3M | 98.6% | 510.2 KB | 1 msg |
| 84665227 | 318 | 110.2M | 91.9% | 458.9 KB | 1 msg |
| 84665228 | 443 | 99.3M | 82.8% | 426.9 KB | 1 msg |
| 84665229 | 278 | 86.2M | 71.8% | 351.2 KB | 1 msg |
| 84665230 | 305 | 93.2M | 77.7% | 391.4 KB | 1 msg |
| 84665231 | 317 | 113.1M | 94.3% | 480.0 KB | 1 msg |
| 84665232 | 244 | 111.5M | 92.9% | 460.1 KB | 1 msg |

**Average: 430 KB/block. Max observed (100% utilization): 520 KB.**

At 100 KB, a full block requires **5+ sequential p2p messages per peer**. The impact compounds on the fetch path: the majority of peers receive only hash announcements and call `GetPooledTransactions` to fetch full txs. A 100 KB response limit means multiple round trips to converge the mempool across the full peer set — not just the small `sqrt(peers)` direct broadcast set.

## Why not 512 KB?

512 KB was initially considered, but full blocks already reach ~520 KB — leaving essentially no margin. Blocks 84665224, 84665225, and 84665226 all exceed or come within 2 KB of 512 KB at 97–100% utilization. Any sustained period at full capacity would regularly split into 2 messages.

## Size selection: 1 MB

| Limit | Covers full block (~520 KB) | Headroom to 200M gas limit (~870 KB) | % of p2p max (16 MB) | vs witness (15 MB) |
|-------|----------------------------|--------------------------------------|----------------------|--------------------|
| 100 KB (current) | No — 5+ messages | No | 0.6% | 0.7% |
| 512 KB | Barely — full blocks exceed it | No | 3.2% | 3.4% |
| **1 MB** | **Yes — 2x headroom** | **Yes — fits in 1 message** | **6.3%** | **6.7%** |
| 2 MB | Yes — 4x headroom | Yes | 12.5% | 13.3% |

1 MB is chosen because:
- It covers the current maximum full-block payload (~520 KB) with ~2x headroom
- It absorbs a gas limit increase to ~200M gas (producing ~870 KB blocks) without another bump
- It stays at 6.3% of the 16 MB p2p hard limit
- It is well below the ~15 MB witness messages already exchanged on this network

## Network topology consideration

A significant portion of Polygon's transaction volume originates from a small number of high-throughput RPC providers (Alchemy, Infura, QuickNode, etc.) that submit large batches of transactions in near every block. These nodes tend to be well-connected to validators and their txs propagate via direct broadcast. However, the broader peer set — archive nodes, indexers, regional RPC nodes — relies entirely on the announce→fetch path. With a 100 KB response limit, these nodes consistently need 5+ round trips per block to converge their mempools, degrading local tx visibility and fee estimation accuracy.

## Risk assessment

- **Protocol compatibility**: none. Packet size limits are local to the sender; receivers handle any size up to the p2p hard max.
- **Memory**: at 50 peers × 1 MB in-flight = 50 MB. Negligible on validator hardware.
- **Head-of-line blocking**: already accepted at 15 MB for witnesses. 1 MB is not a new risk category.
- **Upstream divergence**: go-ethereum targets Ethereum mainnet (~15 txs/12s block). This is an intentional Bor-specific tuning, documented in the constant comment.

## Testing

Built and verified. The constant affects only the flush threshold in the broadcast/announce loops; no behavioral changes beyond batch sizing.