### PR TITLE
consensus/bor, miner: fix stale pending state for non-validator nodes

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1104,7 +1104,10 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, w
 	if currentSigner.signer != (common.Address{}) {
 		succession, err = snap.GetSignerSuccessionNumber(currentSigner.signer)
 		if err != nil {
-			return err
+			// If the signer is not in the active validator set, use succession 0
+			// so that the pending block header is still valid for RPC queries.
+			// Seal() will independently reject the block if unauthorized.
+			succession = 0
 		}
 	}
 
@@ -1154,15 +1157,9 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, w
 
 	// Wait before start the block production if needed (previously this wait was on Seal)
 	if c.config.IsGiugliano(header.Number) && waitOnPrepare {
-		var successionNumber int
 		// if signer is not empty (RPC nodes have empty signer)
 		if currentSigner.signer != (common.Address{}) {
-			var err error
-			successionNumber, err = snap.GetSignerSuccessionNumber(currentSigner.signer)
-			if err != nil {
-				return err
-			}
-			if successionNumber == 0 {
+			if succession == 0 {
 				<-time.After(delay)
 			}
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1221,7 +1221,6 @@ func (w *worker) updateSnapshot(env *environment) {
 	w.snapshotMu.Lock()
 	defer w.snapshotMu.Unlock()
 
-
 	w.snapshotBlock = types.NewBlock(
 		env.header,
 		&types.Body{

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -973,7 +973,12 @@ func (w *worker) taskLoop() {
 			w.pendingMu.Unlock()
 
 			if err := w.engine.Seal(w.chain, task.block, task.state.Witness(), w.resultCh, stopCh); err != nil {
-				log.Warn("Block sealing failed", "err", err)
+				switch err.(type) {
+				case *bor.UnauthorizedSignerError:
+					log.Debug("Block sealing skipped (not in validator set)", "err", err)
+				default:
+					log.Warn("Block sealing failed", "err", err)
+				}
 				w.pendingMu.Lock()
 				delete(w.pendingTasks, sealHash)
 				w.pendingMu.Unlock()
@@ -1215,6 +1220,7 @@ func (w *worker) makeEnv(header *types.Header, coinbase common.Address, witness 
 func (w *worker) updateSnapshot(env *environment) {
 	w.snapshotMu.Lock()
 	defer w.snapshotMu.Unlock()
+
 
 	w.snapshotBlock = types.NewBlock(
 		env.header,

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -59,6 +59,57 @@ import (
 	borSpan "github.com/ethereum/go-ethereum/consensus/bor/heimdall/span"
 )
 
+// TestPendingStateNotStaleForNonValidator verifies that a Bor node whose signer
+// is NOT in the active validator set still keeps its pending snapshot fresh.
+// Regression test: previously, Prepare() returned UnauthorizedSignerError for
+// non-validators, which caused prepareWork to fail and the snapshot to never
+// update, leading to stale trie errors on "pending" RPC queries.
+func TestPendingStateNotStaleForNonValidator(t *testing.T) {
+	chainConfig := *params.BorUnittestChainConfig
+
+	engine, ctrl := getFakeBorFromConfig(t, &chainConfig)
+	defer engine.Close()
+	defer ctrl.Finish()
+
+	// Set up the worker normally, then re-authorize with a key NOT in the
+	// validator set. newTestWorkerBackend authorizes with testBankAddress
+	// (which IS the validator), so we must override AFTER backend creation.
+	nonValidatorKey, _ := crypto.GenerateKey()
+	nonValidatorAddr := crypto.PubkeyToAddress(nonValidatorKey.PublicKey)
+
+	db := rawdb.NewMemoryDatabase()
+	backend := newTestWorkerBackend(t, &chainConfig, engine, db)
+	w := newWorker(DefaultTestConfig(), &chainConfig, engine, backend, new(event.TypeMux), nil, false, false)
+	defer w.close()
+
+	// Override the signer to one NOT in the validator set.
+	engine.(*bor.Bor).Authorize(nonValidatorAddr, func(account accounts.Account, s string, data []byte) ([]byte, error) {
+		return crypto.Sign(crypto.Keccak256(data), nonValidatorKey)
+	})
+	w.setEtherbase(nonValidatorAddr)
+
+	// Start the worker. It will call commitWork which calls Prepare.
+	// Before the fix: Prepare fails with UnauthorizedSignerError, snapshot
+	// is never set, pending() returns nil.
+	// After the fix: Prepare succeeds (defaults succession to 0), snapshot
+	// is updated, pending() returns valid state.
+	w.start()
+
+	// Give the worker time to process the start event and run commitWork.
+	time.Sleep(1 * time.Second)
+
+	pendingBlock, _, pendingState := w.pending()
+	require.NotNil(t, pendingBlock, "pending block should not be nil for non-validator node")
+	require.NotNil(t, pendingState, "pending state should not be nil for non-validator node")
+
+	// The pending state must be readable without errors (not a stale trie).
+	balance := pendingState.GetBalance(testBankAddress)
+	require.False(t, balance.IsZero(),
+		"pending state balance for funded account should not be zero (would indicate stale trie)")
+	require.NoError(t, pendingState.Error(),
+		"pending state should have no database errors")
+}
+
 // nolint : paralleltest
 func TestGenerateBlockAndImportClique(t *testing.T) {
 	testGenerateBlockAndImport(t, true, false)


### PR DESCRIPTION
# Description

Nodes whose signer is configured but not in the active validator set (e.g. after a validator rotation) returned "insufficient funds for transfer" on eth_estimateGas and other RPC calls against the "pending" block. The root cause was that Prepare() returned UnauthorizedSignerError when the signer was not in the validator set, which caused prepareWork() to fail on every block. Since commit() was never called, the pending snapshot was never refreshed, and its underlying pathdb trie layers were eventually garbage-collected — making all state reads return zero.

Fix Prepare() to not fail for unauthorized signers. Instead, default the succession number to 0 and let the block building pipeline continue normally. Seal() already independently rejects blocks from unauthorized signers, so no invalid blocks can be produced. This ensures the pending snapshot is refreshed on every chain head, keeping RPC queries functional regardless of whether the node is actively producing blocks.

Also remove a redundant second call to GetSignerSuccessionNumber in the Giugliano waitOnPrepare block, reusing the succession value already computed earlier in Prepare().


# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
