### PR TITLE
build: bump Go from 1.26.1 to 1.26.2 to fix stdlib CVEs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # This file configures github.com/golangci/golangci-lint.
 version: '2'
 run:
-  go: '1.26.1'
+  go: '1.26.2'
   tests: true
 linters:
   default: none

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ─── BUILDER STAGE ───────────────────────────────────────────────────────────────
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 ARG BOR_DIR=/var/lib/bor/
 ENV BOR_DIR=$BOR_DIR

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/cmd/keeper/go.mod
+++ b/cmd/keeper/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum/go-ethereum/cmd/keeper
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20260104020744-7268a54d0358

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/ethereum/go-ethereum
 
 // Note: Change the go image version in Dockerfile if you change this.
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/0xPolygon/crand v1.0.3


### PR DESCRIPTION
## Summary

- Bumps Go from `1.26.1` to `1.26.2` across `go.mod`, `cmd/keeper/go.mod`, `.golangci.yml`, `Dockerfile`, and `Dockerfile.alltools`
- Fixes 6 Go standard library vulnerabilities reported by govulncheck:

| ID | Description | Package |
|----|-------------|---------|
| GO-2026-4947 | Unexpected work during chain building | `crypto/x509` |
| GO-2026-4946 | Inefficient policy validation | `crypto/x509` |
| GO-2026-4866 | Case-sensitive excludedSubtrees auth bypass | `crypto/x509` |
| GO-2026-4870 | Unauthenticated TLS 1.3 KeyUpdate DoS | `crypto/tls` |
| GO-2026-4869 | Unbounded allocation for old GNU sparse | `archive/tar` |
| GO-2026-4865 | JsBraceDepth context tracking XSS | `html/template` |

Separate from #2182 (which bumps `go.opentelemetry.io/otel/sdk` — a third-party module).

## Test plan

- [ ] govulncheck CI passes
- [ ] Build CI passes