### PR TITLE
all: fix nightly race test flakes

### DIFF
--- a/consensus/bor/heimdall/failover_client_test.go
+++ b/consensus/bor/heimdall/failover_client_test.go
@@ -197,10 +197,13 @@ func TestFailover_SwitchOnPrimaryDown(t *testing.T) {
 	switchesBefore := failoverSwitchCounter.Snapshot().Count()
 	activeBefore := failoverActiveGauge.Snapshot().Value()
 
+	connErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+	// Primary must fail both GetSpan and FetchStatus so the background probe
+	// cannot promote it back to healthy and flip the active gauge back to 0
+	// before this test's final assertion.
 	primary := &mockHeimdallClient{
-		getSpanFn: func(ctx context.Context, _ uint64) (*types.Span, error) {
-			return nil, &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
-		},
+		getSpanFn:     func(ctx context.Context, _ uint64) (*types.Span, error) { return nil, connErr },
+		fetchStatusFn: func(_ context.Context) (*ctypes.SyncInfo, error) { return nil, connErr },
 	}
 	secondary := &mockHeimdallClient{}
 
@@ -1148,8 +1151,12 @@ func TestRegistry_CascadeFallsBackToUnhealthy(t *testing.T) {
 func TestRegistry_MarkUnhealthyOnRealFailure(t *testing.T) {
 	connErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
 
+	// Primary must fail BOTH GetSpan and the FetchStatus health probe — otherwise
+	// the registry's immediate probe cycle (launched by ensureHealthRegistry) can
+	// race with this test's GetSpan and mark primary healthy after MarkUnhealthy.
 	primary := &mockHeimdallClient{
-		getSpanFn: func(_ context.Context, _ uint64) (*types.Span, error) { return nil, connErr },
+		getSpanFn:     func(_ context.Context, _ uint64) (*types.Span, error) { return nil, connErr },
+		fetchStatusFn: func(_ context.Context) (*ctypes.SyncInfo, error) { return nil, connErr },
 	}
 	secondary := &mockHeimdallClient{}
 

--- a/core/state/race_off_test.go
+++ b/core/state/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package state
+
+const raceEnabled = false

--- a/core/state/race_on_test.go
+++ b/core/state/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package state
+
+const raceEnabled = true

--- a/core/state/trie_prefetcher_test.go
+++ b/core/state/trie_prefetcher_test.go
@@ -214,6 +214,12 @@ func TestConcurrentUsedParallelism(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping parallelism test in short mode")
 	}
+	if raceEnabled {
+		// Race instrumentation serializes atomic/mutex ops, so measured
+		// parallel speedup is not meaningful. The test guards against a
+		// global-lock regression; -race coverage isn't the right tool.
+		t.Skip("skipping parallelism test under -race: instrumentation distorts wall-clock speedup")
+	}
 
 	const N = 50          // number of subfetchers / goroutines
 	const M = 5000        // iterations per goroutine

--- a/core/txpool/legacypool/legacypool2_test.go
+++ b/core/txpool/legacypool/legacypool2_test.go
@@ -287,7 +287,10 @@ func TestLockOrdering_PricedHeapNoDeadlock(t *testing.T) {
 	select {
 	case <-done:
 		// success: no deadlock
-	case <-time.After(10 * time.Second):
+	case <-time.After(60 * time.Second):
+		// Timeout must tolerate -race overhead on CI — the work itself is
+		// ~1000 heap operations on a 6k-entry pool, so 60s is safely past
+		// legitimate completion but still catches a real hang.
 		t.Fatal("deadlock detected: reheapMu→pool.mu ordering cycle exists")
 	}
 }
@@ -337,7 +340,7 @@ func TestLockOrdering_ReplacePendingNoDeadlock(t *testing.T) {
 	select {
 	case <-reheapDone:
 		// success: no deadlock
-	case <-time.After(10 * time.Second):
+	case <-time.After(60 * time.Second):
 		t.Fatal("deadlock detected in replacesPending code path")
 	}
 }
@@ -381,7 +384,7 @@ func TestLockOrdering_RemovedNoDeadlock(t *testing.T) {
 	select {
 	case <-done:
 		// success: no deadlock
-	case <-time.After(10 * time.Second):
+	case <-time.After(60 * time.Second):
 		t.Fatal("deadlock detected: reheapMu→pool.mu ordering cycle in Removed path")
 	}
 }

--- a/eth/downloader/bor_downloader_test.go
+++ b/eth/downloader/bor_downloader_test.go
@@ -1587,8 +1587,10 @@ func testBeaconSync(t *testing.T, protocol uint, mode SyncMode) {
 				if bs := int(tester.chain.CurrentBlock().Number.Uint64()) + 1; bs != len(chain.blocks) {
 					t.Fatalf("synchronised blocks mismatch: have %v, want %v", bs, len(chain.blocks))
 				}
-			case <-time.NewTimer(time.Second * 3).C:
-				t.Fatalf("Failed to sync chain in three seconds")
+			case <-time.NewTimer(time.Second * 30).C:
+				// Generous timeout tolerates -race overhead on CI while still
+				// catching a genuine sync stall.
+				t.Fatalf("Failed to sync chain in thirty seconds")
 			}
 		})
 	}

--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -914,13 +914,27 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 			return nil
 		}
 
+		// Wait for the sync loop to settle: both subchain state AND the served
+		// header counter must converge. Under -race the background serving
+		// goroutines trail the subchain update, so reading served the instant
+		// subchain matches can observe a partial count (seen as a 1/20 flake
+		// on CI). Polling until served reaches the expected total removes the
+		// window. 10s budget tolerates -race overhead.
+		midserved := func() uint64 {
+			var s uint64
+			for _, peer := range tt.peers {
+				s += peer.served.Load()
+			}
+			return s
+		}
 		waitStart := time.Now()
-		for waitTime := 20 * time.Millisecond; time.Since(waitStart) < 2*time.Second; waitTime = waitTime * 2 {
-			time.Sleep(waitTime)
-			// Check the post-init end state if it matches the required results
+		for waitTime := 20 * time.Millisecond; time.Since(waitStart) < 30*time.Second; waitTime = waitTime * 2 {
+			time.Sleep(min(waitTime, 500*time.Millisecond))
 			json.Unmarshal(rawdb.ReadSkeletonSyncStatus(db), &progress)
-
-			if err := check(); err == nil {
+			if err := check(); err != nil {
+				continue
+			}
+			if tt.unpredictable || midserved() >= tt.midserve {
 				break
 			}
 		}
@@ -931,19 +945,14 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 		}
 
 		if !tt.unpredictable {
-			var served uint64
-			for _, peer := range tt.peers {
-				served += peer.served.Load()
-			}
-
-			if served != tt.midserve {
+			if served := midserved(); served != tt.midserve {
 				t.Errorf("test %d, mid state: served headers mismatch: have %d, want %d", i, served, tt.midserve)
 			}
 
 			// Wait for expected peer drops (may happen asynchronously after subchain state updates)
 			var drops uint64
 			waitStart = time.Now()
-			for waitTime := 20 * time.Millisecond; time.Since(waitStart) < 2*time.Second; waitTime = waitTime * 2 {
+			for waitTime := 20 * time.Millisecond; time.Since(waitStart) < 30*time.Second; waitTime = waitTime * 2 {
 				drops = 0
 				for _, peer := range tt.peers {
 					drops += peer.dropped.Load()
@@ -951,7 +960,7 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 				if drops >= tt.middrop {
 					break
 				}
-				time.Sleep(waitTime)
+				time.Sleep(min(waitTime, 500*time.Millisecond))
 			}
 
 			if drops != tt.middrop {
@@ -987,14 +996,27 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 
 			return nil
 		}
+		// Same polling shape as the mid-state check above: wait for both
+		// subchain state and total served count to settle before asserting.
+		endserved := func() uint64 {
+			var s uint64
+			for _, peer := range tt.peers {
+				s += peer.served.Load()
+			}
+			if tt.newPeer != nil {
+				s += tt.newPeer.served.Load()
+			}
+			return s
+		}
 		waitStart = time.Now()
 
-		for waitTime := 20 * time.Millisecond; time.Since(waitStart) < 2*time.Second; waitTime = waitTime * 2 {
-			time.Sleep(waitTime)
-			// Check the post-init end state if it matches the required results
+		for waitTime := 20 * time.Millisecond; time.Since(waitStart) < 30*time.Second; waitTime = waitTime * 2 {
+			time.Sleep(min(waitTime, 500*time.Millisecond))
 			json.Unmarshal(rawdb.ReadSkeletonSyncStatus(db), &progress)
-
-			if err := check(); err == nil {
+			if err := check(); err != nil {
+				continue
+			}
+			if tt.unpredictable || endserved() >= tt.endserve {
 				break
 			}
 		}
@@ -1005,23 +1027,14 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 		}
 		// Check that the peers served no more headers than we actually needed
 		if !tt.unpredictable {
-			served := uint64(0)
-			for _, peer := range tt.peers {
-				served += peer.served.Load()
-			}
-
-			if tt.newPeer != nil {
-				served += tt.newPeer.served.Load()
-			}
-
-			if served != tt.endserve {
+			if served := endserved(); served != tt.endserve {
 				t.Errorf("test %d, end state: served headers mismatch: have %d, want %d", i, served, tt.endserve)
 			}
 
 			// Wait for expected peer drops (may happen asynchronously after subchain state updates)
 			var drops uint64
 			waitStart = time.Now()
-			for waitTime := 20 * time.Millisecond; time.Since(waitStart) < 2*time.Second; waitTime = waitTime * 2 {
+			for waitTime := 20 * time.Millisecond; time.Since(waitStart) < 30*time.Second; waitTime = waitTime * 2 {
 				drops = 0
 				for _, peer := range tt.peers {
 					drops += peer.dropped.Load()
@@ -1032,7 +1045,7 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 				if drops >= tt.enddrop {
 					break
 				}
-				time.Sleep(waitTime)
+				time.Sleep(min(waitTime, 500*time.Millisecond))
 			}
 
 			if drops != tt.enddrop {

--- a/eth/relay/multiclient_test.go
+++ b/eth/relay/multiclient_test.go
@@ -385,10 +385,14 @@ func TestSubmitPreconfTx(t *testing.T) {
 	})
 
 	t.Run("submitPreconfTx runs in parallel", func(t *testing.T) {
-		// Ensure all calls take almost 2s of time but don't exceed rpcTimeout
+		// Each handler sleeps for half the RPC timeout. Using rpcTimeout-100ms
+		// left only 100ms of slack before the client-side timeout and flaked
+		// under -race. 1s sleep × 3 serial calls would still exceed the 2s
+		// total-deadline assertion below, so parallelism remains demonstrated.
+		handlerSleep := rpcTimeout / 2
 		for i := range rpcServers {
 			rpcServers[i].setHandleSendPreconfTx(func(w http.ResponseWriter, id int, params json.RawMessage) {
-				time.Sleep(rpcTimeout - 100*time.Millisecond)
+				time.Sleep(handlerSleep)
 				defaultHandleSendPreconfTx(w, id, params)
 			})
 		}
@@ -403,7 +407,7 @@ func TestSubmitPreconfTx(t *testing.T) {
 		require.NoError(t, err, "expected no error in submitting preconf tx")
 		require.True(t, res, "expected preconf to be offered by all BPs")
 		require.Less(t, elapsed, 2*time.Second, "expected parallel calls to finish below timeout")
-		require.Greater(t, elapsed, rpcTimeout-100*time.Millisecond, "expected calls to take at least time taken by all calls")
+		require.GreaterOrEqual(t, elapsed, handlerSleep, "expected calls to take at least time taken by all calls")
 	})
 
 	t.Run("submitPreconfTx with already known error from one BP", func(t *testing.T) {
@@ -580,10 +584,12 @@ func TestSubmitPrivateTx(t *testing.T) {
 	})
 
 	t.Run("submitPrivateTx runs in parallel", func(t *testing.T) {
-		// Reset all handlers and make each call take almost rpcTimeout
+		// Halve the handler sleep to stop crowding the client-side timeout.
+		// See the matching comment in submitPreconfTx for the same rationale.
+		handlerSleep := rpcTimeout / 2
 		for i := range rpcServers {
 			rpcServers[i].setHandleSendPrivateTx(func(w http.ResponseWriter, id int, params json.RawMessage) {
-				time.Sleep(rpcTimeout - 100*time.Millisecond)
+				time.Sleep(handlerSleep)
 				defaultHandleSendPrivateTx(w, id, params)
 			})
 		}
@@ -597,7 +603,7 @@ func TestSubmitPrivateTx(t *testing.T) {
 
 		require.NoError(t, err, "expected no error in submitting private tx")
 		require.Less(t, elapsed, 2*time.Second, "expected parallel calls to finish below total timeout")
-		require.Greater(t, elapsed, rpcTimeout-100*time.Millisecond, "expected calls to take at least the time of one call")
+		require.GreaterOrEqual(t, elapsed, handlerSleep, "expected calls to take at least the time of one call")
 	})
 
 	t.Run("submitPrivateTx with multiple BPs failing", func(t *testing.T) {
@@ -846,10 +852,16 @@ func TestCheckTxStatus(t *testing.T) {
 	})
 
 	t.Run("checkTxStatus runs in parallel", func(t *testing.T) {
-		// All calls take almost rpcTimeout but don't exceed it
+		// Each handler sleeps for half the RPC timeout. The original margin
+		// (rpcTimeout - 100ms) left only 100ms of slack before the client-side
+		// timeout fired — under -race that slack is easily exhausted and the
+		// test spuriously sees context-deadline-exceeded. A 1s sleep still
+		// proves parallelism: 3 serial calls would take ~3s, far above the
+		// 2s total deadline.
+		handlerSleep := rpcTimeout / 2
 		for i := range rpcServers {
 			rpcServers[i].setHandleTxStatus(func(w http.ResponseWriter, id int, params json.RawMessage) {
-				time.Sleep(rpcTimeout - 100*time.Millisecond)
+				time.Sleep(handlerSleep)
 				makeTxStatusHandler(map[common.Hash]txpool.TxStatus{
 					tx1.Hash(): txpool.TxStatusPending,
 				})(w, id, params)
@@ -866,7 +878,7 @@ func TestCheckTxStatus(t *testing.T) {
 		require.NoError(t, err, "expected no error in checking tx status")
 		require.True(t, res, "expected result to be true")
 		require.Less(t, elapsed, 2*time.Second, "expected parallel calls to finish below total timeout")
-		require.Greater(t, elapsed, rpcTimeout-100*time.Millisecond, "expected calls to take at least the time of one call")
+		require.GreaterOrEqual(t, elapsed, handlerSleep, "expected calls to take at least the time of one call")
 	})
 
 	t.Run("checkTxStatus with some failing servers after initialization", func(t *testing.T) {

--- a/internal/ethapi/bor_api_test.go
+++ b/internal/ethapi/bor_api_test.go
@@ -1401,13 +1401,16 @@ func (b *testBackendWithPreMadhuguriBorReceipt) GetBorBlockReceipt(_ context.Con
 }
 
 func (b *testBackendWithPreMadhuguriBorReceipt) ChainConfig() *params.ChainConfig {
-	// Return config with Bor but MadhugiriBlock unset (nil) for pre-Madhuguri behavior
+	// Return config with Bor but MadhugiriBlock unset (nil) for pre-Madhuguri behavior.
+	// Deep-copy BorConfig so we never mutate the shared params.AllEthashProtocolChanges.Bor
+	// instance — concurrent tests read those fields and would race with us.
 	cfg := *params.AllEthashProtocolChanges
-	if cfg.Bor == nil {
-		cfg.Bor = &params.BorConfig{}
+	borCfg := params.BorConfig{}
+	if cfg.Bor != nil {
+		borCfg = *cfg.Bor
 	}
-	// Ensure MadhugiriBlock is nil so IsMadhugiri returns false
-	cfg.Bor.MadhugiriBlock = nil
+	borCfg.MadhugiriBlock = nil
+	cfg.Bor = &borCfg
 	return &cfg
 }
 

--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -104,24 +104,43 @@ func TestExpDecaySample(t *testing.T) {
 // nanosecond duration since start rather than second duration since start.
 // The priority becomes +Inf quickly after starting if this is done,
 // effectively freezing the set of samples until a rescale step happens.
+//
+// Uses the unexported update() with synthesised monotonic timestamps and a
+// seeded RNG so the test is not sensitive to wall-clock jitter or scheduler
+// delay under -race. The regression this test guards against is priority
+// overflow, which would freeze the reservoir at the first batch and stick the
+// average at 10 — any determinism-preserving setup still reproduces that
+// signal.
 func TestExpDecaySampleNanosecondRegression(t *testing.T) {
-	sw := NewExpDecaySample(100, 0.99)
-	for i := 0; i < 100; i++ {
-		sw.Update(10)
-	}
-	time.Sleep(1 * time.Millisecond)
+	sw := NewExpDecaySample(100, 0.99).(*ExpDecaySample)
+	sw.SetRand(rand.New(rand.NewSource(1)))
 
+	// Anchor t0 so update() sees positive dt and matches the original
+	// wall-clock version's timing shape: a tight burst of nanosecond-spaced
+	// samples, a 1ms gap, then another tight burst. The gap makes batch-2's
+	// priorities systematically higher and drives the reservoir average into
+	// [14, 16]. NewExpDecaySample set t0 to time.Now(); we reset both t0 and
+	// the rescale marker t1 to stay clock-independent.
+	sw.t0 = time.Unix(0, 0)
+	sw.t1 = sw.t0.Add(rescaleThreshold)
+
+	step := 100 * time.Nanosecond
+	base := sw.t0
 	for i := 0; i < 100; i++ {
-		sw.Update(20)
+		sw.update(base.Add(time.Duration(i)*step), 10)
 	}
+	base = sw.t0.Add(1 * time.Millisecond).Add(100 * step)
+	for i := 0; i < 100; i++ {
+		sw.update(base.Add(time.Duration(i)*step), 20)
+	}
+
 	v := sw.Snapshot().values
 	avg := float64(0)
-
 	for i := 0; i < len(v); i++ {
 		avg += float64(v[i])
 	}
-
 	avg /= float64(len(v))
+
 	if avg > 16 || avg < 14 {
 		t.Errorf("out of range [14, 16]: %v\n", avg)
 	}


### PR DESCRIPTION
The nightly-race workflow had been failing on every run for a month. Most failures were either race-detector overhead pushing test timings past narrow assertion margins, tests mutating shared global state that collided with parallel tests, or a single real data race that cascaded into many victim tests.

internal/ethapi: testBackendWithPreMadhuguriBorReceipt.ChainConfig() did a shallow copy of params.AllEthashProtocolChanges, leaving cfg.Bor aliased to the global BorConfig, then mutated MadhugiriBlock on it. Concurrent tests calling IsMadhugiri raced with the write. Deep-copy BorConfig like the sibling testBackendWithNilBorTx already does. This single race was the root cause of the ~10 cascading ethapi test failures (TestBorForks, TestBorGetLogs_*, TestCoinbase, TestEstimateGas, etc.).

consensus/bor/heimdall: TestFailover_SwitchOnPrimaryDown and TestRegistry_MarkUnhealthyOnRealFailure set only getSpanFn on the primary mock, leaving FetchStatus returning success. The registry's background probe then raced with the test's MarkUnhealthy call and could flip the primary back to healthy (or the active gauge back to 0) before the assertion ran. Make the primary mock fail FetchStatus too so probe and API are consistent.

core/state: TestConcurrentUsedParallelism measures wall-clock parallel speedup and asserts >=2x. Race instrumentation serializes atomic/mutex ops and skews the measurement to ~1.7x. Skip under -race via a new race_{on,off}_test.go build-tag pair; the test still guards against the global-lock regression in non-race runs.

core/txpool/legacypool: TestLockOrdering_{PricedHeapNoDeadlock, ReplacePendingNoDeadlock,RemovedNoDeadlock} used a 10s deadlock-detect timeout that is genuinely too short once -race instrumentation is added (the bare test takes ~12s). Bump to 60s — still catches real deadlocks, no longer fires on legitimate completion.

eth/downloader: TestBeaconSync68/69Full used a 3s sync timeout that CI routinely exceeded under -race. Bump to 30s.
TestSkeletonSyncRetrievals had four 2s polling loops that could exit before background serving goroutines finished incrementing the served counter (the assertion then read a partial count). Bump the budget to 30s, cap per-iteration sleep at 500ms so exponential backoff stays responsive, and fold the served counter into the polling condition so we wait for both subchain state and served totals before asserting.

eth/relay: TestCheckTxStatus, TestSubmitPreconfTx, TestSubmitPrivateTx parallel subtests had handlers sleeping for rpcTimeout-100ms, leaving only 100ms of slack before the client-side 2s timeout fired; under -race that slack was easily exhausted. Halve the handler sleep to rpcTimeout/2 — still proves parallelism (3 serial calls would exceed the unchanged 2s upper bound) with comfortable margin for -race.

metrics: TestExpDecaySampleNanosecondRegression relied on the unseeded global RNG and wall-clock timing, making the reservoir's average a noisy statistic that occasionally drifted outside [14, 16] under -race. Drive the test with a seeded RNG and synthesised monotonic timestamps; override t0/t1 after NewExpDecaySample so dt in update() stays positive. Test still catches the priority-overflow regression (average would stick at 10 under the buggy formula).