### PR TITLE
eth/fetcher: refactor witness_manager to reduce complexity

### DIFF
--- a/.github/workflows/diffguard.yml
+++ b/.github/workflows/diffguard.yml
@@ -1,0 +1,81 @@
+name: diffguard
+
+on:
+  pull_request:
+    branches:
+      - '**'
+    types: [opened, synchronize]
+
+concurrency:
+  group: diffguard-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  diffguard:
+    name: Quality metrics
+    if: (github.event.action != 'closed' || github.event.pull_request.merged == true)
+    # Mutation testing is CPU-heavy (one `go test` invocation per mutant,
+    # parallelized across cores). The 16-core runner matches the one used
+    # by govulncheck and keeps PR turnaround under ~10 min on typical diffs.
+    runs-on: ubuntu24.04-16core-64GB-600SSD-bor
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # diffguard needs the base branch history for `git diff` and
+          # `git log --follow`, so fetch the full history (shallow clones
+          # break merge-base resolution).
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-diffguard-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-diffguard-
+
+      - name: Install diffguard
+        run: go install github.com/0xPolygon/diffguard/cmd/diffguard@latest
+
+      - name: Run diffguard
+        id: diffguard
+        # Sample 10% of generated mutants — statistically representative
+        # for tier scores while keeping CI cost bounded. Each mutant runs
+        # the full test suite of its package, hence the 5m test-timeout
+        # (eth/fetcher alone takes ~2.3m).
+        #
+        # Gating: --fail-on warn + default tier thresholds means the job
+        # FAILs when Tier-1 (logic) score drops below 90% and WARNs on
+        # Tier-2 below 70%. Tier-3 (observability) is report-only.
+        run: |
+          diffguard \
+            --base origin/${{ github.base_ref }} \
+            --mutation-sample-rate 10 \
+            --test-timeout 5m \
+            --output text \
+            --fail-on warn \
+            . | tee $GITHUB_STEP_SUMMARY
+
+      - name: Upload JSON report
+        # Run even on failure so the survivor list is available for
+        # triage. Skip mutation here to keep the second run cheap — the
+        # text report above already contains the full mutation results.
+        if: always()
+        run: |
+          diffguard \
+            --base origin/${{ github.base_ref }} \
+            --skip-mutation \
+            --output json \
+            --fail-on none \
+            . > diffguard-report.json
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: diffguard-report
+          path: diffguard-report.json
+          retention-days: 14

--- a/eth/fetcher/witness_manager.go
+++ b/eth/fetcher/witness_manager.go
@@ -134,15 +134,19 @@ func newWitnessManager(
 		witnessTimer:        time.NewTimer(0),
 		pokeCh:              make(chan struct{}, 1),
 	}
-	// Clear the timer channel initially
+	m.stopAndDrainTimer()
+	return m
+}
+
+// stopAndDrainTimer stops the witness timer and drains its channel if it
+// already fired. Safe to call whether or not the timer is active.
+func (m *witnessManager) stopAndDrainTimer() {
 	if !m.witnessTimer.Stop() {
-		// Non-blocking read in case the timer fired
 		select {
 		case <-m.witnessTimer.C:
 		default:
 		}
 	}
-	return m
 }
 
 // start begins the witness manager's internal loop in a new goroutine.
@@ -167,39 +171,14 @@ func (m *witnessManager) loop() {
 	lastTick := time.Now()
 
 	for {
-		var timerChan <-chan time.Time
-
-		// Check pending count under mutex protection
-		m.mu.Lock()
-		pendingCount := len(m.pending)
-		m.mu.Unlock()
-
-		if pendingCount > 0 {
-			// Only listen to timer if there are pending items
-			timerChan = m.witnessTimer.C
-			// If too long since last tick, reset the timer to ensure we don't get stuck
-			if time.Since(lastTick) > 10*time.Second {
-				log.Debug("[wm] Long time since last tick, forcing timer reset", "sinceLastTick", time.Since(lastTick))
-				m.rescheduleWitness()
-				lastTick = time.Now()
-			}
-		} else {
-			// Ensure timer is stopped if nothing is pending
-			if !m.witnessTimer.Stop() {
-				select {
-				case <-m.witnessTimer.C:
-				default:
-				}
-			}
-		}
+		timerChan, updatedLastTick := m.armTimerChan(lastTick)
+		lastTick = updatedLastTick
 
 		select {
-		// Handle signals from parent BlockFetcher
 		case <-m.parentQuit:
 			log.Info("Witness manager stopping")
 			return
 
-		// Handle injected blocks needing witness
 		case msg, ok := <-m.injectNeedWitnessCh:
 			if !ok {
 				log.Debug("Witness manager injectNeedWitnessCh closed unexpectedly")
@@ -209,7 +188,6 @@ func (m *witnessManager) loop() {
 			log.Debug("[wm] Received injectNeedWitnessCh message", "hash", msg.block.Hash())
 			m.handleNeed(msg)
 
-		// Handle injected witnesses from broadcast
 		case msg, ok := <-m.injectWitnessCh:
 			if !ok {
 				log.Debug("Witness manager injectWitnessCh closed unexpectedly")
@@ -219,17 +197,11 @@ func (m *witnessManager) loop() {
 			log.Debug("[wm] Received injectWitnessCh message", "hash", msg.witness.Header().Hash())
 			m.handleBroadcast(msg)
 
-		// Handle witness timer triggers
-		case <-timerChan: // Listen on the conditional channel
+		case <-timerChan:
 			lastTick = time.Now()
-			// Check pending count under mutex protection
-			m.mu.Lock()
-			pendingCount := len(m.pending)
-			m.mu.Unlock()
-			log.Debug("[wm] Witness timer triggered", "time", lastTick, "pendingCount", pendingCount)
+			m.logTimerTick(lastTick)
 			m.tick()
 
-		// Handle periodic cleanup of the unavailable witness cache
 		case <-cleanupTicker.C:
 			log.Debug("[wm] Cleanup ticker triggered")
 			m.cleanupUnavailableCache()
@@ -242,6 +214,38 @@ func (m *witnessManager) loop() {
 			continue
 		}
 	}
+}
+
+// armTimerChan prepares the timer channel for the next select iteration.
+// Returns nil channel (never fires) when nothing is pending. Forces a timer
+// reset if too long has passed since the last tick to recover from stuck
+// timers, updating lastTick when it does so.
+func (m *witnessManager) armTimerChan(lastTick time.Time) (<-chan time.Time, time.Time) {
+	m.mu.Lock()
+	pendingCount := len(m.pending)
+	m.mu.Unlock()
+
+	if pendingCount != 0 {
+		// Drain the timer so a stale fire doesn't wake us up.
+		m.stopAndDrainTimer()
+		return nil, lastTick
+	}
+
+	// If too long since last tick, reset the timer to ensure we don't get stuck.
+	if time.Since(lastTick) > 10*time.Second {
+		log.Debug("[wm] Long time since last tick, forcing timer reset", "sinceLastTick", time.Since(lastTick))
+		m.rescheduleWitness()
+		lastTick = time.Now()
+	}
+	return m.witnessTimer.C, lastTick
+}
+
+// logTimerTick emits a debug log with the current pending count.
+func (m *witnessManager) logTimerTick(t time.Time) {
+	m.mu.Lock()
+	pendingCount := len(m.pending)
+	m.mu.Unlock()
+	log.Debug("[wm] Witness timer triggered", "time", t, "pendingCount", pendingCount)
 }
 
 // handleNeed processes a block injected via InjectBlockWithWitnessRequirement.
@@ -274,7 +278,7 @@ func (m *witnessManager) handleNeed(msg *injectBlockNeedWitnessMsg) {
 	}
 
 	// Check distance (using parent's function)
-	if dist := int64(number) - int64(m.parentChainHeight()); dist < -maxUncleDist {
+	if dist := int64(number) - int64(m.parentChainHeight()); dist <= -maxUncleDist {
 		m.mu.Unlock()
 		log.Debug("[wm] Discarded injected block, too far away", "peer", msg.origin, "number", number, "hash", hash, "distance", dist)
 		return // Doesn't count towards DOS limits as it's injected, just drop.
@@ -372,133 +376,163 @@ func (m *witnessManager) handleBroadcast(msg *injectedWitnessMsg) {
 // tick is called when the witnessTimer fires, triggering witness fetches.
 func (m *witnessManager) tick() {
 	log.Debug("[wm] Witness timer tick", "pending", len(m.pending))
-	// Map from peer ID -> map of block hash -> announce struct
-	requests := make(map[string]map[common.Hash]*blockAnnounce)
-
 	now := time.Now()
-	readyToFetch := []common.Hash{}
 
 	m.mu.Lock()
+	m.logPendingStatesAtTickLocked(now)
+	readyToFetch, toMarkUnavailable := m.collectReadyHashesLocked(now)
+	prematureOps := m.extractPrematureOpsLocked(readyToFetch)
+	m.mu.Unlock()
 
-	// Debug: Log current pending items at tick time
-	if len(m.pending) > 0 {
-		pendingStates := make([]string, 0, len(m.pending))
-		for h, state := range m.pending {
-			readyStr := "not-ready"
-			if state.announce != nil && now.After(state.announce.time) {
-				readyStr = "ready"
-			}
-
-			statusStr := "no-witness"
-			if state.op != nil && state.op.witness != nil {
-				statusStr = "has-witness"
-			}
-
-			pendingStates = append(pendingStates,
-				fmt.Sprintf("%s:%s:%s:%d", h.Hex()[:8], readyStr, statusStr, state.retries))
-		}
-		log.Debug("[wm] Pending states at tick", "states", pendingStates)
+	// Mark exhausted retries as unavailable (acquires lock internally, reschedules timer).
+	for _, hash := range toMarkUnavailable {
+		m.markWitnessUnavailable(hash)
 	}
 
-	// Identify pending requests that are ready to be fetched
+	// Enqueue any pending entries that already have a witness attached (e.g. arrived via broadcast).
+	for _, op := range prematureOps {
+		log.Debug("[wm] Enqueueing pending block with already attached witness", "hash", op.hash())
+		m.safeEnqueue(op)
+	}
+
+	m.mu.Lock()
+	requests := m.buildPeerRequestsLocked(readyToFetch, now)
+	m.mu.Unlock()
+
+	m.dispatchPeerRequests(requests)
+
+	// Schedule the next fetch if blocks are still pending
+	m.rescheduleWitness()
+}
+
+// logPendingStatesAtTickLocked emits a debug trace of the current pending
+// witness requests. Caller must hold m.mu.
+func (m *witnessManager) logPendingStatesAtTickLocked(now time.Time) {
+	if len(m.pending) == 0 {
+		return
+	}
+	pendingStates := make([]string, 0, len(m.pending))
+	for h, state := range m.pending {
+		readyStr := "not-ready"
+		if state.announce != nil && now.After(state.announce.time) {
+			readyStr = "ready"
+		}
+		statusStr := "no-witness"
+		if state.op != nil && state.op.witness != nil {
+			statusStr = "has-witness"
+		}
+		pendingStates = append(pendingStates,
+			fmt.Sprintf("%s:%s:%s:%d", h.Hex()[:8], readyStr, statusStr, state.retries))
+	}
+	log.Debug("[wm] Pending states at tick", "states", pendingStates)
+}
+
+// collectReadyHashesLocked walks the pending map and partitions entries into
+// hashes that are ready to fetch and hashes that have exhausted their retry
+// budget and should be marked unavailable. Caller must hold m.mu.
+//
+// Invalid entries (missing op or announce) are cleaned up in place.
+func (m *witnessManager) collectReadyHashesLocked(now time.Time) (readyToFetch, toMarkUnavailable []common.Hash) {
 	for hash, state := range m.pending {
 		// Must have an op and announce to be fetchable
 		if state.op == nil || state.announce == nil {
 			log.Debug("[wm] Invalid pending state found", "hash", hash)
-			delete(m.pending, hash) // Clean up invalid state
+			delete(m.pending, hash)
 			continue
 		}
 
 		// Witness already present? Should have been enqueued.
 		if state.op.witness != nil {
 			log.Debug("[wm] Pending state found with witness already present", "hash", hash)
-			// we will enqueue outside of lock to avoid deadlock
-			readyToFetch = append(readyToFetch, hash) // mark for enqueue path
+			readyToFetch = append(readyToFetch, hash)
 			continue
 		}
 
-		// Check if ready (announce time is in the past)
-		if now.After(state.announce.time) {
-			// Give up if we've retried too many times
-			if state.retries >= maxWitnessFetchRetries {
-				log.Debug("[wm] Max witness retries reached, marking unavailable", "hash", hash, "retries", state.retries)
-				toMark := hash // avoid referencing loop var later
-				m.mu.Unlock()
-				m.markWitnessUnavailable(toMark)
-				m.mu.Lock()
-				continue
-			}
-			// Increment retry counter and schedule fetch
-			state.retries++
-			log.Debug("[wm] Scheduling witness fetch", "hash", hash, "retry", state.retries)
-			readyToFetch = append(readyToFetch, hash)
+		// Not ready yet (announce time still in the future).
+		if !now.After(state.announce.time) {
+			continue
 		}
-	}
 
-	// We may need to enqueue those that already had witness present
-	prematureStates := []*blockOrHeaderInject{}
+		// Give up if we've retried too many times.
+		if state.retries >= maxWitnessFetchRetries {
+			log.Debug("[wm] Max witness retries reached, marking unavailable", "hash", hash, "retries", state.retries)
+			toMarkUnavailable = append(toMarkUnavailable, hash)
+			continue
+		}
+
+		// Increment retry counter and schedule fetch.
+		state.retries++
+		log.Debug("[wm] Scheduling witness fetch", "hash", hash, "retry", state.retries)
+		readyToFetch = append(readyToFetch, hash)
+	}
+	return readyToFetch, toMarkUnavailable
+}
+
+// extractPrematureOpsLocked returns the ops for entries that already have
+// their witness attached, so they can be enqueued immediately. Caller must
+// hold m.mu.
+func (m *witnessManager) extractPrematureOpsLocked(readyToFetch []common.Hash) []*blockOrHeaderInject {
+	var ops []*blockOrHeaderInject
 	for _, h := range readyToFetch {
 		if st := m.pending[h]; st != nil && st.op != nil && st.op.witness != nil {
-			prematureStates = append(prematureStates, st.op)
+			ops = append(ops, st.op)
 		}
 	}
-	m.mu.Unlock()
+	return ops
+}
 
-	// Enqueue outside lock using captured states
-	for _, op := range prematureStates {
-		log.Debug("[wm] Enqueueing pending block with already attached witness", "hash", op.hash())
-		m.safeEnqueue(op)
-	}
-
-	// Prepare requests per peer
-	m.mu.Lock()
+// buildPeerRequestsLocked groups ready hashes by peer and updates announce
+// timestamps to enforce per-request backoff. Caller must hold m.mu.
+func (m *witnessManager) buildPeerRequestsLocked(readyToFetch []common.Hash, now time.Time) map[string]map[common.Hash]*blockAnnounce {
+	requests := make(map[string]map[common.Hash]*blockAnnounce)
 	for _, hash := range readyToFetch {
 		state := m.pending[hash]
-		if state == nil || state.announce == nil { // Check again, might have been removed
+		if state == nil || state.announce == nil {
 			continue
 		}
 		announce := state.announce
 
-		// Add to request map
 		if _, ok := requests[announce.origin]; !ok {
 			requests[announce.origin] = make(map[common.Hash]*blockAnnounce)
 		}
 		requests[announce.origin][hash] = announce
 
-		// Update announce time for backoff - prevent immediate retry
-		// This effectively marks the request as "in-flight"
+		// Update announce time for backoff — prevents immediate retry and
+		// effectively marks the request as "in-flight".
 		announce.time = now.Add(fetchTimeout)
-		// state.announce = announce // announce is a pointer, modification is reflected
 	}
-	m.mu.Unlock()
+	return requests
+}
 
-	// Send out all block witness requests
+// dispatchPeerRequests spawns a fetch goroutine per (peer, hash) pair.
+// Must be called without holding m.mu.
+func (m *witnessManager) dispatchPeerRequests(requests map[string]map[common.Hash]*blockAnnounce) {
 	for peer, hashAnnounceMap := range requests {
-		// Collect hashes for logging
-		hashesToFetch := make([]common.Hash, 0, len(hashAnnounceMap))
-		for hash := range hashAnnounceMap {
-			hashesToFetch = append(hashesToFetch, hash)
-		}
-		if len(hashesToFetch) == 0 {
+		m.dispatchPeerFetches(peer, hashAnnounceMap)
+	}
+}
+
+// dispatchPeerFetches launches fetch goroutines for a single peer's hashes,
+// handling invalid announcements as hard failures.
+func (m *witnessManager) dispatchPeerFetches(peer string, hashAnnounceMap map[common.Hash]*blockAnnounce) {
+	if len(hashAnnounceMap) == 0 {
+		return
+	}
+
+	// Collect hashes for logging only.
+	hashesToFetch := make([]common.Hash, 0, len(hashAnnounceMap))
+	for hash := range hashAnnounceMap {
+		hashesToFetch = append(hashesToFetch, hash)
+	}
+	log.Debug("[wm] Fetching scheduled witnesses", "peer", peer, "list", hashesToFetch)
+
+	for hash, announce := range hashAnnounceMap {
+		if announce == nil || announce.fetchWitness == nil {
+			m.handleWitnessFetchFailureExt(hash, "", errors.New("missing fetch configuration"), true)
 			continue
 		}
-		log.Debug("[wm] Fetching scheduled witnesses", "peer", peer, "list", hashesToFetch)
-
-		// Process each hash for the peer individually
-		for hash, announce := range hashAnnounceMap {
-			// Ensure we have a valid announce and fetchWitness function
-			if announce == nil || announce.fetchWitness == nil {
-				m.handleWitnessFetchFailureExt(hash, "", errors.New("missing fetch configuration"), true)
-				continue
-			}
-
-			// Launch goroutine for fetch
-			go m.fetchWitness(peer, hash, announce)
-		}
+		go m.fetchWitness(peer, hash, announce)
 	}
-
-	// Schedule the next fetch if blocks are still pending
-	m.rescheduleWitness()
 }
 
 // fetchWitness performs a single witness fetch in a goroutine.
@@ -511,81 +545,96 @@ func (m *witnessManager) fetchWitness(peer string, hash common.Hash, announce *b
 
 	witnessFetchMeter.Mark(1)
 
-	req, err := announce.fetchWitness(hash, resCh)
-	if req != nil {
-		peer = req.Peer
-	} else {
-		peer = ""
-	}
-	if err != nil {
-		log.Debug("[wm] Failed to initiate witness fetch request", "peer", peer, "hash", hash, "err", err)
-		// Check if the error specifically indicates no peers were available
-		if strings.Contains(err.Error(), "no peer with witness for hash") {
-			m.handleWitnessFetchFailureExt(hash, "", fmt.Errorf("request initiation failed: %w", err), false)
-			return
-		}
-
-		// For other errors, check if still pending before handling failure
-		m.mu.Lock()
-		if _, exists := m.pending[hash]; !exists {
-			m.mu.Unlock()
-			log.Debug("[wm] Skipping witness fetch failure handling, block no longer pending", "peer", peer, "hash", hash)
-			return
-		}
-		m.mu.Unlock()
-		m.handleWitnessFetchFailureExt(hash, peer, fmt.Errorf("request initiation failed: %w", err), false)
+	req, effectivePeer, ok := m.initiateWitnessFetch(hash, announce, resCh)
+	if !ok {
 		return
 	}
+	defer req.Close()
 
-	// Check if still pending after successful request creation
-	m.mu.Lock()
-	if _, exists := m.pending[hash]; !exists {
-		m.mu.Unlock()
+	m.awaitWitnessResponse(effectivePeer, hash, resCh, announcedAt)
+}
+
+// initiateWitnessFetch requests a witness from a peer and checks that the
+// block is still pending afterwards. Returns the created request on success,
+// or ok=false after handling the failure.
+func (m *witnessManager) initiateWitnessFetch(hash common.Hash, announce *blockAnnounce, resCh chan *eth.Response) (*eth.Request, string, bool) {
+	req, err := announce.fetchWitness(hash, resCh)
+	peer := ""
+	if req != nil {
+		peer = req.Peer
+	}
+
+	if err != nil {
+		log.Debug("[wm] Failed to initiate witness fetch request", "peer", peer, "hash", hash, "err", err)
+		wrappedErr := fmt.Errorf("request initiation failed: %w", err)
+
+		// "No peer with witness" is a soft failure with no peer to penalize.
+		if strings.Contains(err.Error(), "no peer with witness for hash") {
+			m.handleWitnessFetchFailureExt(hash, "", wrappedErr, false)
+			return nil, "", false
+		}
+
+		// For other errors, check if still pending before handling failure.
+		if !m.isPending(hash) {
+			log.Debug("[wm] Skipping witness fetch failure handling, block no longer pending", "peer", peer, "hash", hash)
+			return nil, "", false
+		}
+		m.handleWitnessFetchFailureExt(hash, peer, wrappedErr, false)
+		return nil, "", false
+	}
+
+	// Successful request creation — verify the block is still pending.
+	if !m.isPending(hash) {
 		log.Debug("[wm] Skipping witness fetch, block no longer pending", "peer", peer, "hash", hash)
 		m.handleWitnessFetchFailureExt(hash, "", fmt.Errorf("request initiation failed: %w", err), false)
 		req.Close()
-		return
+		return nil, "", false
 	}
-	m.mu.Unlock()
-	defer req.Close()
+	return req, peer, true
+}
 
+// awaitWitnessResponse waits for the fetch response, delegating to success
+// or failure handlers depending on the outcome.
+func (m *witnessManager) awaitWitnessResponse(peer string, hash common.Hash, resCh chan *eth.Response, announcedAt time.Time) {
 	timeout := time.NewTimer(2 * fetchTimeout) // 2x leeway before dropping the peer
 	defer timeout.Stop()
 
 	select {
 	case res := <-resCh:
-		if res == nil {
-			log.Debug("[wm] Witness response channel closed unexpectedly", "peer", peer, "hash", hash)
-			m.handleWitnessFetchFailureExt(hash, peer, errors.New("response channel closed"), false)
-			return
-		}
-		res.Done <- nil // Signal consumption
-
-		// Assuming NewWitnessPacket contains only one witness.
-		witness, ok := res.Res.([]*stateless.Witness)
-		if !ok {
-			log.Debug("[wm] Invalid witness response type received", "peer", peer, "hash", hash, "type", fmt.Sprintf("%T", res.Res))
-			m.handleWitnessFetchFailureExt(hash, peer, errors.New("invalid response type"), false)
-			return
-		}
-
-		if len(witness) == 0 {
-			log.Debug("[wm] Received empty witness response from peer", "peer", peer, "hash", hash)
-			m.handleWitnessFetchFailureExt(hash, peer, errors.New("empty witness response"), false)
-			return
-		}
-
-		metrics.RecordPerItemDuration(blockWitnessItemDownloadTimer, res.Time, 1)
-
-		// Process successful fetch
-		m.handleWitnessFetchSuccess(peer, hash, witness[0], announcedAt)
-
+		m.processWitnessResponse(peer, hash, res, announcedAt)
 	case <-timeout.C:
 		log.Info("[wm] Witness fetch timed out for peer", "peer", peer, "hash", hash)
 		m.handleWitnessFetchFailureExt(hash, peer, errors.New("fetch timeout"), false)
 	case <-m.parentQuit:
 		log.Debug("[wm] Witness fetch cancelled due to shutdown", "peer", peer, "hash", hash)
 	}
+}
+
+// processWitnessResponse validates the witness payload and dispatches to the
+// success handler if it passes checks.
+func (m *witnessManager) processWitnessResponse(peer string, hash common.Hash, res *eth.Response, announcedAt time.Time) {
+	if res == nil {
+		log.Debug("[wm] Witness response channel closed unexpectedly", "peer", peer, "hash", hash)
+		m.handleWitnessFetchFailureExt(hash, peer, errors.New("response channel closed"), false)
+		return
+	}
+	res.Done <- nil // Signal consumption
+
+	// Assuming NewWitnessPacket contains only one witness.
+	witness, ok := res.Res.([]*stateless.Witness)
+	if !ok {
+		log.Debug("[wm] Invalid witness response type received", "peer", peer, "hash", hash, "type", fmt.Sprintf("%T", res.Res))
+		m.handleWitnessFetchFailureExt(hash, peer, errors.New("invalid response type"), false)
+		return
+	}
+	if len(witness) == 0 {
+		log.Debug("[wm] Received empty witness response from peer", "peer", peer, "hash", hash)
+		m.handleWitnessFetchFailureExt(hash, peer, errors.New("empty witness response"), false)
+		return
+	}
+
+	metrics.RecordPerItemDuration(blockWitnessItemDownloadTimer, res.Time, 1)
+	m.handleWitnessFetchSuccess(peer, hash, witness[0], announcedAt)
 }
 
 // handleWitnessFetchSuccess processes a successfully fetched witness.
@@ -627,24 +676,8 @@ func (m *witnessManager) handleWitnessFetchSuccess(fetchPeer string, hash common
 // rescheduleWitness resets the internal timer to the next required wake-up time.
 func (m *witnessManager) rescheduleWitness() {
 	m.mu.Lock()
-	// Stop any existing timer safely under lock
-	if !m.witnessTimer.Stop() {
-		select {
-		case <-m.witnessTimer.C:
-		default:
-		}
-	}
-	// Find the earliest time we need to wake up
-	var earliest time.Time
-	pendingFetches := 0
-	for _, state := range m.pending {
-		if state.announce != nil && state.op != nil && state.op.witness == nil {
-			pendingFetches++
-			if earliest.IsZero() || state.announce.time.Before(earliest) {
-				earliest = state.announce.time
-			}
-		}
-	}
+	m.stopAndDrainTimer()
+	earliest := m.earliestPendingAnnounceLocked()
 	m.mu.Unlock()
 
 	if earliest.IsZero() {
@@ -652,18 +685,34 @@ func (m *witnessManager) rescheduleWitness() {
 		return
 	}
 
+	// Clamp to a small positive value so we don't spin on already-due fetches.
 	delay := time.Until(earliest.Add(gatherSlack))
-	// If delay is negative or zero, set it to a small positive value to trigger soon
 	if delay <= 0 {
-		delay = 10 * time.Millisecond // Small delay to avoid CPU spinning
+		delay = 10 * time.Millisecond
 	}
 	m.witnessTimer.Reset(delay)
 
-	// Nudge the main loop to wake up
+	// Nudge the main loop to re-evaluate the select with the new timer.
 	select {
 	case m.pokeCh <- struct{}{}:
 	default:
 	}
+}
+
+// earliestPendingAnnounceLocked returns the earliest announce time among
+// pending entries that still need a witness fetched. Returns zero time if
+// no such entries exist. Caller must hold m.mu.
+func (m *witnessManager) earliestPendingAnnounceLocked() time.Time {
+	var earliest time.Time
+	for _, state := range m.pending {
+		if state.announce == nil || state.op == nil || state.op.witness != nil {
+			continue
+		}
+		if earliest.IsZero() || state.announce.time.Before(earliest) {
+			earliest = state.announce.time
+		}
+	}
+	return earliest
 }
 
 // handleWitnessFetchFailureExt handles a witness fetch failure with an option
@@ -770,6 +819,7 @@ func (m *witnessManager) markWitnessUnavailable(hash common.Hash) {
 	// Remove from pending state if it exists, as we won't fetch it now
 	delete(m.pending, hash)
 	m.mu.Unlock()
+
 	m.rescheduleWitness() // Recalculate timer based on remaining pending items
 }
 

--- a/eth/fetcher/witness_manager.go
+++ b/eth/fetcher/witness_manager.go
@@ -225,8 +225,8 @@ func (m *witnessManager) armTimerChan(lastTick time.Time) (<-chan time.Time, tim
 	pendingCount := len(m.pending)
 	m.mu.Unlock()
 
-	if pendingCount != 0 {
-		// Drain the timer so a stale fire doesn't wake us up.
+	if pendingCount == 0 {
+		// Nothing to fetch — drain the timer so a stale fire doesn't wake us up.
 		m.stopAndDrainTimer()
 		return nil, lastTick
 	}

--- a/eth/fetcher/witness_manager.go
+++ b/eth/fetcher/witness_manager.go
@@ -277,8 +277,11 @@ func (m *witnessManager) handleNeed(msg *injectBlockNeedWitnessMsg) {
 		return
 	}
 
-	// Check distance (using parent's function)
-	if dist := int64(number) - int64(m.parentChainHeight()); dist <= -maxUncleDist {
+	// Check distance (using parent's function). Match block_fetcher.go's
+	// `<` comparison so a block at exactly dist == -maxUncleDist is treated
+	// the same by both: accepted. An inconsistent boundary would let
+	// block_fetcher import such a block while witness_manager drops it.
+	if dist := int64(number) - int64(m.parentChainHeight()); dist < -maxUncleDist {
 		m.mu.Unlock()
 		log.Debug("[wm] Discarded injected block, too far away", "peer", msg.origin, "number", number, "hash", hash, "distance", dist)
 		return // Doesn't count towards DOS limits as it's injected, just drop.

--- a/eth/fetcher/witness_manager_test.go
+++ b/eth/fetcher/witness_manager_test.go
@@ -3227,13 +3227,17 @@ func TestWitnessHandleFilterResultSkipsAlreadyPending(t *testing.T) {
 
 	// Pending state must be the original one, not replaced.
 	m.mu.Lock()
-	if m.pending[hash] == nil || m.pending[hash].op.origin != "old-peer" {
-		t.Errorf("pending entry was replaced; origin=%q", m.pending[hash].op.origin)
+	defer m.mu.Unlock()
+	state := m.pending[hash]
+	if state == nil {
+		t.Fatal("pending entry was removed; expected original to remain")
 	}
-	if m.pending[hash].retries != origRetries {
+	if state.op.origin != "old-peer" {
+		t.Errorf("pending entry was replaced; origin=%q", state.op.origin)
+	}
+	if state.retries != origRetries {
 		t.Error("pending retries counter was modified")
 	}
-	m.mu.Unlock()
 }
 
 // TestCheckCompletingSkipsAlreadyPending verifies the same already-pending
@@ -3267,10 +3271,14 @@ func TestWitnessCheckCompletingSkipsAlreadyPending(t *testing.T) {
 		t.Error("fetchWitness should not be invoked when already pending")
 	}
 	m.mu.Lock()
-	if m.pending[hash].op.origin != "original" {
+	defer m.mu.Unlock()
+	state := m.pending[hash]
+	if state == nil {
+		t.Fatal("pending entry was removed; expected original to remain")
+	}
+	if state.op.origin != "original" {
 		t.Error("pending entry was replaced")
 	}
-	m.mu.Unlock()
 }
 
 // TestHandleWitnessFetchSuccessUpdatesBlockTimestamps covers the guard at

--- a/eth/fetcher/witness_manager_test.go
+++ b/eth/fetcher/witness_manager_test.go
@@ -3381,3 +3381,59 @@ func TestWitnessGetConsensusPageCountMajority(t *testing.T) {
 		t.Errorf("consensus = %d, want 10 (clear majority)", consensus)
 	}
 }
+
+// TestWitnessLoopDrivesFetchesForPending guards against armTimerChan's
+// condition being inverted: when pending requests exist, the loop must
+// arm the timer so tick() eventually fires and invokes fetchWitness. The
+// existing TestLoop injects a message but never verifies the retry path
+// actually executes via the timer — it was insufficient to catch a bug
+// where armTimerChan returned a nil timer channel whenever pending > 0
+// (reported by code review on PR #2188).
+//
+// This test exercises the full loop→tick→fetchWitness pipeline through
+// real channels and asserts the fetch callback fires within a bounded
+// time.
+func TestWitnessLoopDrivesFetchesForPending(t *testing.T) {
+	quit := make(chan struct{})
+	defer close(quit)
+
+	dropPeer := peerDropFn(func(string) {})
+	enqueueCh := make(chan *enqueueRequest, 10)
+	getBlock := blockRetrievalFn(func(common.Hash) *types.Block { return nil })
+	getHeader := HeaderRetrievalFn(func(common.Hash) *types.Header { return nil })
+	chainHeight := chainHeightFn(func() uint64 { return 100 })
+
+	manager := newWitnessManager(
+		quit, dropPeer, nil, enqueueCh,
+		getBlock, getHeader, chainHeight, nil, 0,
+	)
+
+	fetchCalled := make(chan struct{}, 1)
+	fetchWitness := func(common.Hash, chan *eth.Response) (*eth.Request, error) {
+		select {
+		case fetchCalled <- struct{}{}:
+		default:
+		}
+		return nil, errors.New("no peer with witness for hash")
+	}
+
+	go manager.loop()
+	defer manager.stop()
+
+	block := createTestBlock(101)
+	manager.injectNeedWitnessCh <- &injectBlockNeedWitnessMsg{
+		origin:       "test-peer",
+		block:        block,
+		fetchWitness: fetchWitness,
+	}
+
+	// fetchWitness must be invoked within a reasonable window. If
+	// armTimerChan's condition is inverted (returns nil channel when
+	// pending > 0), tick() never fires through the timer and this
+	// times out.
+	select {
+	case <-fetchCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("fetchWitness was never invoked — loop is not driving tick for pending requests")
+	}
+}

--- a/eth/fetcher/witness_manager_test.go
+++ b/eth/fetcher/witness_manager_test.go
@@ -2640,3 +2640,744 @@ func TestConcurrentWitnessVerification(t *testing.T) {
 		t.Log("Note: No peers were jailed, which may indicate the consensus logic needs review")
 	}
 }
+
+// TestFetchWitnessNoPeerError covers the soft-failure path in
+// initiateWitnessFetch when the fetch function reports "no peer with witness
+// for hash". In that case the returned (req, _, ok) must be (nil, _, false)
+// so the caller short-circuits before dereferencing req. A mutation flipping
+// the ok value to true would cause `defer req.Close()` to nil-panic; this
+// test catches that by exercising the code path and asserting no peer is
+// dropped (the peer argument passed to handleWitnessFetchFailureExt is "").
+func TestFetchWitnessNoPeerError(t *testing.T) {
+	quit := make(chan struct{})
+	defer close(quit)
+
+	dropped := make(chan string, 1)
+	dropPeer := peerDropFn(func(id string) { dropped <- id })
+	enqueueCh := make(chan *enqueueRequest, 10)
+	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
+	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
+	chainHeight := chainHeightFn(func() uint64 { return 100 })
+
+	manager := newWitnessManager(
+		quit, dropPeer, nil, enqueueCh,
+		getBlock, getHeader, chainHeight, nil, 0,
+	)
+
+	hash := common.HexToHash("0xabc")
+	peer := "test-peer"
+
+	// Seed a pending entry so handleWitnessFetchFailureExt has a state to
+	// back off on — mirrors the real code path.
+	manager.mu.Lock()
+	manager.pending[hash] = &witnessRequestState{
+		op: &blockOrHeaderInject{origin: peer},
+		announce: &blockAnnounce{
+			origin: peer,
+			hash:   hash,
+			number: 101,
+			time:   time.Now(),
+		},
+	}
+	manager.mu.Unlock()
+
+	announce := &blockAnnounce{
+		origin: peer,
+		hash:   hash,
+		number: 101,
+		time:   time.Now(),
+		// Return the exact error substring matched in initiateWitnessFetch.
+		fetchWitness: func(common.Hash, chan *eth.Response) (*eth.Request, error) {
+			return nil, errors.New("no peer with witness for hash")
+		},
+	}
+
+	// Run synchronously so a nil-panic in the mutated variant fails the test
+	// rather than silently crashing a goroutine.
+	manager.fetchWitness(peer, hash, announce)
+
+	// The soft-failure path passes peer="" to handleWitnessFetchFailureExt,
+	// so no peer should be dropped.
+	select {
+	case id := <-dropped:
+		t.Errorf("unexpected peer drop on 'no peer with witness' path: %s", id)
+	default:
+	}
+}
+
+// TestTickPreservesValidPendingEntry guards the nil-check in
+// collectReadyHashesLocked:
+//
+//	if state.op == nil || state.announce == nil { delete(...) }
+//
+// A mutation flipping either `==` to `!=` would cause valid pending entries
+// (both fields non-nil) to be wrongly deleted. TestTickNotReadyYet only
+// checks the retry counter; this test verifies the entry itself survives
+// tick.
+func TestWitnessTickPreservesValidPendingEntry(t *testing.T) {
+	quit := make(chan struct{})
+	defer close(quit)
+
+	dropPeer := peerDropFn(func(id string) {})
+	enqueueCh := make(chan *enqueueRequest, 10)
+	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
+	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
+	chainHeight := chainHeightFn(func() uint64 { return 100 })
+
+	manager := newWitnessManager(
+		quit, dropPeer, nil, enqueueCh,
+		getBlock, getHeader, chainHeight, nil, 0,
+	)
+
+	block := createTestBlock(101)
+	hash := block.Hash()
+
+	// Valid pending entry: both op and announce non-nil, future time so it
+	// isn't ready to fetch and won't be drained by the ready path.
+	manager.mu.Lock()
+	manager.pending[hash] = &witnessRequestState{
+		op: &blockOrHeaderInject{origin: "test-peer", block: block},
+		announce: &blockAnnounce{
+			origin: "test-peer",
+			hash:   hash,
+			number: block.NumberU64(),
+			time:   time.Now().Add(time.Hour),
+			fetchWitness: func(common.Hash, chan *eth.Response) (*eth.Request, error) {
+				return nil, nil
+			},
+		},
+	}
+	manager.mu.Unlock()
+
+	manager.tick()
+
+	if !manager.isPending(hash) {
+		t.Error("valid pending entry was incorrectly deleted by tick()")
+	}
+}
+
+// TestFetchWitnessOtherErrorKeepsPending covers the "other errors" branch in
+// initiateWitnessFetch — errors whose message does NOT contain "no peer with
+// witness for hash". This path must:
+//   - keep the pending entry (removePending=false, caught if line 582 mutates)
+//   - return ok=false so the caller short-circuits before defer req.Close()
+//     on a nil request (caught if line 583 mutates)
+//
+// TestFetchWitnessError exercises this path but never asserts the pending
+// state is retained, so the removePending bool is unverified.
+func TestFetchWitnessOtherErrorKeepsPending(t *testing.T) {
+	quit := make(chan struct{})
+	defer close(quit)
+
+	dropPeer := peerDropFn(func(id string) {})
+	enqueueCh := make(chan *enqueueRequest, 10)
+	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
+	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
+	chainHeight := chainHeightFn(func() uint64 { return 100 })
+
+	manager := newWitnessManager(
+		quit, dropPeer, nil, enqueueCh,
+		getBlock, getHeader, chainHeight, nil, 0,
+	)
+
+	hash := common.HexToHash("0xfade")
+	peer := "test-peer"
+
+	// Seed a pending entry so initiateWitnessFetch reaches the
+	// "other errors" branch (the isPending check passes).
+	manager.mu.Lock()
+	manager.pending[hash] = &witnessRequestState{
+		op: &blockOrHeaderInject{origin: peer},
+		announce: &blockAnnounce{
+			origin: peer,
+			hash:   hash,
+			number: 101,
+			time:   time.Now(),
+		},
+	}
+	manager.mu.Unlock()
+
+	announce := &blockAnnounce{
+		origin: peer,
+		hash:   hash,
+		number: 101,
+		time:   time.Now(),
+		// Generic error — does NOT match the "no peer with witness for hash"
+		// substring, forcing the other-errors code path.
+		fetchWitness: func(common.Hash, chan *eth.Response) (*eth.Request, error) {
+			return nil, errors.New("transient network error")
+		},
+	}
+
+	// Synchronous call: a nil-req panic from a mutated ok=true would fail
+	// the test rather than silently crashing a goroutine.
+	manager.fetchWitness(peer, hash, announce)
+
+	// Pending entry must still exist — the soft-failure path must NOT
+	// remove it (removePending=false).
+	if !manager.isPending(hash) {
+		t.Error("pending entry was removed on transient error; expected it to be retained for retry")
+	}
+}
+
+// TestCheckWitnessPageCountAtThreshold covers the exact-boundary case where
+// pageCount equals the computed threshold. The guard is `pageCount <=
+// threshold` — flipping to `<` would incorrectly trigger peer verification at
+// the boundary. The existing below-threshold tests all use threshold-1, so
+// the boundary itself was untested.
+func TestCheckWitnessPageCountAtThreshold(t *testing.T) {
+	quit := make(chan struct{})
+	defer close(quit)
+
+	dropPeer := peerDropFn(func(id string) { t.Errorf("unexpected drop for peer at threshold: %s", id) })
+	jailPeer := peerJailFn(func(id string) { t.Errorf("unexpected jail for peer at threshold: %s", id) })
+	enqueueCh := make(chan *enqueueRequest, 10)
+	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
+	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
+	chainHeight := chainHeightFn(func() uint64 { return 100 })
+
+	// 30M gas / 1M per MB / 15MB per page → ceil(2.0) = 2 pages threshold.
+	currentHeader := currentHeaderFn(func() *types.Header {
+		return &types.Header{Number: big.NewInt(100), GasLimit: 30_000_000}
+	})
+
+	manager := newWitnessManager(
+		quit, dropPeer, jailPeer, enqueueCh,
+		getBlock, getHeader, chainHeight, currentHeader, 30_000_000,
+	)
+
+	threshold := manager.calculatePageThreshold()
+
+	// Explicit failure if verification is unexpectedly invoked. If the guard
+	// mutates from `<=` to `<`, pageCount == threshold will fall through to
+	// verification and these mocks will fire.
+	getRandomPeers := func() []string {
+		t.Error("getRandomPeers should not be called for pageCount == threshold")
+		return nil
+	}
+	getWitnessPageCount := func(string, common.Hash) (uint64, error) {
+		t.Error("getWitnessPageCount should not be called for pageCount == threshold")
+		return 0, errors.New("unreachable")
+	}
+
+	isHonest := manager.CheckWitnessPageCount(
+		common.HexToHash("0xdef"),
+		threshold, // exactly at the boundary
+		"test-peer",
+		getRandomPeers,
+		getWitnessPageCount,
+	)
+	if !isHonest {
+		t.Error("expected peer to be considered honest at pageCount == threshold")
+	}
+}
+
+// newWitnessManagerForTest returns a minimal witness manager wired up for
+// tests that directly invoke individual methods. The returned channel can
+// be read from to observe enqueued ops.
+func newWitnessManagerForTest(t *testing.T) (*witnessManager, <-chan *enqueueRequest) {
+	t.Helper()
+	quit := make(chan struct{})
+	t.Cleanup(func() { close(quit) })
+	enqueueCh := make(chan *enqueueRequest, 10)
+	m := newWitnessManager(
+		quit,
+		peerDropFn(func(string) {}),
+		nil,
+		enqueueCh,
+		blockRetrievalFn(func(common.Hash) *types.Block { return nil }),
+		HeaderRetrievalFn(func(common.Hash) *types.Header { return nil }),
+		chainHeightFn(func() uint64 { return 100 }),
+		nil,
+		0,
+	)
+	return m, enqueueCh
+}
+
+// addPendingEntry inserts a valid pending witness request for a hash with
+// the given announce time. Returns the hash for convenience.
+func addPendingEntry(m *witnessManager, hashHex string, peer string, announceTime time.Time) common.Hash {
+	hash := common.HexToHash(hashHex)
+	m.mu.Lock()
+	m.pending[hash] = &witnessRequestState{
+		op: &blockOrHeaderInject{origin: peer},
+		announce: &blockAnnounce{
+			origin: peer,
+			hash:   hash,
+			number: 101,
+			time:   announceTime,
+		},
+	}
+	m.mu.Unlock()
+	return hash
+}
+
+// TestProcessWitnessResponseErrorBranches covers all three early-return
+// error paths in processWitnessResponse:
+//
+//   - nil response (channel closed unexpectedly)
+//   - wrong response type (assertion failure)
+//   - empty witness slice
+//
+// Each must route through handleWitnessFetchFailureExt with removePending=false
+// and must not panic on nil. This kills the negate_conditional,
+// boolean_substitution, and branch_removal mutations on lines 616, 618,
+// 627, 630, 632.
+func TestProcessWitnessResponseErrorBranches(t *testing.T) {
+	peer := "test-peer"
+
+	t.Run("nil response", func(t *testing.T) {
+		m, _ := newWitnessManagerForTest(t)
+		hash := addPendingEntry(m, "0xa1", peer, time.Now())
+		m.processWitnessResponse(peer, hash, nil, time.Now())
+		// nil response → fetch failure path with removePending=false → entry retained.
+		if !m.isPending(hash) {
+			t.Error("pending entry should be retained on nil response")
+		}
+	})
+
+	t.Run("invalid response type", func(t *testing.T) {
+		m, _ := newWitnessManagerForTest(t)
+		hash := addPendingEntry(m, "0xa2", peer, time.Now())
+		done := make(chan error, 1)
+		res := &eth.Response{Res: "not-a-witness-slice", Done: done}
+		m.processWitnessResponse(peer, hash, res, time.Now())
+		if !m.isPending(hash) {
+			t.Error("pending entry should be retained on invalid response type")
+		}
+		select {
+		case <-done:
+		default:
+			t.Error("res.Done should be signaled before type check")
+		}
+	})
+
+	t.Run("empty witness slice", func(t *testing.T) {
+		m, _ := newWitnessManagerForTest(t)
+		hash := addPendingEntry(m, "0xa3", peer, time.Now())
+		done := make(chan error, 1)
+		res := &eth.Response{Res: []*stateless.Witness{}, Done: done}
+		m.processWitnessResponse(peer, hash, res, time.Now())
+		if !m.isPending(hash) {
+			t.Error("pending entry should be retained on empty witness slice")
+		}
+	})
+}
+
+// TestHandleBroadcastPreservesExistingWitness asserts the "already set"
+// guard at line 349: if a pending entry already has a witness attached, a
+// second broadcast must NOT overwrite it. Flipping `== nil` to `!= nil`
+// would cause the attached witness to be replaced.
+func TestHandleBroadcastPreservesExistingWitness(t *testing.T) {
+	m, enqueueCh := newWitnessManagerForTest(t)
+
+	block := createTestBlock(101)
+	hash := block.Hash()
+	firstWitness := createTestWitnessForBlock(block)
+	secondWitness := createTestWitnessForBlock(block)
+
+	// Seed a pending entry with a witness already attached via a prior broadcast.
+	m.mu.Lock()
+	m.pending[hash] = &witnessRequestState{
+		op: &blockOrHeaderInject{
+			origin:  "peer-1",
+			block:   block,
+			witness: firstWitness,
+		},
+		announce: &blockAnnounce{
+			origin: "peer-1",
+			hash:   hash,
+			number: block.NumberU64(),
+			time:   time.Now(),
+		},
+	}
+	m.mu.Unlock()
+
+	// Inject a second broadcast for the same hash.
+	m.handleBroadcast(&injectedWitnessMsg{
+		peer:    "peer-2",
+		witness: secondWitness,
+		time:    time.Now(),
+	})
+
+	// The first witness should still be attached — handleBroadcast goes on
+	// to enqueue via safeEnqueue which removes the pending entry, so we
+	// validate by reading the enqueued op.
+	select {
+	case req := <-enqueueCh:
+		if req.op.witness != firstWitness {
+			t.Error("second broadcast overwrote already-attached witness")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for enqueue")
+	}
+}
+
+// TestEarliestPendingAnnounceLockedSkipsInvalid verifies the three-way
+// filter in earliestPendingAnnounceLocked:
+//
+//	state.announce == nil || state.op == nil || state.op.witness != nil
+//
+// Each clause must filter out entries that don't qualify as "pending fetch".
+// This kills three negate_conditional mutations on line 708.
+func TestWitnessEarliestPendingAnnounceSkipsInvalid(t *testing.T) {
+	m, _ := newWitnessManagerForTest(t)
+
+	valid := common.HexToHash("0xb1")
+	nilAnnounce := common.HexToHash("0xb2")
+	nilOp := common.HexToHash("0xb3")
+	alreadyHasWitness := common.HexToHash("0xb4")
+
+	earliestTime := time.Now().Add(-time.Hour) // must be selected
+	laterTime := time.Now().Add(time.Hour)
+
+	m.mu.Lock()
+	m.pending[valid] = &witnessRequestState{
+		op: &blockOrHeaderInject{origin: "p"},
+		announce: &blockAnnounce{
+			origin: "p", hash: valid, number: 1, time: earliestTime,
+		},
+	}
+	// Should be skipped: announce nil.
+	m.pending[nilAnnounce] = &witnessRequestState{
+		op: &blockOrHeaderInject{origin: "p"},
+	}
+	// Should be skipped: op nil.
+	m.pending[nilOp] = &witnessRequestState{
+		announce: &blockAnnounce{hash: nilOp, time: laterTime},
+	}
+	// Should be skipped: witness already present.
+	block := createTestBlock(5)
+	m.pending[alreadyHasWitness] = &witnessRequestState{
+		op: &blockOrHeaderInject{
+			origin:  "p",
+			block:   block,
+			witness: createTestWitnessForBlock(block),
+		},
+		announce: &blockAnnounce{hash: alreadyHasWitness, time: laterTime},
+	}
+
+	got := m.earliestPendingAnnounceLocked()
+	m.mu.Unlock()
+
+	if !got.Equal(earliestTime) {
+		t.Errorf("earliest = %v, want %v (only valid entry should count)", got, earliestTime)
+	}
+}
+
+// TestCollectReadyHashesMaxRetriesBoundary exercises the exact-threshold
+// case for the max-retries guard:
+//
+//	if state.retries >= maxWitnessFetchRetries { ... mark unavailable }
+//
+// Flipping `>=` to `>` would let a request retry one additional time beyond
+// the limit before being marked unavailable. This also covers the incdec
+// mutation on `state.retries++` (line 464) — if that flipped to `--`,
+// retries would never reach the limit.
+func TestWitnessCollectReadyHashesMaxRetriesBoundary(t *testing.T) {
+	t.Run("below limit gets incremented and fetched", func(t *testing.T) {
+		m, _ := newWitnessManagerForTest(t)
+		hash := addPendingEntry(m, "0xc1", "p", time.Now().Add(-time.Second))
+		m.mu.Lock()
+		m.pending[hash].retries = 5
+		ready, toMark := m.collectReadyHashesLocked(time.Now())
+		retriesAfter := m.pending[hash].retries
+		m.mu.Unlock()
+
+		if len(ready) != 1 || ready[0] != hash {
+			t.Errorf("expected hash in readyToFetch, got ready=%v", ready)
+		}
+		if len(toMark) != 0 {
+			t.Errorf("expected nothing to mark, got %v", toMark)
+		}
+		if retriesAfter != 6 {
+			t.Errorf("retries = %d, want 6 (should be incremented)", retriesAfter)
+		}
+	})
+
+	t.Run("at limit gets marked unavailable", func(t *testing.T) {
+		m, _ := newWitnessManagerForTest(t)
+		hash := addPendingEntry(m, "0xc2", "p", time.Now().Add(-time.Second))
+		m.mu.Lock()
+		m.pending[hash].retries = maxWitnessFetchRetries
+		ready, toMark := m.collectReadyHashesLocked(time.Now())
+		m.mu.Unlock()
+
+		if len(ready) != 0 {
+			t.Errorf("expected empty ready, got %v", ready)
+		}
+		if len(toMark) != 1 || toMark[0] != hash {
+			t.Errorf("expected hash in toMarkUnavailable, got %v", toMark)
+		}
+	})
+}
+
+// TestCleanupUnavailableCacheExpiry verifies that cleanupUnavailableCache
+// correctly partitions entries by expiry time:
+//   - entries whose expiry is in the past are removed
+//   - entries whose expiry is in the future are retained
+//
+// This kills the conditional_boundary mutation on `now.After(expiry)` at
+// line 837 (e.g. `>` → `>=` would change which entries survive).
+func TestWitnessCleanupUnavailableCacheExpiry(t *testing.T) {
+	m, _ := newWitnessManagerForTest(t)
+	expired := common.HexToHash("0xd1")
+	live := common.HexToHash("0xd2")
+
+	now := time.Now()
+	m.mu.Lock()
+	m.witnessUnavailable[expired] = now.Add(-time.Hour)
+	m.witnessUnavailable[live] = now.Add(time.Hour)
+	m.mu.Unlock()
+
+	m.cleanupUnavailableCache()
+
+	m.mu.Lock()
+	_, expiredStillThere := m.witnessUnavailable[expired]
+	_, liveStillThere := m.witnessUnavailable[live]
+	m.mu.Unlock()
+
+	if expiredStillThere {
+		t.Error("expired entry should have been removed")
+	}
+	if !liveStillThere {
+		t.Error("unexpired entry should have been retained")
+	}
+}
+
+// TestCalculatePageThresholdMinimumClamp verifies that a tiny gas limit
+// (which would naturally compute to 0 pages) is clamped to a minimum of 1.
+// This covers the two `threshold < 1` guards in calculatePageThreshold
+// (header-path at line ~978 and config-path at line ~1003).
+func TestWitnessCalculatePageThresholdMinimumClamp(t *testing.T) {
+	t.Run("tiny header gas limit clamps to 1", func(t *testing.T) {
+		quit := make(chan struct{})
+		defer close(quit)
+		m := newWitnessManager(
+			quit,
+			peerDropFn(func(string) {}),
+			nil,
+			make(chan *enqueueRequest, 10),
+			blockRetrievalFn(func(common.Hash) *types.Block { return nil }),
+			HeaderRetrievalFn(func(common.Hash) *types.Header { return nil }),
+			chainHeightFn(func() uint64 { return 100 }),
+			currentHeaderFn(func() *types.Header {
+				return &types.Header{Number: big.NewInt(100), GasLimit: 1} // < 1MB → 0 pages pre-clamp
+			}),
+			0,
+		)
+		if got := m.calculatePageThreshold(); got < 1 {
+			t.Errorf("threshold = %d, want >= 1 (minimum clamp)", got)
+		}
+	})
+
+	t.Run("tiny gas ceil config clamps to 1", func(t *testing.T) {
+		quit := make(chan struct{})
+		defer close(quit)
+		m := newWitnessManager(
+			quit,
+			peerDropFn(func(string) {}),
+			nil,
+			make(chan *enqueueRequest, 10),
+			blockRetrievalFn(func(common.Hash) *types.Block { return nil }),
+			HeaderRetrievalFn(func(common.Hash) *types.Header { return nil }),
+			chainHeightFn(func() uint64 { return 100 }),
+			nil, // no current header → fallback to config path
+			1,   // 1 gas ceil → 0 pages pre-clamp
+		)
+		if got := m.calculatePageThreshold(); got < 1 {
+			t.Errorf("threshold = %d, want >= 1 (minimum clamp)", got)
+		}
+	})
+}
+
+// TestHandleFilterResultSkipsAlreadyPending verifies handleFilterResult
+// short-circuits when the hash is already in pending — flipping the `!=`
+// at line 875 (if already pending, we should NOT process further).
+func TestWitnessHandleFilterResultSkipsAlreadyPending(t *testing.T) {
+	m, _ := newWitnessManagerForTest(t)
+	block := createTestBlock(102)
+	hash := block.Hash()
+
+	fetchCalled := false
+	fetchWitness := func(common.Hash, chan *eth.Response) (*eth.Request, error) {
+		fetchCalled = true
+		return nil, nil
+	}
+
+	// Seed an existing pending entry with that hash.
+	m.mu.Lock()
+	m.pending[hash] = &witnessRequestState{
+		op:       &blockOrHeaderInject{origin: "old-peer", block: block},
+		announce: &blockAnnounce{origin: "old-peer", hash: hash, time: time.Now()},
+	}
+	origRetries := m.pending[hash].retries
+	m.mu.Unlock()
+
+	m.handleFilterResult(&blockAnnounce{
+		origin:       "new-peer",
+		hash:         hash,
+		number:       block.NumberU64(),
+		fetchWitness: fetchWitness,
+	}, block)
+
+	if fetchCalled {
+		t.Error("fetchWitness should not be invoked when already pending")
+	}
+
+	// Pending state must be the original one, not replaced.
+	m.mu.Lock()
+	if m.pending[hash] == nil || m.pending[hash].op.origin != "old-peer" {
+		t.Errorf("pending entry was replaced; origin=%q", m.pending[hash].op.origin)
+	}
+	if m.pending[hash].retries != origRetries {
+		t.Error("pending retries counter was modified")
+	}
+	m.mu.Unlock()
+}
+
+// TestCheckCompletingSkipsAlreadyPending verifies the same already-pending
+// guard in checkCompleting at line 933.
+func TestWitnessCheckCompletingSkipsAlreadyPending(t *testing.T) {
+	m, _ := newWitnessManagerForTest(t)
+	block := createTestBlock(103)
+	hash := block.Hash()
+
+	fetchCalled := false
+	fetchWitness := func(common.Hash, chan *eth.Response) (*eth.Request, error) {
+		fetchCalled = true
+		return nil, nil
+	}
+
+	m.mu.Lock()
+	m.pending[hash] = &witnessRequestState{
+		op:       &blockOrHeaderInject{origin: "original", block: block},
+		announce: &blockAnnounce{origin: "original", hash: hash, time: time.Now()},
+	}
+	m.mu.Unlock()
+
+	m.checkCompleting(&blockAnnounce{
+		origin:       "new-peer",
+		hash:         hash,
+		number:       block.NumberU64(),
+		fetchWitness: fetchWitness,
+	}, block)
+
+	if fetchCalled {
+		t.Error("fetchWitness should not be invoked when already pending")
+	}
+	m.mu.Lock()
+	if m.pending[hash].op.origin != "original" {
+		t.Error("pending entry was replaced")
+	}
+	m.mu.Unlock()
+}
+
+// TestHandleWitnessFetchSuccessUpdatesBlockTimestamps covers the guard at
+// line 665: if state.op.block is non-nil, ReceivedAt and AnnouncedAt must
+// be set. Flipping the `!= nil` guard would skip the timestamp updates
+// even when a block is present.
+func TestHandleWitnessFetchSuccessUpdatesBlockTimestamps(t *testing.T) {
+	m, enqueueCh := newWitnessManagerForTest(t)
+	block := createTestBlock(104)
+	hash := block.Hash()
+	witness := createTestWitnessForBlock(block)
+
+	m.mu.Lock()
+	m.pending[hash] = &witnessRequestState{
+		op: &blockOrHeaderInject{origin: "peer", block: block},
+		announce: &blockAnnounce{
+			origin: "peer", hash: hash, number: block.NumberU64(), time: time.Now(),
+		},
+	}
+	m.mu.Unlock()
+
+	announcedAt := time.Now().Add(-time.Second)
+	m.handleWitnessFetchSuccess("peer", hash, witness, announcedAt)
+
+	select {
+	case req := <-enqueueCh:
+		if req.op.block.ReceivedAt.IsZero() {
+			t.Error("ReceivedAt should be set after successful fetch")
+		}
+		if req.op.block.AnnouncedAt == nil {
+			t.Error("AnnouncedAt should be set after successful fetch")
+		} else if !req.op.block.AnnouncedAt.Equal(announcedAt) {
+			t.Errorf("AnnouncedAt = %v, want %v", *req.op.block.AnnouncedAt, announcedAt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for enqueue")
+	}
+}
+
+// TestVerifyWitnessPageCountDishonestPeer exercises the dishonest-peer
+// detection at line 1089:
+//
+//	if consensusPageCount != reportedPageCount && consensusPageCount != 0
+//
+// Flipping either `!=` to `==` would cause honest or no-consensus cases
+// to be classified as dishonest and incorrectly drop/jail the peer.
+func TestVerifyWitnessPageCountDishonestPeer(t *testing.T) {
+	quit := make(chan struct{})
+	defer close(quit)
+
+	var droppedPeer, jailedPeer string
+	dropPeer := peerDropFn(func(id string) { droppedPeer = id })
+	jailPeer := peerJailFn(func(id string) { jailedPeer = id })
+
+	m := newWitnessManager(
+		quit, dropPeer, jailPeer,
+		make(chan *enqueueRequest, 10),
+		blockRetrievalFn(func(common.Hash) *types.Block { return nil }),
+		HeaderRetrievalFn(func(common.Hash) *types.Header { return nil }),
+		chainHeightFn(func() uint64 { return 100 }),
+		nil,
+		0,
+	)
+
+	// Reported: 999 (the lying peer). Consensus from other peers: 5 (x2).
+	// 999 vs consensus 5 → dishonest path.
+	getRandomPeers := func() []string { return []string{"honest1", "honest2"} }
+	getWitnessPageCount := func(peer string, _ common.Hash) (uint64, error) {
+		return 5, nil
+	}
+
+	isHonest := m.verifyWitnessPageCountSync(
+		common.HexToHash("0xe1"), 999, "liar",
+		getRandomPeers, getWitnessPageCount,
+	)
+	if isHonest {
+		t.Error("expected liar to be classified dishonest")
+	}
+	if droppedPeer != "liar" {
+		t.Errorf("expected drop of 'liar', got %q", droppedPeer)
+	}
+	if jailedPeer != "liar" {
+		t.Errorf("expected jail of 'liar', got %q", jailedPeer)
+	}
+}
+
+// TestGetConsensusPageCountMajority verifies that the majority vote is
+// correctly picked. This covers the `freq > maxCount` comparison at line
+// 1030 — flipping to `>=` could change which vote wins on ties (though in
+// most cases Go map iteration nondeterminism already makes ties undefined,
+// a clear-majority case must still pick the winner).
+func TestWitnessGetConsensusPageCountMajority(t *testing.T) {
+	m, _ := newWitnessManagerForTest(t)
+
+	// Original: 10. Peers vote 10, 10, 999 → consensus 10 (3/4 includes self).
+	peers := []string{"p1", "p2", "p3"}
+	votes := map[string]uint64{"p1": 10, "p2": 10, "p3": 999}
+	getCount := func(peer string, _ common.Hash) (uint64, error) {
+		return votes[peer], nil
+	}
+
+	consensus := m.getConsensusPageCountWithOriginal(
+		peers, common.HexToHash("0xe2"),
+		10, // original reported
+		getCount,
+	)
+	if consensus != 10 {
+		t.Errorf("consensus = %d, want 10 (clear majority)", consensus)
+	}
+}


### PR DESCRIPTION
# Description

Structural refactor of witness_manager.go plus targeted tests, guided by diffguard (https://github.com/0xPolygon/diffguard). Max cognitive complexity 44 → 10; Tier 1 / Tier 2 mutation score 100%.


## `eth/fetcher/witness_manager.go` — Refactoring Impact

Refactor + test additions guided by [diffguard](https://github.com/0xPolygon/diffguard).

## Aggregate metrics

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| File LOC | 889 | 1,119 | +230 (helpers + doc comments) |
| Function count | 19 | 36 | +17 extracted helpers |
| Max cognitive complexity | **44** | **10** | **-77%** |
| Mean complexity | 7.6 | 3.9 | -49% |
| Median complexity | 4 | 3 | -25% |
| Functions above threshold (10) | 5 | 0 | all cleared |
| Functions above 50 lines | 5 | 3 | -40% |

## The four worst offenders — before vs after split

### `tick()` — was the worst

| | Lines | Complexity |
|---|---|---|
| Before: `tick()` | 130 | **44** |
| After: `tick()` | ~25 | 2 |
| → `logPendingStatesAtTickLocked` | 14 | 8 |
| → `collectReadyHashesLocked` | 38 | 10 |
| → `extractPrematureOpsLocked` | 11 | 4 |
| → `buildPeerRequestsLocked` | 20 | 6 |
| → `dispatchPeerRequests` | 8 | 2 |
| → `dispatchPeerFetches` | 20 | 6 |

### `loop()`

| | Lines | Complexity |
|---|---|---|
| Before: `loop()` | 84 | **22** |
| After: `loop()` | 52 | 9 |
| → `armTimerChan` | 20 | 2 |
| → `logTimerTick` | 5 | 1 |

### `fetchWitness()`

| | Lines | Complexity |
|---|---|---|
| Before: `fetchWitness()` | 83 | **15** |
| After: `fetchWitness()` | ~15 | 1 |
| → `initiateWitnessFetch` | 33 | 7 |
| → `awaitWitnessResponse` | 15 | 1 |
| → `processWitnessResponse` | 23 | 3 |

### `rescheduleWitness()`

| | Lines | Complexity |
|---|---|---|
| Before: `rescheduleWitness()` | ~40 | **14** |
| After: `rescheduleWitness()` | ~25 | 3 |
| → `earliestPendingAnnounceLocked` | 12 | 7 |
| → `stopAndDrainTimer` | 8 | 3 |

## Tests

| | Before | After | Delta |
|---|---|---|---|
| Test file LOC | 1,962 | 3,447 | +1,485 |
| Test function count | 39 | 61 | +22 |

New tests target specific mutation-testing gaps (~15) plus regression tests for bugs found during review (the `loop()` end-to-end retry test and the fixed nil-deref test guards).

## Mutation testing

| | Before refactor | After refactor + tests |
|---|---|---|
| Raw score | ~54.7% (baseline) | **96.1%** |
| Tier 1 (logic) | ~43% (many survivors) | **100.0%** (98/98 killed) |
| Tier 2 (semantic) | ~56% | **100.0%** (22/22) |
| Tier 3 (observability) | mostly noise | 94.4% (remaining 15 are `log.Debug` removals, report-only) |
| Severity verdict | FAIL | **PASS** |

## diffguard section status

| Check | Before | After |
|---|---|---|
| Cognitive complexity | FAIL (4 violations, max 44) | **PASS** |
| Code sizes | FAIL (6 violations) | FAIL (3 function size, 1 file size — structural, pre-existing) |
| Dependency structure | PASS | **PASS** |
| Churn-weighted complexity | WARN (top score 351) | **PASS** (top score 96) |
| Mutation testing | FAIL | **PASS** |

