### PR TITLE
eth: cancel milestone subscriber on shutdown

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -754,8 +754,9 @@ func (s *Ethereum) startCheckpointWhitelistService() {
 	s.retryHeimdallHandler(s.fetchAndHandleWhitelistCheckpoint, tickerDuration, whitelistTimeout)
 }
 
-// startMilestoneWhitelistService starts the goroutine to fetch milestiones and update the
-// milestone whitelist map.
+// startMilestoneWhitelistService starts the goroutine that updates the milestone whitelist map.
+// It subscribes to milestone events from heimdall via websocket when available, and falls back
+// to polling otherwise.
 func (s *Ethereum) startMilestoneWhitelistService() {
 	ethHandler, bor, _ := s.getHandler()
 
@@ -763,10 +764,17 @@ func (s *Ethereum) startMilestoneWhitelistService() {
 		tickerDuration = 2 * time.Second
 	)
 
-	// If heimdall ws is available use WS subscription to new milestone events instead of polling
+	// If heimdall WS is available, use WS subscription for new milestone events instead of polling
 	if bor != nil && bor.HeimdallWSClient != nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			<-s.closeCh
+			cancel()
+		}()
+
 		for {
-			if err := s.subscribeAndHandleMilestone(context.Background(), ethHandler, bor); err != nil {
+			if err := s.subscribeAndHandleMilestone(ctx, ethHandler, bor); err != nil {
 				log.Error("Error subscribing to milestone events", "err", err)
 			}
 
@@ -775,7 +783,7 @@ func (s *Ethereum) startMilestoneWhitelistService() {
 			case <-s.closeCh:
 				return
 			case <-time.After(tickerDuration):
-				// Continue to retry subscribing to milestone event
+				// Continue to retry subscribing to milestone events
 			}
 		}
 	}


### PR DESCRIPTION
# Description

The Heimdall milestone WS subscriber in `startMilestoneWhitelistService` was launched with `context.Background()`, so it kept running after `close(s.closeCh)` and outlived `s.chainDb.Close()`. 

Logs:
```sh
INFO  Persisting dirty state head=86,085,215 ...                      ← chainDb about to close
INFO  Whitelisting milestone deferred err="chain out of sync"
ERROR error handling milestone ws event err="chain out of sync"
ERROR Failed to store the lock field struct err="pebble: closed"
ERROR Error in writing lock data of milestone to db err="...: pebble: closed for lock field struct"
ERROR Failed to store the future milestone field struct err="pebble: closed"
ERROR connection lost; will attempt to reconnect on heimdall ws subscription error="websocket: close 1006"
INFO  successfully connected on heimdall ws subscription url=ws://localhost:26657/websocket
```

After the fix, the subscriber returns as soon as closeCh closes, and none of the above appear post-shutdown.