### PR TITLE
ethdb, triedb: tune pebble write path and add safe pathdb state carry-over

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -328,8 +328,7 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 			{TargetFileSize: 16 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
 			{TargetFileSize: 32 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
 			{TargetFileSize: 64 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			// Remove the bloom filter from L6, as the bottom level is always checked anyway
-			{TargetFileSize: 128 * 1024 * 1024},
+			{TargetFileSize: 128 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
 		},
 		ReadOnly: readonly,
 		EventListener: &pebble.EventListener{

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -300,6 +300,8 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 		// memory allowance for cache.
 		Cache:        pebble.NewCache(int64(cache * 1024 * 1024)),
 		MaxOpenFiles: handles,
+		// BytesPerSync was 512 KB as implicit default. Increasing it will provide fewer but larger syncs during compaction
+		BytesPerSync: 1 * 1024 * 1024,
 
 		// The size of memory table(as well as the write buffer).
 		// Note, there may have more than two memory tables in the system.
@@ -310,7 +312,8 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 		// Note, this must be the number of tables not the size of all memtables
 		// according to https://github.com/cockroachdb/pebble/blob/master/options.go#L738-L742
 		// and to https://github.com/cockroachdb/pebble/blob/master/db.go#L1892-L1903.
-		MemTableStopWritesThreshold: memTableLimit,
+		// Doubling the threshold will reduce write stalls during flush
+		MemTableStopWritesThreshold: memTableLimit * 2,
 
 		// The default compaction concurrency(1 thread),
 		// Here use all available CPUs for faster compaction.
@@ -325,7 +328,8 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 			{TargetFileSize: 16 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
 			{TargetFileSize: 32 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
 			{TargetFileSize: 64 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
-			{TargetFileSize: 128 * 1024 * 1024, FilterPolicy: bloom.FilterPolicy(10)},
+			// Remove the bloom filter from L6, as the bottom level is always checked anyway
+			{TargetFileSize: 128 * 1024 * 1024},
 		},
 		ReadOnly: readonly,
 		EventListener: &pebble.EventListener{
@@ -363,6 +367,12 @@ func New(file string, cache int, handles int, namespace string, readonly bool) (
 	// Disable seek compaction explicitly. Check https://github.com/ethereum/go-ethereum/pull/20130
 	// for more details.
 	opt.Experimental.ReadSamplingMultiplier = -1
+
+	// Adaptive compaction scales the workers based on the load instead of always using all CPUs
+	// L0CompactionConcurrency compaction worker per overlapping sublevel
+	opt.Experimental.L0CompactionConcurrency = 1
+	// CompactionDebtConcurrency worker per 256 MB of compaction debt
+	opt.Experimental.CompactionDebtConcurrency = 1 << 28
 
 	// Open the db and recover any potential corruptions
 	innerDB, err := pebble.Open(file, opt)

--- a/triedb/pathdb/buffer.go
+++ b/triedb/pathdb/buffer.go
@@ -38,7 +38,7 @@ type buffer struct {
 	layers     uint64    // The number of diff layers aggregated inside
 	limit      uint64    // The maximum total memory allowance in bytes
 	nodeLimit  uint64    // Trie node memory threshold that triggers a flush
-	stateLimit uint64    // State memory threshold (hard cap)
+	stateLimit uint64    // State memory reservation/budget within limit; not an independent hard cap
 	nodes      *nodeSet  // Aggregated trie node set
 	states     *stateSet // Aggregated state set
 

--- a/triedb/pathdb/buffer.go
+++ b/triedb/pathdb/buffer.go
@@ -35,10 +35,12 @@ import (
 // must be checked before diving into disk (since it basically is not yet written
 // data).
 type buffer struct {
-	layers uint64    // The number of diff layers aggregated inside
-	limit  uint64    // The maximum memory allowance in bytes
-	nodes  *nodeSet  // Aggregated trie node set
-	states *stateSet // Aggregated state set
+	layers     uint64    // The number of diff layers aggregated inside
+	limit      uint64    // The maximum total memory allowance in bytes
+	nodeLimit  uint64    // Trie node memory threshold that triggers a flush
+	stateLimit uint64    // State memory threshold (hard cap)
+	nodes      *nodeSet  // Aggregated trie node set
+	states     *stateSet // Aggregated state set
 
 	// done is the notifier whether the content in buffer has been flushed or not.
 	// This channel is nil if the buffer is not frozen.
@@ -49,7 +51,7 @@ type buffer struct {
 }
 
 // newBuffer initializes the buffer with the provided states and trie nodes.
-func newBuffer(limit int, nodes *nodeSet, states *stateSet, layers uint64) *buffer {
+func newBuffer(limit int, stateReservation int, nodes *nodeSet, states *stateSet, layers uint64) *buffer {
 	// Don't panic for lazy users if any provided set is nil
 	if nodes == nil {
 		nodes = newNodeSet(nil)
@@ -57,11 +59,19 @@ func newBuffer(limit int, nodes *nodeSet, states *stateSet, layers uint64) *buff
 	if states == nil {
 		states = newStates(nil, nil, false)
 	}
+	if stateReservation <= 0 || stateReservation > 100 {
+		stateReservation = defaultStateReservation
+	}
+	stateLimit := uint64(limit) * uint64(stateReservation) / 100
+	nodeLimit := uint64(limit) - stateLimit
+
 	return &buffer{
-		layers: layers,
-		limit:  uint64(limit),
-		nodes:  nodes,
-		states: states,
+		layers:     layers,
+		limit:      uint64(limit),
+		nodeLimit:  nodeLimit,
+		stateLimit: stateLimit,
+		nodes:      nodes,
+		states:     states,
 	}
 }
 
@@ -120,10 +130,18 @@ func (b *buffer) empty() bool {
 	return b.layers == 0
 }
 
-// full returns an indicator if the size of accumulated content exceeds the
-// configured threshold.
+// full returns an indicator if the buffer should be flushed.
+// A flush is triggered when trie nodes exceed their allocation or when
+// the total buffer size exceeds the hard limit.
 func (b *buffer) full() bool {
-	return b.size() > b.limit
+	return b.nodes.size > b.nodeLimit || b.size() > b.limit
+}
+
+// shouldCarryStates returns true if states should be carried over to the new
+// buffer after a flush. States are carried over when the flush was triggered
+// by trie nodes exceeding their allocation (not by states exceeding theirs).
+func (b *buffer) shouldCarryStates() bool {
+	return b.states.size <= b.stateLimit
 }
 
 // size returns the approximate memory size of the held content.
@@ -139,6 +157,13 @@ func (b *buffer) flush(root common.Hash, db ethdb.KeyValueStore, freezer ethdb.A
 	}
 	b.done = make(chan struct{}) // allocate the channel for notification
 
+	// Capture references to nodes, states, and layers before the goroutine
+	// starts. This allows the caller to transfer b.states ownership (for
+	// carry-over) without racing with the background flush.
+	flushNodes := b.nodes
+	flushStates := b.states
+	flushLayers := b.layers
+
 	// Schedule the background thread to construct the batch, which usually
 	// take a few seconds.
 	go func() {
@@ -151,15 +176,15 @@ func (b *buffer) flush(root common.Hash, db ethdb.KeyValueStore, freezer ethdb.A
 
 		// Ensure the target state id is aligned with the internal counter.
 		head := rawdb.ReadPersistentStateID(db)
-		if head+b.layers != id {
-			b.flushErr = fmt.Errorf("buffer layers (%d) cannot be applied on top of persisted state id (%d) to reach requested state id (%d)", b.layers, head, id)
+		if head+flushLayers != id {
+			b.flushErr = fmt.Errorf("buffer layers (%d) cannot be applied on top of persisted state id (%d) to reach requested state id (%d)", flushLayers, head, id)
 			return
 		}
 
 		// Terminate the state snapshot generation if it's active
 		var (
 			start = time.Now()
-			batch = db.NewBatchWithSize((b.nodes.dbsize() + b.states.dbsize()) * 11 / 10) // extra 10% for potential pebble internal stuff
+			batch = db.NewBatchWithSize((flushNodes.dbsize() + flushStates.dbsize()) * 11 / 10) // an extra 10% for potential pebble internal stuff
 		)
 		// Explicitly sync the state freezer to ensure all written data is persisted to disk
 		// before updating the key-value store.
@@ -172,8 +197,8 @@ func (b *buffer) flush(root common.Hash, db ethdb.KeyValueStore, freezer ethdb.A
 				return
 			}
 		}
-		nodes := b.nodes.write(batch, nodesCache)
-		accounts, slots := b.states.write(batch, progress, statesCache)
+		nodes := flushNodes.write(batch, nodesCache)
+		accounts, slots := flushStates.write(batch, progress, statesCache)
 		rawdb.WritePersistentStateID(batch, id)
 		rawdb.WriteSnapshotRoot(batch, root)
 

--- a/triedb/pathdb/buffer_test.go
+++ b/triedb/pathdb/buffer_test.go
@@ -1,0 +1,506 @@
+package pathdb
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+)
+
+// TestBufferLimitSplit verifies that newBuffer correctly splits the total limit
+// into nodeLimit and stateLimit based on the stateReservation percentage.
+func TestBufferLimitSplit(t *testing.T) {
+	tests := []struct {
+		name             string
+		limit            int
+		stateReservation int
+		wantNodeLimit    uint64
+		wantStateLimit   uint64
+	}{
+		{
+			name:             "default 80/20 split",
+			limit:            1000,
+			stateReservation: 80,
+			wantNodeLimit:    200,
+			wantStateLimit:   800,
+		},
+		{
+			name:             "50/50 split",
+			limit:            1000,
+			stateReservation: 50,
+			wantNodeLimit:    500,
+			wantStateLimit:   500,
+		},
+		{
+			name:             "invalid reservation falls back to default",
+			limit:            1000,
+			stateReservation: 0,
+			wantNodeLimit:    1000 - 1000*defaultStateReservation/100,
+			wantStateLimit:   1000 * defaultStateReservation / 100,
+		},
+		{
+			name:             "over 100 falls back to default",
+			limit:            1000,
+			stateReservation: 150,
+			wantNodeLimit:    1000 - 1000*defaultStateReservation/100,
+			wantStateLimit:   1000 * defaultStateReservation / 100,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newBuffer(tt.limit, tt.stateReservation, nil, nil, 0)
+			if b.nodeLimit != tt.wantNodeLimit {
+				t.Errorf("nodeLimit = %d, want %d", b.nodeLimit, tt.wantNodeLimit)
+			}
+			if b.stateLimit != tt.wantStateLimit {
+				t.Errorf("stateLimit = %d, want %d", b.stateLimit, tt.wantStateLimit)
+			}
+			if b.limit != uint64(tt.limit) {
+				t.Errorf("limit = %d, want %d", b.limit, tt.limit)
+			}
+		})
+	}
+}
+
+// TestBufferFullTriggeredByNodeLimit verifies that full() returns true when
+// trie nodes exceed their allocation, even if the total size is under the hard limit.
+func TestBufferFullTriggeredByNodeLimit(t *testing.T) {
+	// 1000 byte limit, 80% states (800), 20% nodes (200)
+	b := newBuffer(1000, 80, nil, nil, 0)
+
+	// Nodes at 150, states at 100 — total 250 < 1000, nodes < 200
+	b.nodes.size = 150
+	b.states.size = 100
+	if b.full() {
+		t.Error("buffer should not be full: nodes and total both under limits")
+	}
+
+	// Nodes at 201 — exceeds nodeLimit (200), but total (301) < limit (1000)
+	b.nodes.size = 201
+	if !b.full() {
+		t.Error("buffer should be full: nodes exceed nodeLimit")
+	}
+}
+
+// TestBufferFullTriggeredByTotalLimit verifies that full() returns true when
+// the total size exceeds the hard limit, even if nodes are under their limit.
+func TestBufferFullTriggeredByTotalLimit(t *testing.T) {
+	// 1000 byte limit, 80% states (800), 20% nodes (200)
+	b := newBuffer(1000, 80, nil, nil, 0)
+
+	// Nodes at 100 (under 200 nodeLimit), states at 950 — total 1050 > 1000
+	b.nodes.size = 100
+	b.states.size = 950
+	if !b.full() {
+		t.Error("buffer should be full: total exceeds hard limit")
+	}
+}
+
+// TestShouldCarryStates verifies that states are carried over only when
+// the flush was triggered by nodes, not by states exceeding their limit.
+func TestShouldCarryStates(t *testing.T) {
+	// 1000 byte limit, 80% states (800), 20% nodes (200)
+	b := newBuffer(1000, 80, nil, nil, 0)
+
+	// States under stateLimit — should carry
+	b.states.size = 500
+	b.nodes.size = 250 // nodes over nodeLimit, triggering flush
+	if !b.shouldCarryStates() {
+		t.Error("should carry states: states (500) <= stateLimit (800)")
+	}
+
+	// States exactly at stateLimit — should carry
+	b.states.size = 800
+	if !b.shouldCarryStates() {
+		t.Error("should carry states: states (800) == stateLimit (800)")
+	}
+
+	// States over stateLimit — should NOT carry
+	b.states.size = 801
+	if b.shouldCarryStates() {
+		t.Error("should not carry states: states (801) > stateLimit (800)")
+	}
+}
+
+// TestStateSetCopy verifies that copy() produces an independent deep copy.
+func TestStateSetCopy(t *testing.T) {
+	addrHash := common.HexToHash("0x01")
+	slotHash := common.HexToHash("0x02")
+
+	original := newStates(
+		map[common.Hash][]byte{addrHash: {1, 2, 3}},
+		map[common.Hash]map[common.Hash][]byte{
+			addrHash: {slotHash: {4, 5, 6}},
+		},
+		false,
+	)
+
+	copied := original.copy()
+
+	// Verify data matches
+	if data, ok := copied.account(addrHash); !ok || len(data) != 3 || data[0] != 1 {
+		t.Error("copied account data doesn't match original")
+	}
+	if data, ok := copied.storage(addrHash, slotHash); !ok || len(data) != 3 || data[0] != 4 {
+		t.Error("copied storage data doesn't match original")
+	}
+	if copied.size != original.size {
+		t.Errorf("copied size %d != original size %d", copied.size, original.size)
+	}
+
+	// Mutate the copy and verify the original is unchanged
+	copied.accountData[addrHash] = []byte{9, 9, 9}
+	copied.storageData[addrHash][slotHash] = []byte{8, 8, 8}
+
+	if data, _ := original.account(addrHash); data[0] != 1 {
+		t.Error("mutating copy affected original account data")
+	}
+	if data, _ := original.storage(addrHash, slotHash); data[0] != 4 {
+		t.Error("mutating copy affected original storage data")
+	}
+}
+
+// TestNewBufferWithCarriedStates verifies that a buffer created with
+// pre-existing states correctly includes them and tracks their size.
+func TestNewBufferWithCarriedStates(t *testing.T) {
+	addrHash := common.HexToHash("0x01")
+	slotHash := common.HexToHash("0x02")
+
+	carried := newStates(
+		map[common.Hash][]byte{addrHash: {1, 2, 3}},
+		map[common.Hash]map[common.Hash][]byte{
+			addrHash: {slotHash: {4, 5, 6}},
+		},
+		false,
+	)
+	carriedSize := carried.size
+
+	b := newBuffer(1000, 80, nil, carried, 0)
+
+	// States should be present
+	if data, ok := b.account(addrHash); !ok || data[0] != 1 {
+		t.Error("carried account not found in new buffer")
+	}
+	if data, ok := b.storage(addrHash, slotHash); !ok || data[0] != 4 {
+		t.Error("carried storage not found in new buffer")
+	}
+
+	// Size should reflect carried states
+	if b.states.size != carriedSize {
+		t.Errorf("buffer states size = %d, want %d", b.states.size, carriedSize)
+	}
+
+	// Layers should be 0 (fresh buffer)
+	if b.layers != 0 {
+		t.Errorf("layers = %d, want 0", b.layers)
+	}
+}
+
+// TestStateCarryOverSimulation simulates the flush plus carry-over sequence
+// that happens in disklayer.go to verify the full cycle works correctly.
+func TestStateCarryOverSimulation(t *testing.T) {
+	// Simulate: buffer with 80/20 split, nodes exceed their limit, states don't
+	b := newBuffer(1000, 80, nil, nil, 0)
+
+	// Add some state data
+	addrHash := common.HexToHash("0x01")
+	b.states.accountData[addrHash] = []byte{1, 2, 3}
+	b.states.size = 500 // simulate accumulated state
+	b.nodes.size = 250  // over nodeLimit (200)
+	b.layers = 5
+
+	// Buffer should be full (nodes > nodeLimit)
+	if !b.full() {
+		t.Fatal("buffer should be full")
+	}
+
+	// States should be carried (500 <= 800)
+	if !b.shouldCarryStates() {
+		t.Fatal("states should be carried")
+	}
+
+	// Simulate the carry-over logic
+	var newBuf *buffer
+	if b.shouldCarryStates() {
+		carried := b.states.copy()
+		newBuf = newBuffer(1000, 80, nil, carried, 0)
+	} else {
+		newBuf = newBuffer(1000, 80, nil, nil, 0)
+	}
+
+	// New buffer should have the carried states
+	if data, ok := newBuf.account(addrHash); !ok || data[0] != 1 {
+		t.Error("state not carried over to new buffer")
+	}
+
+	// The new buffer should have fresh layers count
+	if newBuf.layers != 0 {
+		t.Errorf("new buffer layers = %d, want 0", newBuf.layers)
+	}
+
+	// New buffer nodes should be empty
+	if newBuf.nodes.size != 0 {
+		t.Errorf("new buffer nodes size = %d, want 0", newBuf.nodes.size)
+	}
+
+	// The new buffer should NOT be full (nodes are empty now)
+	if newBuf.full() {
+		t.Error("new buffer should not be full after carry-over")
+	}
+}
+
+// TestNoStateCarryWhenStatesExceedLimit verifies that states are NOT carried
+// when they exceed the stateLimit (i.e., the flush was triggered by total size).
+func TestNoStateCarryWhenStatesExceedLimit(t *testing.T) {
+	b := newBuffer(1000, 80, nil, nil, 0)
+
+	addrHash := common.HexToHash("0x01")
+	b.states.accountData[addrHash] = []byte{1, 2, 3}
+	b.states.size = 900 // exceeds stateLimit (800)
+	b.nodes.size = 150  // total 1050 > 1000
+
+	if !b.full() {
+		t.Fatal("buffer should be full")
+	}
+	if b.shouldCarryStates() {
+		t.Fatal("states should NOT be carried when over stateLimit")
+	}
+
+	// Simulate: no carry-over
+	newBuf := newBuffer(1000, 80, nil, nil, 0)
+	if _, ok := newBuf.account(addrHash); ok {
+		t.Error("state should not exist in new buffer when not carried")
+	}
+}
+
+// TestEmptyBufferSemantics verifies that empty() only checks layers, not data.
+// The revert path uses empty() to decide "are there uncommitted transitions?"
+// A buffer with carried states but zero layers IS empty (no transitions to revert).
+func TestEmptyBufferSemantics(t *testing.T) {
+	// A truly empty buffer
+	b := newBuffer(1000, 80, nil, nil, 0)
+	if !b.empty() {
+		t.Error("fresh buffer should be empty")
+	}
+
+	// Buffer with carried states but zero layers — still "empty" (no transitions)
+	carried := newStates(
+		map[common.Hash][]byte{common.HexToHash("0x01"): {1, 2, 3}},
+		nil,
+		false,
+	)
+	b = newBuffer(1000, 80, nil, carried, 0)
+	if !b.empty() {
+		t.Error("buffer with carried states but zero layers should be empty (no transitions)")
+	}
+
+	// Buffer with layers is not empty
+	b = newBuffer(1000, 80, nil, nil, 1)
+	if b.empty() {
+		t.Error("buffer with layers > 0 should NOT be empty")
+	}
+}
+
+// TestRevertClearsCarriedStates verifies that when the revert path encounters
+// an empty buffer (layers==0) with carried states, the carried states are
+// cleared via reset() so they don't serve stale reads after persistent revert.
+// This simulates the diskLayer.revert() code path.
+func TestRevertClearsCarriedStates(t *testing.T) {
+	addrHash := common.HexToHash("0x01")
+
+	// Create a buffer with carried states (layers=0)
+	carried := newStates(
+		map[common.Hash][]byte{addrHash: {1, 2, 3}},
+		nil,
+		false,
+	)
+	b := newBuffer(1000, 80, nil, carried, 0)
+
+	// Buffer is "empty" (no layers), but has carried state data
+	if !b.empty() {
+		t.Fatal("buffer with zero layers should be empty")
+	}
+	if _, ok := b.account(addrHash); !ok {
+		t.Fatal("carried state should be present before reset")
+	}
+
+	// Simulate what diskLayer.revert() does: detect empty buffer,
+	// reset it to clear stale carried states, then proceed to
+	// persistent-state revert.
+	b.reset()
+	if _, ok := b.account(addrHash); ok {
+		t.Error("carried state should be cleared after reset")
+	}
+	if b.states.size != 0 {
+		t.Errorf("state size should be 0 after reset, got %d", b.states.size)
+	}
+}
+
+// TestRevertToWithLayers verifies that revertTo correctly handles a buffer
+// with committed layers, including when carried states are present.
+func TestRevertToWithLayers(t *testing.T) {
+	addrHash := common.HexToHash("0x01")
+
+	// Create a buffer with carried states
+	carried := newStates(
+		map[common.Hash][]byte{addrHash: {1, 2, 3}},
+		nil,
+		false,
+	)
+	b := newBuffer(1000, 80, nil, carried, 0)
+
+	// revertTo with layers=0 returns errStateUnrecoverable
+	err := b.revertTo(nil, nil, nil, nil)
+	if !errors.Is(err, errStateUnrecoverable) {
+		t.Errorf("revertTo on zero-layer buffer should return errStateUnrecoverable, got: %v", err)
+	}
+
+	// Simulate commit: add a layer, then revert it
+	b.layers = 1
+	err = b.revertTo(nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("revertTo should succeed: %v", err)
+	}
+
+	// After revert to layers=0, buffer is fully reset (carried states cleared)
+	if !b.empty() {
+		t.Error("buffer should be empty after reverting to zero layers")
+	}
+	if _, ok := b.account(addrHash); ok {
+		t.Error("carried state should be cleared after revert to zero layers")
+	}
+}
+
+// TestNoCarryOnForceFlush verifies that states are NOT carried over when
+// the flush is triggered by force or history pressure.
+func TestNoCarryOnForceFlush(t *testing.T) {
+	// Simulate: buffer with node pressure + shouldCarryStates() = true,
+	// but force/flush flags override.
+	b := newBuffer(1000, 80, nil, nil, 0)
+
+	addrHash := common.HexToHash("0x01")
+	b.states.accountData[addrHash] = []byte{1, 2, 3}
+	b.states.size = 500 // under stateLimit (800)
+	b.nodes.size = 250  // over nodeLimit (200)
+
+	// shouldCarryStates is true (states within budget)
+	if !b.shouldCarryStates() {
+		t.Fatal("shouldCarryStates should be true")
+	}
+
+	// Simulate force=true path: carry-over is suppressed
+	var newBuf *buffer
+	if b.shouldCarryStates() {
+		carried := b.states.copy()
+		newBuf = newBuffer(1000, 80, nil, carried, 0)
+	} else {
+		newBuf = newBuffer(1000, 80, nil, nil, 0)
+	}
+	if _, ok := newBuf.account(addrHash); ok {
+		t.Error("state should NOT be carried on force flush")
+	}
+
+	// Simulate flush=true (history-driven) path: carry-over is suppressed
+	if b.shouldCarryStates() {
+		carried := b.states.copy()
+		newBuf = newBuffer(1000, 80, nil, carried, 0)
+	} else {
+		newBuf = newBuffer(1000, 80, nil, nil, 0)
+	}
+	if _, ok := newBuf.account(addrHash); ok {
+		t.Error("state should NOT be carried on history-driven flush")
+	}
+
+	// Simulate a normal node-pressure path: carry-over happens
+	if b.shouldCarryStates() {
+		carried := b.states.copy()
+		newBuf = newBuffer(1000, 80, nil, carried, 0)
+	} else {
+		newBuf = newBuffer(1000, 80, nil, nil, 0)
+	}
+	if _, ok := newBuf.account(addrHash); !ok {
+		t.Error("state SHOULD be carried on normal node-pressure flush")
+	}
+}
+
+// TestAsyncFlushOwnershipTransfer exercises the real async flush() goroutine
+// together with the ownership-transfer carry-over path. It verifies that:
+//  1. Carried states are readable from the new live buffer during the flush.
+//  2. The frozen buffer's states are emptied (no stale duplicate).
+//  3. The flushed data lands on disk after waitFlush().
+func TestAsyncFlushOwnershipTransfer(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+
+	addrHash := common.HexToHash("0x01")
+	slotHash := common.HexToHash("0x02")
+	accountBlob := []byte{1, 2, 3}
+	storageBlob := []byte{4, 5, 6}
+
+	// Build a buffer that will trigger a flush via node pressure.
+	// 10'000 byte limit, 80/20 split → nodeLimit=2000, stateLimit=8000.
+	buf := newBuffer(10000, 80, nil, nil, 0)
+	buf.states = newStates(
+		map[common.Hash][]byte{addrHash: accountBlob},
+		map[common.Hash]map[common.Hash][]byte{
+			addrHash: {slotHash: storageBlob},
+		},
+		false,
+	)
+	buf.nodes.size = 2500 // exceeds nodeLimit (2000) → full()
+	buf.layers = 1        // flush expects layers to match persistent state id
+
+	if !buf.full() {
+		t.Fatal("buffer should be full")
+	}
+	if !buf.shouldCarryStates() {
+		t.Fatal("states should be eligible for carry-over")
+	}
+
+	// Seed the persistent state ID so the flush goroutine's sanity check
+	rawdb.WritePersistentStateID(db, 0)
+
+	// Freeze the buffer and start the async flush
+	frozen := buf
+	frozen.flush(common.Hash{}, db, nil, nil, nil, nil, 1, nil)
+
+	// Perform the ownership transfer
+	carried := frozen.states
+	frozen.states = newStates(nil, nil, carried.rawStorageKey)
+	live := newBuffer(10000, 80, nil, carried, 0)
+
+	// 1. Carried states are readable from the live buffer during the flush.
+	if data, ok := live.account(addrHash); !ok {
+		t.Fatal("carried account not readable from live buffer")
+	} else if len(data) != 3 || data[0] != 1 {
+		t.Fatalf("carried account data mismatch: got %v", data)
+	}
+	if data, ok := live.storage(addrHash, slotHash); !ok {
+		t.Fatal("carried storage not readable from live buffer")
+	} else if len(data) != 3 || data[0] != 4 {
+		t.Fatalf("carried storage data mismatch: got %v", data)
+	}
+
+	// 2. Frozen buffer's states are emptied — no stale duplicate.
+	if _, ok := frozen.account(addrHash); ok {
+		t.Error("frozen buffer should not still hold account after ownership transfer")
+	}
+	if _, ok := frozen.storage(addrHash, slotHash); ok {
+		t.Error("frozen buffer should not still hold storage after ownership transfer")
+	}
+
+	// 3. Wait for the async flush to complete and verify data landed on disk.
+	if err := frozen.waitFlush(); err != nil {
+		t.Fatalf("flush failed: %v", err)
+	}
+	if blob := rawdb.ReadAccountSnapshot(db, addrHash); len(blob) == 0 {
+		t.Error("account snapshot not persisted to disk after flush")
+	} else if blob[0] != 1 {
+		t.Errorf("persisted account data mismatch: got %v", blob)
+	}
+	if blob := rawdb.ReadStorageSnapshot(db, addrHash, slotHash); len(blob) == 0 {
+		t.Error("storage snapshot not persisted to disk after flush")
+	} else if blob[0] != 4 {
+		t.Errorf("persisted storage data mismatch: got %v", blob)
+	}
+}

--- a/triedb/pathdb/buffer_test.go
+++ b/triedb/pathdb/buffer_test.go
@@ -6,7 +6,98 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
 )
+
+var _ ethdb.ResettableAncientStore = (*blockingAncientStore)(nil)
+
+type blockingAncientStore struct {
+	syncStarted chan struct{}
+	releaseSync chan struct{}
+}
+
+func newBlockingAncientStore() *blockingAncientStore {
+	return &blockingAncientStore{
+		syncStarted: make(chan struct{}),
+		releaseSync: make(chan struct{}),
+	}
+}
+
+func (s *blockingAncientStore) Ancient(string, uint64) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *blockingAncientStore) AncientRange(string, uint64, uint64, uint64) ([][]byte, error) {
+	return nil, nil
+}
+
+func (s *blockingAncientStore) AncientBytes(string, uint64, uint64, uint64) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *blockingAncientStore) Ancients() (uint64, error) {
+	return 0, nil
+}
+
+func (s *blockingAncientStore) Tail() (uint64, error) {
+	return 0, nil
+}
+
+func (s *blockingAncientStore) AncientSize(string) (uint64, error) {
+	return 0, nil
+}
+
+func (s *blockingAncientStore) ItemAmountInAncient() (uint64, error) {
+	return 0, nil
+}
+
+func (s *blockingAncientStore) AncientOffSet() uint64 {
+	return 0
+}
+
+func (s *blockingAncientStore) ReadAncients(fn func(ethdb.AncientReaderOp) error) error {
+	return fn(s)
+}
+
+func (s *blockingAncientStore) ModifyAncients(fn func(ethdb.AncientWriteOp) error) (int64, error) {
+	return 0, fn(noopAncientWriteOp{})
+}
+
+func (s *blockingAncientStore) SyncAncient() error {
+	close(s.syncStarted)
+	<-s.releaseSync
+	return nil
+}
+
+func (s *blockingAncientStore) TruncateHead(uint64) (uint64, error) {
+	return 0, nil
+}
+
+func (s *blockingAncientStore) TruncateTail(uint64) (uint64, error) {
+	return 0, nil
+}
+
+func (s *blockingAncientStore) AncientDatadir() (string, error) {
+	return "", nil
+}
+
+func (s *blockingAncientStore) Reset() error {
+	return nil
+}
+
+func (s *blockingAncientStore) Close() error {
+	return nil
+}
+
+type noopAncientWriteOp struct{}
+
+func (noopAncientWriteOp) Append(string, uint64, interface{}) error {
+	return nil
+}
+
+func (noopAncientWriteOp) AppendRaw(string, uint64, []byte) error {
+	return nil
+}
 
 // TestBufferLimitSplit verifies that newBuffer correctly splits the total limit
 // into nodeLimit and stateLimit based on the stateReservation percentage.
@@ -123,10 +214,12 @@ func TestShouldCarryStates(t *testing.T) {
 	}
 }
 
-// TestStateSetCopy verifies that copy() produces an independent deep copy.
+// TestStateSetCopy verifies that copy() preserves snapshot isolation for
+// later mutations.
 func TestStateSetCopy(t *testing.T) {
 	addrHash := common.HexToHash("0x01")
 	slotHash := common.HexToHash("0x02")
+	slotHash2 := common.HexToHash("0x03")
 
 	original := newStates(
 		map[common.Hash][]byte{addrHash: {1, 2, 3}},
@@ -149,15 +242,26 @@ func TestStateSetCopy(t *testing.T) {
 		t.Errorf("copied size %d != original size %d", copied.size, original.size)
 	}
 
-	// Mutate the copy and verify the original is unchanged
-	copied.accountData[addrHash] = []byte{9, 9, 9}
-	copied.storageData[addrHash][slotHash] = []byte{8, 8, 8}
+	// Mutate the copy through the normal merge path and verify the original is unchanged.
+	copied.merge(newStates(
+		map[common.Hash][]byte{addrHash: {9, 9, 9}},
+		map[common.Hash]map[common.Hash][]byte{
+			addrHash: {
+				slotHash:  {8, 8, 8},
+				slotHash2: {7, 7, 7},
+			},
+		},
+		false,
+	))
 
 	if data, _ := original.account(addrHash); data[0] != 1 {
 		t.Error("mutating copy affected original account data")
 	}
 	if data, _ := original.storage(addrHash, slotHash); data[0] != 4 {
 		t.Error("mutating copy affected original storage data")
+	}
+	if _, ok := original.storage(addrHash, slotHash2); ok {
+		t.Error("mutating copy created storage in the original state set")
 	}
 }
 
@@ -372,135 +476,210 @@ func TestRevertToWithLayers(t *testing.T) {
 	}
 }
 
-// TestNoCarryOnForceFlush verifies that states are NOT carried over when
-// the flush is triggered by force or history pressure.
-func TestNoCarryOnForceFlush(t *testing.T) {
-	// Simulate: buffer with node pressure + shouldCarryStates() = true,
-	// but force/flush flags override.
-	b := newBuffer(1000, 80, nil, nil, 0)
+// TestDiskLayerCommitForceFlushDoesNotCarryStates verifies that force=true
+// suppresses carry-over in the real commit path even when the state budget
+// would otherwise allow it.
+func TestDiskLayerCommitForceFlushDoesNotCarryStates(t *testing.T) {
+	diskdb := rawdb.NewMemoryDatabase()
+	db := &Database{
+		config: &Config{
+			WriteBufferSize:  10000,
+			StateReservation: 80,
+			StateHistory:     0,
+			NoAsyncFlush:     true,
+		},
+		diskdb: diskdb,
+	}
 
 	addrHash := common.HexToHash("0x01")
-	b.states.accountData[addrHash] = []byte{1, 2, 3}
-	b.states.size = 500 // under stateLimit (800)
-	b.nodes.size = 250  // over nodeLimit (200)
+	accountBlob := []byte{1, 2, 3}
 
-	// shouldCarryStates is true (states within budget)
-	if !b.shouldCarryStates() {
-		t.Fatal("shouldCarryStates should be true")
-	}
+	dl := newDiskLayer(common.Hash{}, 0, db, nil, nil, newBuffer(10000, 80, nil, nil, 0), nil)
+	bottom := newDiffLayer(
+		dl,
+		common.HexToHash("0x10"),
+		1,
+		1,
+		NewNodeSetWithOrigin(nil, nil),
+		NewStateSetWithOrigin(
+			map[common.Hash][]byte{addrHash: accountBlob},
+			nil,
+			nil,
+			nil,
+			false,
+		),
+	)
 
-	// Simulate force=true path: carry-over is suppressed
-	var newBuf *buffer
-	if b.shouldCarryStates() {
-		carried := b.states.copy()
-		newBuf = newBuffer(1000, 80, nil, carried, 0)
-	} else {
-		newBuf = newBuffer(1000, 80, nil, nil, 0)
+	ndl, err := dl.commit(bottom, true)
+	if err != nil {
+		t.Fatalf("commit failed: %v", err)
 	}
-	if _, ok := newBuf.account(addrHash); ok {
-		t.Error("state should NOT be carried on force flush")
+	if _, ok := ndl.buffer.account(addrHash); ok {
+		t.Fatal("state should not be carried on force flush")
 	}
-
-	// Simulate flush=true (history-driven) path: carry-over is suppressed
-	if b.shouldCarryStates() {
-		carried := b.states.copy()
-		newBuf = newBuffer(1000, 80, nil, carried, 0)
-	} else {
-		newBuf = newBuffer(1000, 80, nil, nil, 0)
-	}
-	if _, ok := newBuf.account(addrHash); ok {
-		t.Error("state should NOT be carried on history-driven flush")
-	}
-
-	// Simulate a normal node-pressure path: carry-over happens
-	if b.shouldCarryStates() {
-		carried := b.states.copy()
-		newBuf = newBuffer(1000, 80, nil, carried, 0)
-	} else {
-		newBuf = newBuffer(1000, 80, nil, nil, 0)
-	}
-	if _, ok := newBuf.account(addrHash); !ok {
-		t.Error("state SHOULD be carried on normal node-pressure flush")
+	if got := rawdb.ReadAccountSnapshot(diskdb, addrHash); len(got) == 0 {
+		t.Fatal("force flush should persist the account snapshot")
 	}
 }
 
-// TestAsyncFlushOwnershipTransfer exercises the real async flush() goroutine
-// together with the ownership-transfer carry-over path. It verifies that:
-//  1. Carried states are readable from the new live buffer during the flush.
-//  2. The frozen buffer's states are emptied (no stale duplicate).
-//  3. The flushed data lands on disk after waitFlush().
-func TestAsyncFlushOwnershipTransfer(t *testing.T) {
-	db := rawdb.NewMemoryDatabase()
+// TestDiskLayerCommitHistoryFlushDoesNotCarryStates verifies that a
+// history-driven flush suppresses carry-over in the real commit path.
+func TestDiskLayerCommitHistoryFlushDoesNotCarryStates(t *testing.T) {
+	diskdb := rawdb.NewMemoryDatabase()
+	freezer, err := rawdb.NewStateFreezer("", false, false)
+	if err != nil {
+		t.Fatalf("failed to create in-memory state freezer: %v", err)
+	}
+	defer freezer.Close()
+
+	db := &Database{
+		config: &Config{
+			WriteBufferSize:  10000,
+			StateReservation: 80,
+			StateHistory:     1,
+			NoAsyncFlush:     true,
+		},
+		diskdb:       diskdb,
+		stateFreezer: freezer,
+	}
+
+	addrHash1 := common.HexToHash("0x01")
+	addrHash2 := common.HexToHash("0x02")
+	accountBlob1 := []byte{1, 2, 3}
+	accountBlob2 := []byte{4, 5, 6}
+
+	dl := newDiskLayer(common.Hash{}, 0, db, nil, nil, newBuffer(10000, 80, nil, nil, 0), nil)
+	first := newDiffLayer(
+		dl,
+		common.HexToHash("0x10"),
+		1,
+		1,
+		NewNodeSetWithOrigin(nil, nil),
+		NewStateSetWithOrigin(
+			map[common.Hash][]byte{addrHash1: accountBlob1},
+			nil,
+			nil,
+			nil,
+			false,
+		),
+	)
+
+	ndl, err := dl.commit(first, false)
+	if err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	second := newDiffLayer(
+		ndl,
+		common.HexToHash("0x20"),
+		2,
+		2,
+		NewNodeSetWithOrigin(nil, nil),
+		NewStateSetWithOrigin(
+			map[common.Hash][]byte{addrHash2: accountBlob2},
+			nil,
+			nil,
+			nil,
+			false,
+		),
+	)
+
+	ndl, err = ndl.commit(second, false)
+	if err != nil {
+		t.Fatalf("second commit failed: %v", err)
+	}
+	if _, ok := ndl.buffer.account(addrHash2); ok {
+		t.Fatal("state should not be carried on history-driven flush")
+	}
+	if got := rawdb.ReadAccountSnapshot(diskdb, addrHash2); len(got) == 0 {
+		t.Fatal("history-driven flush should persist the account snapshot")
+	}
+}
+
+// TestDiskLayerCommitCarryOverIsolation verifies that the live buffer created
+// after a node-pressure flush does not share mutable state with the in-flight
+// async flush. Otherwise, subsequent live-buffer writes or resets could corrupt
+// the persisted state for the older snapshot.
+func TestDiskLayerCommitCarryOverIsolation(t *testing.T) {
+	diskdb := rawdb.NewMemoryDatabase()
+	freezer := newBlockingAncientStore()
+	db := &Database{
+		config: &Config{
+			WriteBufferSize:  10000,
+			StateReservation: 80,
+			StateHistory:     0,
+		},
+		diskdb:       diskdb,
+		stateFreezer: freezer,
+	}
 
 	addrHash := common.HexToHash("0x01")
 	slotHash := common.HexToHash("0x02")
-	accountBlob := []byte{1, 2, 3}
-	storageBlob := []byte{4, 5, 6}
+	originalBlob := []byte{1, 2, 3}
+	originalSlotBlob := []byte{4, 5, 6}
+	mutatedBlob := []byte{9, 9, 9}
+	mutatedSlotBlob := []byte{7, 7, 7}
 
-	// Build a buffer that will trigger a flush via node pressure.
-	// 10'000 byte limit, 80/20 split → nodeLimit=2000, stateLimit=8000.
-	buf := newBuffer(10000, 80, nil, nil, 0)
-	buf.states = newStates(
-		map[common.Hash][]byte{addrHash: accountBlob},
-		map[common.Hash]map[common.Hash][]byte{
-			addrHash: {slotHash: storageBlob},
-		},
-		false,
+	dl := newDiskLayer(common.Hash{}, 0, db, nil, nil, newBuffer(10000, 80, nil, nil, 0), nil)
+	dl.buffer.nodes.size = 2500 // exceed nodeLimit (2000) without needing the real trie nodes
+
+	bottom := newDiffLayer(
+		dl,
+		common.HexToHash("0x10"),
+		1,
+		1,
+		NewNodeSetWithOrigin(nil, nil),
+		NewStateSetWithOrigin(
+			map[common.Hash][]byte{addrHash: originalBlob},
+			map[common.Hash]map[common.Hash][]byte{
+				addrHash: {slotHash: originalSlotBlob},
+			},
+			nil,
+			nil,
+			false,
+		),
 	)
-	buf.nodes.size = 2500 // exceeds nodeLimit (2000) → full()
-	buf.layers = 1        // flush expects layers to match persistent state id
 
-	if !buf.full() {
-		t.Fatal("buffer should be full")
+	ndl, err := dl.commit(bottom, false)
+	if err != nil {
+		t.Fatalf("commit failed: %v", err)
 	}
-	if !buf.shouldCarryStates() {
-		t.Fatal("states should be eligible for carry-over")
+	if ndl.frozen == nil {
+		t.Fatal("expected frozen buffer for async flush")
 	}
-
-	// Seed the persistent state ID so the flush goroutine's sanity check
-	rawdb.WritePersistentStateID(db, 0)
-
-	// Freeze the buffer and start the async flush
-	frozen := buf
-	frozen.flush(common.Hash{}, db, nil, nil, nil, nil, 1, nil)
-
-	// Perform the ownership transfer
-	carried := frozen.states
-	frozen.states = newStates(nil, nil, carried.rawStorageKey)
-	live := newBuffer(10000, 80, nil, carried, 0)
-
-	// 1. Carried states are readable from the live buffer during the flush.
-	if data, ok := live.account(addrHash); !ok {
-		t.Fatal("carried account not readable from live buffer")
-	} else if len(data) != 3 || data[0] != 1 {
-		t.Fatalf("carried account data mismatch: got %v", data)
+	if got, ok := ndl.buffer.account(addrHash); !ok {
+		t.Fatal("expected carried account in live buffer")
+	} else if string(got) != string(originalBlob) {
+		t.Fatalf("carried account mismatch: got %v want %v", got, originalBlob)
 	}
-	if data, ok := live.storage(addrHash, slotHash); !ok {
-		t.Fatal("carried storage not readable from live buffer")
-	} else if len(data) != 3 || data[0] != 4 {
-		t.Fatalf("carried storage data mismatch: got %v", data)
+	if got, ok := ndl.buffer.storage(addrHash, slotHash); !ok {
+		t.Fatal("expected carried storage in live buffer")
+	} else if string(got) != string(originalSlotBlob) {
+		t.Fatalf("carried storage mismatch: got %v want %v", got, originalSlotBlob)
 	}
 
-	// 2. Frozen buffer's states are emptied — no stale duplicate.
-	if _, ok := frozen.account(addrHash); ok {
-		t.Error("frozen buffer should not still hold account after ownership transfer")
-	}
-	if _, ok := frozen.storage(addrHash, slotHash); ok {
-		t.Error("frozen buffer should not still hold storage after ownership transfer")
-	}
+	<-freezer.syncStarted
 
-	// 3. Wait for the async flush to complete and verify data landed on disk.
-	if err := frozen.waitFlush(); err != nil {
+	// Simulate later live-buffer activity while the previous flush is still blocked.
+	ndl.buffer.states.accountData[addrHash] = mutatedBlob
+	ndl.buffer.states.merge(newStates(nil, map[common.Hash]map[common.Hash][]byte{
+		addrHash: {slotHash: mutatedSlotBlob},
+	}, false))
+	ndl.buffer.reset()
+
+	close(freezer.releaseSync)
+
+	if err := ndl.frozen.waitFlush(); err != nil {
 		t.Fatalf("flush failed: %v", err)
 	}
-	if blob := rawdb.ReadAccountSnapshot(db, addrHash); len(blob) == 0 {
-		t.Error("account snapshot not persisted to disk after flush")
-	} else if blob[0] != 1 {
-		t.Errorf("persisted account data mismatch: got %v", blob)
+	if got := rawdb.ReadAccountSnapshot(diskdb, addrHash); len(got) == 0 {
+		t.Fatal("account snapshot not persisted")
+	} else if string(got) != string(originalBlob) {
+		t.Fatalf("persisted account mismatch: got %v want %v", got, originalBlob)
 	}
-	if blob := rawdb.ReadStorageSnapshot(db, addrHash, slotHash); len(blob) == 0 {
-		t.Error("storage snapshot not persisted to disk after flush")
-	} else if blob[0] != 4 {
-		t.Errorf("persisted storage data mismatch: got %v", blob)
+	if got := rawdb.ReadStorageSnapshot(diskdb, addrHash, slotHash); len(got) == 0 {
+		t.Fatal("storage snapshot not persisted")
+	} else if string(got) != string(originalSlotBlob) {
+		t.Fatalf("persisted storage mismatch: got %v want %v", got, originalSlotBlob)
 	}
 }

--- a/triedb/pathdb/config.go
+++ b/triedb/pathdb/config.go
@@ -92,7 +92,7 @@ type Config struct {
 	TrieCleanSize       int    // Maximum memory allowance (in bytes) for caching clean trie data
 	StateCleanSize      int    // Maximum memory allowance (in bytes) for caching clean state data
 	WriteBufferSize     int    // Maximum memory allowance (in bytes) for write buffer
-	StateReservation    int    // Percentage of write buffer reserved for states (0-100, default 80)
+	StateReservation    int    // Percentage of write buffer reserved for states (1-100, default 80)
 	ReadOnly            bool   // Flag whether the database is opened in read only mode
 	JournalDirectory    string // Absolute path of journal directory (null means the journal data is persisted in key-value store)
 

--- a/triedb/pathdb/config.go
+++ b/triedb/pathdb/config.go
@@ -75,6 +75,7 @@ var Defaults = &Config{
 	StateCleanSize:      defaultStateCleanSize,
 	WriteBufferSize:     defaultBufferSize,
 	StateReservation:    defaultStateReservation,
+	PreloadRateLimit:    defaultPreloadRateLimit,
 }
 
 // ReadOnly is the config in order to open database in read only mode.

--- a/triedb/pathdb/config.go
+++ b/triedb/pathdb/config.go
@@ -32,17 +32,30 @@ const (
 	defaultStateCleanSize = 16 * 1024 * 1024
 
 	// maxBufferSize is the maximum memory allowance of node buffer.
-	// Too large buffer will cause the system to pause for a long
-	// time when write happens. Also, the largest batch that pebble can
-	// support is 4GB, node will panic if batch size exceeds this limit.
-	maxBufferSize = 256 * 1024 * 1024
+	// When async flushing is enabled (the default, controlled by
+	// NoAsyncFlush in Config), the buffer is frozen and flushed in a
+	// background goroutine while a new buffer accepts writes, so block
+	// processing is not blocked by the flush. When async flushing is
+	// disabled (NoAsyncFlush = true), larger buffers will cause the
+	// system to pause for a longer time when the flush happens.
+	// The largest batch that pebble can support is 4GB; the serialized
+	// batch is typically smaller than the in-memory buffer size.
+	maxBufferSize = 2048 * 1024 * 1024
 
 	// defaultBufferSize is the default memory allowance of node buffer
 	// that aggregates the writes from above until it's flushed into the
 	// disk. It's meant to be used once the initial sync is finished.
-	// Do not increase the buffer size arbitrarily, otherwise the system
-	// pause time will increase when the database writes happen.
+	// Do not increase the buffer size arbitrarily without async flushing
+	// enabled, otherwise the system pause time will increase when the
+	// database writes happen.
 	defaultBufferSize = 64 * 1024 * 1024
+
+	// defaultStateReservation is the percentage of the write buffer reserved
+	// for state data (accounts plus storage slots). The remaining portion is for
+	// trie nodes. When trie nodes exceed their allocation, the buffer is flushed,
+	// but states are carried over to the new buffer, allowing state
+	// data to accumulate across flush cycles for a higher dirty hit rate.
+	defaultStateReservation = 80
 
 	// defaultPreloadRateLimit is the default rate limit for address cache preloading
 	// in bytes per second. 1 MB/s balances sync impact with preload performance.
@@ -61,7 +74,7 @@ var Defaults = &Config{
 	TrieCleanSize:       defaultTrieCleanSize,
 	StateCleanSize:      defaultStateCleanSize,
 	WriteBufferSize:     defaultBufferSize,
-	PreloadRateLimit:    defaultPreloadRateLimit,
+	StateReservation:    defaultStateReservation,
 }
 
 // ReadOnly is the config in order to open database in read only mode.
@@ -78,6 +91,7 @@ type Config struct {
 	TrieCleanSize       int    // Maximum memory allowance (in bytes) for caching clean trie data
 	StateCleanSize      int    // Maximum memory allowance (in bytes) for caching clean state data
 	WriteBufferSize     int    // Maximum memory allowance (in bytes) for write buffer
+	StateReservation    int    // Percentage of write buffer reserved for states (0-100, default 80)
 	ReadOnly            bool   // Flag whether the database is opened in read only mode
 	JournalDirectory    string // Absolute path of journal directory (null means the journal data is persisted in key-value store)
 
@@ -105,6 +119,10 @@ func (c *Config) sanitize() *Config {
 		log.Warn("Sanitizing invalid node buffer size", "provided", common.StorageSize(conf.WriteBufferSize), "updated", common.StorageSize(maxBufferSize))
 		conf.WriteBufferSize = maxBufferSize
 	}
+	if conf.StateReservation <= 0 || conf.StateReservation > 100 {
+		log.Warn("Sanitizing invalid state reservation", "provided", conf.StateReservation, "updated", defaultStateReservation)
+		conf.StateReservation = defaultStateReservation
+	}
 	return &conf
 }
 
@@ -117,6 +135,7 @@ func (c *Config) fields() []interface{} {
 	list = append(list, "triecache", common.StorageSize(c.TrieCleanSize))
 	list = append(list, "statecache", common.StorageSize(c.StateCleanSize))
 	list = append(list, "buffer", common.StorageSize(c.WriteBufferSize))
+	list = append(list, "statereservation", fmt.Sprintf("%d%%", c.StateReservation))
 
 	if c.StateHistory == 0 {
 		list = append(list, "state-history", "entire chain")

--- a/triedb/pathdb/difflayer_test.go
+++ b/triedb/pathdb/difflayer_test.go
@@ -30,7 +30,7 @@ import (
 func emptyLayer() *diskLayer {
 	return &diskLayer{
 		db:     New(rawdb.NewMemoryDatabase(), nil, false),
-		buffer: newBuffer(defaultBufferSize, nil, nil, 0),
+		buffer: newBuffer(defaultBufferSize, defaultStateReservation, nil, nil, 0),
 	}
 }
 

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -478,16 +478,10 @@ func (dl *diskLayer) commit(bottom *diffLayer, force bool) (*diskLayer, error) {
 		// history-driven flushes which expect a full clear. States are
 		// carried when they are still within their allocation, meaning
 		// trie nodes were the cause of the flush.
-		//
-		// Transfer ownership instead of copying: flush() captured its own
-		// reference to the states before the goroutine started, so the
-		// background flush is unaffected. After carry-over, state reads
-		// always hit the live buffer first (which holds the carried states),
-		// making the frozen buffer's states redundant for lookups. Replacing
-		// them with an empty set avoids duplicating the map overhead.
+		// Use a shallow copy so the live buffer can evolve independently
+		// while the background flush persists the original snapshot.
 		if !force && !flush && combined.shouldCarryStates() {
-			carried := combined.states
-			combined.states = newStates(nil, nil, carried.rawStorageKey)
+			carried := combined.states.copy()
 			combined = newBuffer(dl.db.config.WriteBufferSize, dl.db.config.StateReservation, nil, carried, 0)
 		} else {
 			combined = newBuffer(dl.db.config.WriteBufferSize, dl.db.config.StateReservation, nil, nil, 0)

--- a/triedb/pathdb/disklayer.go
+++ b/triedb/pathdb/disklayer.go
@@ -473,7 +473,25 @@ func (dl *diskLayer) commit(bottom *diffLayer, force bool) (*diskLayer, error) {
 			}
 			dl.frozen = nil
 		}
-		combined = newBuffer(dl.db.config.WriteBufferSize, nil, nil, 0)
+		// Carry states over to the new buffer only when the flush was
+		// triggered by node pressure (combined.full()), not by force or
+		// history-driven flushes which expect a full clear. States are
+		// carried when they are still within their allocation, meaning
+		// trie nodes were the cause of the flush.
+		//
+		// Transfer ownership instead of copying: flush() captured its own
+		// reference to the states before the goroutine started, so the
+		// background flush is unaffected. After carry-over, state reads
+		// always hit the live buffer first (which holds the carried states),
+		// making the frozen buffer's states redundant for lookups. Replacing
+		// them with an empty set avoids duplicating the map overhead.
+		if !force && !flush && combined.shouldCarryStates() {
+			carried := combined.states
+			combined.states = newStates(nil, nil, carried.rawStorageKey)
+			combined = newBuffer(dl.db.config.WriteBufferSize, dl.db.config.StateReservation, nil, carried, 0)
+		} else {
+			combined = newBuffer(dl.db.config.WriteBufferSize, dl.db.config.StateReservation, nil, nil, 0)
+		}
 	}
 	// Link the generator if snapshot is not yet completed
 	ndl := newDiskLayer(bottom.root, bottom.stateID(), dl.db, dl.nodes, dl.states, combined, dl.frozen)
@@ -534,6 +552,10 @@ func (dl *diskLayer) revert(h *stateHistory) (*diskLayer, error) {
 		log.Debug("Reverted data in write buffer", "oldroot", h.meta.root, "newroot", h.meta.parent, "elapsed", common.PrettyDuration(time.Since(start)))
 		return ndl, nil
 	}
+	// The buffer has no uncommitted transitions. Clear any carried-over
+	// state data so it won't serve stale reads after the persistent
+	// state is reverted below.
+	dl.buffer.reset()
 	// Block until the frozen buffer is fully flushed
 	if dl.frozen != nil {
 		if err := dl.frozen.waitFlush(); err != nil {

--- a/triedb/pathdb/generate.go
+++ b/triedb/pathdb/generate.go
@@ -186,7 +186,7 @@ func generateSnapshot(triedb *Database, root common.Hash, noBuild bool) *diskLay
 		stats     = &generatorStats{start: time.Now()}
 		genMarker = []byte{} // Initialized but empty!
 	)
-	dl := newDiskLayer(root, 0, triedb, nil, nil, newBuffer(triedb.config.WriteBufferSize, nil, nil, 0), nil)
+	dl := newDiskLayer(root, 0, triedb, nil, nil, newBuffer(triedb.config.WriteBufferSize, triedb.config.StateReservation, nil, nil, 0), nil)
 	dl.setGenerator(newGenerator(triedb.diskdb, noBuild, genMarker, stats))
 
 	if !noBuild {

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -177,7 +177,7 @@ func (db *Database) loadLayers() layer {
 		log.Info("Failed to load journal, discard it", "err", err)
 	}
 	// Return single layer with persistent state.
-	return newDiskLayer(root, rawdb.ReadPersistentStateID(db.diskdb), db, nil, nil, newBuffer(db.config.WriteBufferSize, nil, nil, 0), nil)
+	return newDiskLayer(root, rawdb.ReadPersistentStateID(db.diskdb), db, nil, nil, newBuffer(db.config.WriteBufferSize, db.config.StateReservation, nil, nil, 0), nil)
 }
 
 // loadDiskLayer reads the binary blob from the layer journal, reconstructing
@@ -209,7 +209,7 @@ func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 	if err := states.decode(r); err != nil {
 		return nil, err
 	}
-	return newDiskLayer(root, id, db, nil, nil, newBuffer(db.config.WriteBufferSize, &nodes, &states, id-stored), nil), nil
+	return newDiskLayer(root, id, db, nil, nil, newBuffer(db.config.WriteBufferSize, db.config.StateReservation, &nodes, &states, id-stored), nil), nil
 }
 
 // loadDiffLayer reads the next sections of a layer journal, reconstructing a new

--- a/triedb/pathdb/layertree_test.go
+++ b/triedb/pathdb/layertree_test.go
@@ -26,7 +26,7 @@ import (
 
 func newTestLayerTree() *layerTree {
 	db := New(rawdb.NewMemoryDatabase(), nil, false)
-	l := newDiskLayer(common.Hash{0x1}, 0, db, nil, nil, newBuffer(0, nil, nil, 0), nil)
+	l := newDiskLayer(common.Hash{0x1}, 0, db, nil, nil, newBuffer(0, defaultStateReservation, nil, nil, 0), nil)
 	t := newLayerTree(l)
 	return t
 }

--- a/triedb/pathdb/states.go
+++ b/triedb/pathdb/states.go
@@ -70,6 +70,12 @@ type stateSet struct {
 
 	rawStorageKey bool // indicates whether the storage set uses the raw slot key or the hash
 
+	// storageShared indicates that inherited storage submaps should be treated
+	// as copy-on-write. ownedStorage tracks which accounts have already detached
+	// from the shared snapshot and may be mutated in place.
+	storageShared bool
+	ownedStorage  map[common.Hash]struct{}
+
 	// Lock for guarding the two lists above. These lists might be accessed
 	// concurrently and lock protection is essential to avoid concurrent
 	// slice or map read/write.
@@ -95,7 +101,9 @@ func newStates(accounts map[common.Hash][]byte, storages map[common.Hash]map[com
 	return s
 }
 
-// copy creates a deep copy of the state set (safe to mutate concurrently).
+// copy clones the top-level maps and keeps storage submaps shared until the
+// first write in the returned stateSet, minimizing carry-over memory overhead
+// while keeping the source snapshot untouched for async flushing.
 func (s *stateSet) copy() *stateSet {
 	accounts := make(map[common.Hash][]byte, len(s.accountData))
 	for hash, data := range s.accountData {
@@ -103,13 +111,56 @@ func (s *stateSet) copy() *stateSet {
 	}
 	storages := make(map[common.Hash]map[common.Hash][]byte, len(s.storageData))
 	for accountHash, slots := range s.storageData {
-		slotsCopy := make(map[common.Hash][]byte, len(slots))
-		for storageHash, data := range slots {
-			slotsCopy[storageHash] = data
-		}
-		storages[accountHash] = slotsCopy
+		storages[accountHash] = slots
 	}
-	return newStates(accounts, storages, s.rawStorageKey)
+	return &stateSet{
+		accountData:       accounts,
+		storageData:       storages,
+		size:              s.size,
+		rawStorageKey:     s.rawStorageKey,
+		storageShared:     len(storages) > 0,
+		storageListSorted: make(map[common.Hash][]common.Hash),
+	}
+}
+
+// storageIsShared reports whether the account's storage submap is still shared
+// with the source snapshot and must be detached before mutation.
+func (s *stateSet) storageIsShared(accountHash common.Hash) bool {
+	if !s.storageShared {
+		return false
+	}
+	if _, owned := s.ownedStorage[accountHash]; owned {
+		return false
+	}
+	return true
+}
+
+// markStorageOwned records that the account's storage submap has been detached
+// from the shared snapshot and may now be mutated in place.
+func (s *stateSet) markStorageOwned(accountHash common.Hash) {
+	if !s.storageShared {
+		return
+	}
+	if s.ownedStorage == nil {
+		s.ownedStorage = make(map[common.Hash]struct{})
+	}
+	s.ownedStorage[accountHash] = struct{}{}
+}
+
+// writableStorage returns a storage submap that is safe to mutate, cloning it
+// on first write if it is still shared with the source snapshot.
+func (s *stateSet) writableStorage(accountHash common.Hash) map[common.Hash][]byte {
+	slots := s.storageData[accountHash]
+	if !s.storageIsShared(accountHash) {
+		return slots
+	}
+	cloned := make(map[common.Hash][]byte, len(slots))
+	for storageHash, data := range slots {
+		cloned[storageHash] = data
+	}
+	s.storageData[accountHash] = cloned
+	s.markStorageOwned(accountHash)
+	return cloned
 }
 
 // account returns the account data associated with the specified address hash.
@@ -277,7 +328,7 @@ func (s *stateSet) merge(other *stateSet) {
 			continue
 		}
 		// Storage exists in both local and external set, merge the slots
-		slots := s.storageData[accountHash]
+		slots := s.writableStorage(accountHash)
 		for storageHash, data := range storage {
 			if origin, ok := slots[storageHash]; ok {
 				delta += len(data) - len(origin)
@@ -317,10 +368,11 @@ func (s *stateSet) revertTo(accountOrigin map[common.Hash][]byte, storageOrigin 
 	}
 	// Overwrite the storage data with original value blindly
 	for addrHash, storage := range storageOrigin {
-		slots := s.storageData[addrHash]
-		if len(slots) == 0 {
+		slots, ok := s.storageData[addrHash]
+		if !ok || len(slots) == 0 {
 			panic(fmt.Sprintf("non-existent storage set for reverting, %x", addrHash))
 		}
+		slots = s.writableStorage(addrHash)
 		for storageHash, blob := range storage {
 			data, ok := slots[storageHash]
 			if !ok {
@@ -430,6 +482,8 @@ func (s *stateSet) decode(r *rlp.Stream) error {
 		}
 	}
 	s.storageData = storageSet
+	s.storageShared = false
+	s.ownedStorage = nil
 	s.storageListSorted = make(map[common.Hash][]common.Hash)
 
 	s.size = s.check()
@@ -447,6 +501,8 @@ func (s *stateSet) reset() {
 	s.accountData = make(map[common.Hash][]byte)
 	s.storageData = make(map[common.Hash]map[common.Hash][]byte)
 	s.size = 0
+	s.storageShared = false
+	s.ownedStorage = nil
 	s.accountListSorted = nil
 	s.storageListSorted = make(map[common.Hash][]common.Hash)
 }

--- a/triedb/pathdb/states.go
+++ b/triedb/pathdb/states.go
@@ -95,6 +95,23 @@ func newStates(accounts map[common.Hash][]byte, storages map[common.Hash]map[com
 	return s
 }
 
+// copy creates a deep copy of the state set (safe to mutate concurrently).
+func (s *stateSet) copy() *stateSet {
+	accounts := make(map[common.Hash][]byte, len(s.accountData))
+	for hash, data := range s.accountData {
+		accounts[hash] = data // []byte values are treated as immutable
+	}
+	storages := make(map[common.Hash]map[common.Hash][]byte, len(s.storageData))
+	for accountHash, slots := range s.storageData {
+		slotsCopy := make(map[common.Hash][]byte, len(slots))
+		for storageHash, data := range slots {
+			slotsCopy[storageHash] = data
+		}
+		storages[accountHash] = slotsCopy
+	}
+	return newStates(accounts, storages, s.rawStorageKey)
+}
+
 // account returns the account data associated with the specified address hash.
 func (s *stateSet) account(hash common.Hash) ([]byte, bool) {
 	// If the account is known locally, return it

--- a/triedb/pathdb/states_test.go
+++ b/triedb/pathdb/states_test.go
@@ -477,3 +477,120 @@ func TestStateSizeTracking(t *testing.T) {
 		t.Fatalf("Unexpected size, want: %d, got: %d", revertSize, a.size)
 	}
 }
+
+func mapPointer[K comparable, V any](m map[K]V) uintptr {
+	return reflect.ValueOf(m).Pointer()
+}
+
+func TestStateSetCopyUsesCopyOnWriteForStorageMaps(t *testing.T) {
+	accountA := common.HexToHash("0x01")
+	accountB := common.HexToHash("0x02")
+	slot1 := common.HexToHash("0x11")
+	slot2 := common.HexToHash("0x22")
+	slot3 := common.HexToHash("0x33")
+	slot4 := common.HexToHash("0x44")
+
+	original := newStates(
+		map[common.Hash][]byte{
+			accountA: {1},
+			accountB: {2},
+		},
+		map[common.Hash]map[common.Hash][]byte{
+			accountA: {slot1: {10}},
+			accountB: {slot2: {20}},
+		},
+		false,
+	)
+	copied := original.copy()
+
+	if original.storageShared {
+		t.Fatal("copy should not mutate source storage sharing state")
+	}
+	if original.ownedStorage != nil {
+		t.Fatal("copy should not mutate source ownership tracking")
+	}
+	if mapPointer(copied.accountData) == mapPointer(original.accountData) {
+		t.Fatal("accountData top-level map should be cloned")
+	}
+	if mapPointer(copied.storageData) == mapPointer(original.storageData) {
+		t.Fatal("storageData top-level map should be cloned")
+	}
+	if mapPointer(copied.storageData[accountA]) != mapPointer(original.storageData[accountA]) {
+		t.Fatal("account A storage submap should be shared until first write")
+	}
+	if mapPointer(copied.storageData[accountB]) != mapPointer(original.storageData[accountB]) {
+		t.Fatal("account B storage submap should be shared until first write")
+	}
+
+	copied.merge(newStates(nil, map[common.Hash]map[common.Hash][]byte{
+		accountA: {slot3: {30}},
+	}, false))
+	firstDetach := mapPointer(copied.storageData[accountA])
+
+	if firstDetach == mapPointer(original.storageData[accountA]) {
+		t.Fatal("account A storage submap should detach on first write")
+	}
+	if mapPointer(copied.storageData[accountB]) != mapPointer(original.storageData[accountB]) {
+		t.Fatal("untouched storage submaps should remain shared")
+	}
+	if _, ok := original.storageData[accountA][slot3]; ok {
+		t.Fatal("mutating copied stateSet should not affect original storage submap")
+	}
+
+	copied.merge(newStates(nil, map[common.Hash]map[common.Hash][]byte{
+		accountA: {slot4: {40}},
+	}, false))
+	if mapPointer(copied.storageData[accountA]) != firstDetach {
+		t.Fatal("detached storage submap should be reused for subsequent writes")
+	}
+}
+
+func TestStateSetRevertToDetachesSharedStorageMaps(t *testing.T) {
+	account := common.HexToHash("0x01")
+	slot := common.HexToHash("0x11")
+
+	original := newStates(nil, map[common.Hash]map[common.Hash][]byte{
+		account: {slot: {10}},
+	}, false)
+	copied := original.copy()
+
+	if mapPointer(copied.storageData[account]) != mapPointer(original.storageData[account]) {
+		t.Fatal("storage submap should be shared until first write")
+	}
+	copied.revertTo(nil, map[common.Hash]map[common.Hash][]byte{
+		account: {slot: {99}},
+	})
+
+	if mapPointer(copied.storageData[account]) == mapPointer(original.storageData[account]) {
+		t.Fatal("revertTo should detach shared storage submap before mutating it")
+	}
+	if got := copied.storageData[account][slot]; len(got) != 1 || got[0] != 99 {
+		t.Fatalf("copied stateSet should contain reverted value, got %v", got)
+	}
+	if got := original.storageData[account][slot]; len(got) != 1 || got[0] != 10 {
+		t.Fatalf("original stateSet should remain unchanged, got %v", got)
+	}
+}
+
+func TestStateSetRevertToMissingStorageDoesNotCreateEntry(t *testing.T) {
+	account := common.HexToHash("0x01")
+	missing := common.HexToHash("0x02")
+	slot := common.HexToHash("0x11")
+
+	copied := newStates(nil, map[common.Hash]map[common.Hash][]byte{
+		account: {slot: {10}},
+	}, false).copy()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected revertTo to panic for a missing storage set")
+		}
+		if _, ok := copied.storageData[missing]; ok {
+			t.Fatal("revertTo panic should not create a new storage entry")
+		}
+	}()
+
+	copied.revertTo(nil, map[common.Hash]map[common.Hash][]byte{
+		missing: {slot: {20}},
+	})
+}


### PR DESCRIPTION
# Description

This PR implements some PebbleDB optimizations.
Others are on a config level, and will be managed in pos-ops.
The suggested configs are (tested on a 128GB RAM machine)
```
  [cache]
    cache = 24576 # 3x the original value
    gc = 5
    gomemlimit = "55GB"
    snapshot = 25
    database = 45
    trie = 25
```

The PR combines write-path tuning with pathdb buffer changes aimed at reducing write stalls and improving dirty-state reuse across flushes.
On the Pebble side, it tunes sync and compaction behavior. On the pathdb side, it splits the write buffer into node/state budgets, allows state carry-over when flushes are caused by trie-node pressure, and keeps that carry-over safe under async flushing via copy-on-write state snapshots. The copy-on-write carry-over means:
- top-level state maps are copied
- per-account storage submaps are shared initially
- a storage submap is cloned only on first write
This keeps the frozen flush snapshot immutable while still avoiding eager duplication of all storage submaps.

Pebble tuning:
- increase `BytesPerSync` from the implicit default to `1 MiB`
- increase `MemTableStopWritesThreshold` to reduce write stalls during flushes
- enable adaptive compaction settings:
    - `L0CompactionConcurrency = 1`
    - `CompactionDebtConcurrency = 256 MiB`

Pathdb buffer changes:
- raise `maxBufferSize` to `2 GiB`
- add `StateReservation` to split the write buffer between:
    - trie nodes
    - flat state (accounts/storage)
- update buffer fullness logic:
    - flush when trie nodes exceed their reservation
    - also flush when total buffer usage exceeds the hard limit
- carry state forward only when:
    - the flush was caused by node pressure
    - state is still within its reserved budget
- wire the new buffer constructor/config through generation and journal loading
- clear carried-over state on revert when there are no uncommitted transitions left

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mainnet
- [ ] I have created new e2e tests into express-cli