### PR TITLE
internal/cli: enabled witness filestore by default

### DIFF
--- a/docs/cli/default_config.toml
+++ b/docs/cli/default_config.toml
@@ -218,7 +218,7 @@ devfakeauthor = false
   disable-bor-wallet = true
 
 [grpc]
-  addr = ":3131"
+  addr = "127.0.0.1:3131"
 
 [developer]
   dev = false
@@ -237,7 +237,7 @@ devfakeauthor = false
   parallel-stateless-import = false
   parallel-stateless-import-workers = 0
   witnessapi = false
-  filestore = false
+  filestore = true
   fastforwardthreshold = 6400
 
 [pprof]

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -120,7 +120,7 @@ The ```bor server``` command runs the Bor client.
 
 - ```witness.fastforwardthreshold```: Minimum necessary distance between local header and chain tip to trigger fast forward (default: 6400)
 
-- ```witness.filestore```: Store witness blobs on the filesystem instead of the key-value database (default: false)
+- ```witness.filestore```: Store witness blobs on the filesystem instead of the key-value database (default: true)
 
 - ```witness.parallelstatelessimport```: Enable parallel stateless block import (default: false)
 

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -1047,7 +1047,7 @@ func DefaultConfig() *Config {
 			EnableParallelStatelessImport:  false,
 			ParallelStatelessImportWorkers: 0,
 			WitnessAPI:                     false,
-			FileStore:                      false,
+			FileStore:                      true,
 			FastForwardThreshold:           6400,
 		},
 		History: &HistoryConfig{


### PR DESCRIPTION
Enabled the filesysyem based witness storage, implemented in https://github.com/0xPolygon/bor/pull/2098, by default.