### PR TITLE
consensus/bor: guard nil sprint header in CommitStates

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1744,7 +1744,18 @@ func (c *Bor) CommitStates(
 			return nil, err
 		}
 
-		to = time.Unix(int64(chain.Chain.GetHeaderByNumber(number-c.config.CalculateSprint(number)).Time), 0)
+		sprintLength := c.config.CalculateSprint(number)
+		if number < sprintLength {
+			return nil, fmt.Errorf("invalid sprint start block for block %d with sprint length %d", number, sprintLength)
+		}
+
+		sprintStartNumber := number - sprintLength
+		sprintStartHeader := chain.Chain.GetHeaderByNumber(sprintStartNumber)
+		if sprintStartHeader == nil {
+			return nil, fmt.Errorf("failed to fetch sprint start header %d for block %d", sprintStartNumber, number)
+		}
+
+		to = time.Unix(int64(sprintStartHeader.Time), 0)
 	}
 
 	lastStateID := lastStateIDBig.Uint64()


### PR DESCRIPTION
# Description

In the pre-Indore path of `CommitStates`, the state-sync upper timestamp was derived from the sprint-start header time. The previous code dereferenced `GetHeaderByNumber(...).Time` directly, without checking whether the header existed.

Under ancient pruning conditions, that sprint-start header may be unavailable. In that case, the old flow could hit a nil dereference and panic on the consensus finalization path.

This update adds only the required safety checks:

1. compute `sprintLength` once;
2. guard `number < sprintLength` and return a clear error to avoid underflow;
3. load the sprint-start header, validate it is non-nil, and return an explicit error when missing before reading `Time`.

Behavior is unchanged when data is present; only crash-prone branches now fail with explicit errors instead of panicking.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

N/A

# Nodes audience

No node-segmented rollout is required.

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
- In case link the PR here:
- [ ] This PR requires changes to matic-cli
- In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

1. `gofmt -w consensus/bor/bor.go`
2. `go test ./consensus/bor -run TestCommitStates -count=1`
3. `go vet ./consensus/bor`
4. `go test ./consensus/bor/... -count=1`
5. `make lint`

# Additional comments
