### PR TITLE
metrics: fix ResettingSample Prometheus _count monotonicity

### DIFF
--- a/metrics/resetting_sample.go
+++ b/metrics/resetting_sample.go
@@ -11,15 +11,24 @@ func ResettingSample(sample Sample) Sample {
 }
 
 // resettingSample is a simple wrapper around a sample that resets it upon the
-// snapshot retrieval.
+// snapshot retrieval. It maintains cumulative count and sum separately so that
+// Prometheus _count counters remain monotonically increasing across scrapes.
 type resettingSample struct {
 	Sample
+	count int64
+	sum   int64
 }
 
 // Snapshot returns a read-only copy of the sample with the original reset.
+// Count and Sum are cumulative for Prometheus counter semantics.
+// Values (used for percentiles) are from the current interval only.
 func (rs *resettingSample) Snapshot() *sampleSnapshot {
 	s := rs.Sample.Snapshot()
+	rs.count += s.Count()
+	rs.sum += s.Sum()
 	rs.Sample.Clear()
 
-	return s
+	return newSampleSnapshotPrecalculated(
+		rs.count, s.Values(), s.Min(), s.Max(), rs.sum,
+	)
 }

--- a/metrics/resetting_sample.go
+++ b/metrics/resetting_sample.go
@@ -20,6 +20,12 @@ type resettingSample struct {
 	count atomic.Int64
 }
 
+// Clear resets both the underlying sample and the cumulative count.
+func (rs *resettingSample) Clear() {
+	rs.Sample.Clear()
+	rs.count.Store(0)
+}
+
 // Snapshot returns a read-only copy of the sample with the original reset.
 // Count is cumulative for Prometheus counter semantics.
 // Values, Sum, Min, Max are from the current interval only.

--- a/metrics/resetting_sample.go
+++ b/metrics/resetting_sample.go
@@ -1,5 +1,7 @@
 package metrics
 
+import "sync/atomic"
+
 // ResettingSample converts an ordinary sample into one that resets whenever its
 // snapshot is retrieved. This will break for multi-monitor systems, but when only
 // a single metric is being pushed out, this ensure that low-frequency events don't
@@ -11,24 +13,22 @@ func ResettingSample(sample Sample) Sample {
 }
 
 // resettingSample is a simple wrapper around a sample that resets it upon the
-// snapshot retrieval. It maintains cumulative count and sum separately so that
+// snapshot retrieval. It maintains cumulative count separately so that
 // Prometheus _count counters remain monotonically increasing across scrapes.
 type resettingSample struct {
 	Sample
-	count int64
-	sum   int64
+	count atomic.Int64
 }
 
 // Snapshot returns a read-only copy of the sample with the original reset.
-// Count and Sum are cumulative for Prometheus counter semantics.
-// Values (used for percentiles) are from the current interval only.
+// Count is cumulative for Prometheus counter semantics.
+// Values, Sum, Min, Max are from the current interval only.
 func (rs *resettingSample) Snapshot() *sampleSnapshot {
 	s := rs.Sample.Snapshot()
-	rs.count += s.Count()
-	rs.sum += s.Sum()
+	count := rs.count.Add(s.Count())
 	rs.Sample.Clear()
 
 	return newSampleSnapshotPrecalculated(
-		rs.count, s.Values(), s.Min(), s.Max(), rs.sum,
+		count, s.Values(), s.Min(), s.Max(), s.Sum(),
 	)
 }

--- a/metrics/resetting_sample.go
+++ b/metrics/resetting_sample.go
@@ -35,6 +35,6 @@ func (rs *resettingSample) Snapshot() *sampleSnapshot {
 	rs.Sample.Clear()
 
 	return newSampleSnapshotPrecalculated(
-		count, s.Values(), s.Min(), s.Max(), s.Sum(),
+		count, s.values, s.Min(), s.Max(), s.Sum(),
 	)
 }

--- a/metrics/resetting_sample_test.go
+++ b/metrics/resetting_sample_test.go
@@ -104,3 +104,63 @@ func TestResettingSampleEmptyInterval(t *testing.T) {
 		t.Errorf("mean should be 0 on empty interval, got %.2f", snap2.Mean())
 	}
 }
+
+func TestResettingSampleClearResetsCumulativeCount(t *testing.T) {
+	s := ResettingSample(&testSample{})
+
+	s.Update(10)
+	s.Update(20)
+	snap1 := s.Snapshot()
+
+	if snap1.Count() != 2 {
+		t.Fatalf("snap1.Count(): got %d, want 2", snap1.Count())
+	}
+
+	// External Clear should reset cumulative count
+	s.Clear()
+
+	s.Update(30)
+	snap2 := s.Snapshot()
+
+	// After Clear, count should restart from 1, not continue from 2
+	if snap2.Count() != 1 {
+		t.Errorf("after Clear, snap2.Count(): got %d, want 1", snap2.Count())
+	}
+}
+
+func TestResettingSampleMultipleEmptyIntervals(t *testing.T) {
+	s := ResettingSample(&testSample{})
+
+	s.Update(10)
+	snap1 := s.Snapshot()
+
+	// Multiple consecutive empty intervals
+	snap2 := s.Snapshot()
+	snap3 := s.Snapshot()
+
+	if snap2.Count() != snap1.Count() || snap3.Count() != snap1.Count() {
+		t.Errorf("count must stay stable across empty intervals: %d -> %d -> %d",
+			snap1.Count(), snap2.Count(), snap3.Count())
+	}
+}
+
+func TestResettingSampleMinMaxPerInterval(t *testing.T) {
+	s := ResettingSample(&testSample{})
+
+	s.Update(100)
+	s.Update(200)
+	snap1 := s.Snapshot()
+
+	if snap1.Min() != 100 || snap1.Max() != 200 {
+		t.Errorf("snap1: min=%d max=%d, want min=100 max=200", snap1.Min(), snap1.Max())
+	}
+
+	// Second interval with different range
+	s.Update(5)
+	s.Update(10)
+	snap2 := s.Snapshot()
+
+	if snap2.Min() != 5 || snap2.Max() != 10 {
+		t.Errorf("snap2: min=%d max=%d, want min=5 max=10", snap2.Min(), snap2.Max())
+	}
+}

--- a/metrics/resetting_sample_test.go
+++ b/metrics/resetting_sample_test.go
@@ -1,0 +1,106 @@
+package metrics
+
+import "testing"
+
+// testSample is a minimal Sample implementation with deterministic Clear behavior.
+type testSample struct {
+	values []int64
+}
+
+func (s *testSample) Update(v int64) { s.values = append(s.values, v) }
+
+func (s *testSample) Clear() { s.values = s.values[:0] }
+
+func (s *testSample) Snapshot() *sampleSnapshot {
+	return newSampleSnapshot(int64(len(s.values)), append([]int64(nil), s.values...))
+}
+
+func TestResettingSampleCountMonotonicallyIncreases(t *testing.T) {
+	s := ResettingSample(&testSample{})
+
+	s.Update(10)
+	s.Update(20)
+	s.Update(30)
+	snap1 := s.Snapshot()
+
+	if snap1.Count() != 3 {
+		t.Errorf("snap1.Count(): got %d, want 3", snap1.Count())
+	}
+
+	s.Update(40)
+	s.Update(50)
+	snap2 := s.Snapshot()
+
+	if snap2.Count() != 5 {
+		t.Errorf("snap2.Count(): got %d, want 5 (cumulative)", snap2.Count())
+	}
+
+	if snap2.Count() < snap1.Count() {
+		t.Errorf("count must not decrease: %d -> %d", snap1.Count(), snap2.Count())
+	}
+}
+
+func TestResettingSampleMeanIsPerInterval(t *testing.T) {
+	s := ResettingSample(&testSample{})
+
+	// First interval: mean should be (10+20+30)/3 = 20
+	s.Update(10)
+	s.Update(20)
+	s.Update(30)
+	snap1 := s.Snapshot()
+
+	if snap1.Mean() != 20.0 {
+		t.Errorf("snap1.Mean(): got %.2f, want 20.00", snap1.Mean())
+	}
+
+	// Second interval: mean should be (40+50)/2 = 45, not polluted by cumulative sum
+	s.Update(40)
+	s.Update(50)
+	snap2 := s.Snapshot()
+
+	if snap2.Mean() != 45.0 {
+		t.Errorf("snap2.Mean(): got %.2f, want 45.00", snap2.Mean())
+	}
+}
+
+func TestResettingSampleValuesResetPerInterval(t *testing.T) {
+	s := ResettingSample(&testSample{})
+
+	s.Update(10)
+	s.Update(20)
+	s.Snapshot()
+
+	s.Update(30)
+	snap := s.Snapshot()
+
+	values := snap.Values()
+	if len(values) != 1 || values[0] != 30 {
+		t.Errorf("values should be [30] from current interval, got %v", values)
+	}
+}
+
+func TestResettingSampleEmptyInterval(t *testing.T) {
+	s := ResettingSample(&testSample{})
+
+	s.Update(10)
+	snap1 := s.Snapshot()
+
+	// Empty interval — no updates
+	snap2 := s.Snapshot()
+
+	if snap2.Count() != snap1.Count() {
+		t.Errorf("count should stay %d on empty interval, got %d", snap1.Count(), snap2.Count())
+	}
+
+	if len(snap2.Values()) != 0 {
+		t.Errorf("values should be empty on empty interval, got %v", snap2.Values())
+	}
+
+	if snap2.Sum() != 0 {
+		t.Errorf("sum should be 0 on empty interval, got %d", snap2.Sum())
+	}
+
+	if snap2.Mean() != 0 {
+		t.Errorf("mean should be 0 on empty interval, got %.2f", snap2.Mean())
+	}
+}


### PR DESCRIPTION
# Description

  `ResettingSample.Snapshot()` calls `Clear()` which resets count and sum to 0 on every Prometheus scrape. This causes `_count` metrics (declared as Prometheus `counter` type) to decrease, violating counter monotonicity and breaking `rate()`, `increase()`, and average latency calculations.

  Fixed by maintaining cumulative count and sum in `resettingSample`, while keeping the resetting behavior for sample values used in percentile calculations.

fixes #2173 

  # Changes

  - [x] Bugfix (non-breaking change that solves an issue)
  - [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
  - [ ] Changes only for a subset of nodes

  # Breaking changes

  N/A

  # Nodes audience

  N/A

  # Checklist

  - [ ] I have added at least 2 reviewer or the whole pos-v1 team
  - [x] I have added sufficient documentation in code
  - [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
  - [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
  - [ ] Includes RPC methods changes, and the Notion documentation has been updated

  # Cross repository changes

  - [ ] This PR requires changes to heimdall
  - [ ] This PR requires changes to matic-cli

  ## Testing

  - [x] I have added unit tests
  - [ ] I have tested this code manually on local environment
  - [ ] I have added tests to CI
  - [ ] I have tested this code manually on remote devnet using express-cli
  - [ ] I have tested this code manually on amoy
  - [ ] I have created new e2e tests into express-cli

  # Additional comments

  Affected metrics: all histograms using `ResettingSample`, including `rpc_duration_*` (RPC latency), P2P tracking, and protocol handler metrics.
