### PR TITLE
disable eth_simulateV1

### DIFF
--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -760,6 +760,7 @@ func ExampleRevertErrorData() {
 }
 
 func TestSimulateV1(t *testing.T) {
+	t.Skip("eth_simulateV1 is disabled on Bor — unskip when re-enabling")
 	backend, _, err := newTestBackend(nil)
 	if err != nil {
 		t.Fatalf("Failed to create test backend: %v", err)
@@ -825,6 +826,7 @@ func TestSimulateV1(t *testing.T) {
 }
 
 func TestSimulateV1WithBlockOverrides(t *testing.T) {
+	t.Skip("eth_simulateV1 is disabled on Bor — unskip when re-enabling")
 	backend, _, err := newTestBackend(nil)
 	if err != nil {
 		t.Fatalf("Failed to create test backend: %v", err)
@@ -887,6 +889,7 @@ func TestSimulateV1WithBlockOverrides(t *testing.T) {
 }
 
 func TestSimulateV1WithStateOverrides(t *testing.T) {
+	t.Skip("eth_simulateV1 is disabled on Bor — unskip when re-enabling")
 	backend, _, err := newTestBackend(nil)
 	if err != nil {
 		t.Fatalf("Failed to create test backend: %v", err)
@@ -954,6 +957,7 @@ func TestSimulateV1WithStateOverrides(t *testing.T) {
 }
 
 func TestSimulateV1WithBlockNumberOrHash(t *testing.T) {
+	t.Skip("eth_simulateV1 is disabled on Bor — unskip when re-enabling")
 	backend, _, err := newTestBackend(nil)
 	if err != nil {
 		t.Fatalf("Failed to create test backend: %v", err)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1069,6 +1069,8 @@ func (api *BlockChainAPI) CallWithState(ctx context.Context, args TransactionArg
 // Note, this function doesn't make any changes in the state/blockchain and is
 // useful to execute and retrieve values.
 func (api *BlockChainAPI) SimulateV1(ctx context.Context, opts simOpts, blockNrOrHash *rpc.BlockNumberOrHash) ([]*simBlockResult, error) {
+	return nil, errors.New("eth_simulateV1 is not supported on Bor")
+	//nolint:govet // Unreachable code kept intentionally so it can be re-enabled easily.
 	if len(opts.BlockStateCalls) == 0 {
 		return nil, &invalidParamsError{message: "empty input"}
 	} else if len(opts.BlockStateCalls) > maxSimulateBlocks {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -1562,7 +1562,22 @@ func TestCall(t *testing.T) {
 	}
 }
 
+func TestSimulateV1Disabled(t *testing.T) {
+	t.Parallel()
+
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc:  types.GenesisAlloc{},
+	}
+	b := newTestBackend(t, 1, genesis, ethash.NewFaker(), nil)
+	api := NewBlockChainAPI(b)
+	result, err := api.SimulateV1(context.Background(), simOpts{}, nil)
+	require.Nil(t, result)
+	require.EqualError(t, err, "eth_simulateV1 is not supported on Bor")
+}
+
 func TestSimulateV1(t *testing.T) {
+	t.Skip("eth_simulateV1 is disabled on Bor — unskip when re-enabling")
 	t.Parallel()
 	// Initialize test accounts
 	var (
@@ -3014,6 +3029,7 @@ func TestSimulateV1ChainLinkage(t *testing.T) {
 }
 
 func TestSimulateV1TxSender(t *testing.T) {
+	t.Skip("eth_simulateV1 is disabled on Bor — unskip when re-enabling")
 	var (
 		sender    = common.Address{0xaa, 0xaa}
 		sender2   = common.Address{0xaa, 0xab}


### PR DESCRIPTION
# Description

Temporarily disable eth_simulateV1

```
curl -s -X POST http://127.0.0.1:54384 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_simulateV1","params":[{"blockStateCalls":[{"calls":[]}]},null],"id":1}' | jq                                              
{                                                                                                                                                                                                                                       
  "jsonrpc": "2.0",                                                                                                                                                                                                                     
  "id": 1,                                                                                                                                                                                                                              
  "error": {                                                                                                                                                                                                                            
    "code": -32000,                                                                                                                                                                                                                     
    "message": "eth_simulateV1 is not supported on Bor"                                                                                                                                                                                 
  }                                                                                                                                                                                                                                     
}      
```