### PR TITLE
rawdb: recover witness size from filesystem metadata miss

### DIFF
--- a/core/rawdb/accessors_state.go
+++ b/core/rawdb/accessors_state.go
@@ -311,12 +311,21 @@ func HasWitness(db ethdb.Reader, blockHash common.Hash) bool {
 func ReadWitnessSize(db ethdb.KeyValueReader, blockHash common.Hash) *uint64 {
 	log.Debug("ReadWitnessSize", "blockHash", blockHash)
 	data, err := db.Get(witnessSizeKey(blockHash))
-	if err != nil || len(data) == 0 {
-		return nil
+	if err == nil && len(data) != 0 {
+		number := binary.BigEndian.Uint64(data)
+		return &number
 	}
 
-	number := binary.BigEndian.Uint64(data)
-	return &number
+	// In filesystem witness mode, recover missing DB metadata by checking the
+	// persisted witness file size.
+	if wsdb, ok := db.(witnessStoreDB); ok {
+		if fsws, ok := wsdb.WitnessStore().(*fsWitnessStore); ok {
+			if size := fsws.readWitnessSizeFromFile(blockHash); size != nil {
+				return size
+			}
+		}
+	}
+	return nil
 }
 
 func WriteWitness(db ethdb.KeyValueWriter, blockHash common.Hash, witness []byte) {

--- a/core/rawdb/database_witness_test.go
+++ b/core/rawdb/database_witness_test.go
@@ -72,6 +72,41 @@ func TestOpen_FSWitnessStore(t *testing.T) {
 	}
 }
 
+// TestOpen_FSWitnessStore_ReadWitnessSizeFallbackToFile verifies that when
+// witness size metadata is missing from DB, ReadWitnessSize recovers it from
+// the filesystem-backed witness blob.
+func TestOpen_FSWitnessStore_ReadWitnessSizeFallbackToFile(t *testing.T) {
+	witnessDir := filepath.Join(t.TempDir(), "witnesses")
+
+	db, err := Open(memorydb.New(), OpenOptions{
+		DisableFreeze:    true,
+		WitnessFileStore: true,
+		WitnessStoreDir:  witnessDir,
+	})
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	ws := db.(witnessStoreDB).WitnessStore()
+	hash := testHash(111)
+	payload := []byte("fs-size-fallback")
+	ws.WriteWitness(hash, payload)
+
+	// Simulate crash residue: file exists but DB size metadata is missing.
+	if err := db.Delete(witnessSizeKey(hash)); err != nil {
+		t.Fatalf("failed to delete witness size key: %v", err)
+	}
+
+	size := ReadWitnessSize(db, hash)
+	if size == nil {
+		t.Fatal("expected witness size fallback from filesystem")
+	}
+	if *size != uint64(len(payload)) {
+		t.Fatalf("unexpected fallback size: want %d, got %d", len(payload), *size)
+	}
+}
+
 // TestOpen_FSWitnessStore_FlagTrueButDirEmpty verifies that when
 // WitnessFileStore is true but WitnessStoreDir is empty, the DB backend
 // is used instead (guard against misconfiguration).

--- a/core/rawdb/witness_store_fs.go
+++ b/core/rawdb/witness_store_fs.go
@@ -42,6 +42,17 @@ func (s *fsWitnessStore) ReadWitness(hash common.Hash) []byte {
 	return ReadWitness(s.db, hash)
 }
 
+// readWitnessSizeFromFile returns the on-disk witness size for the given hash.
+// It is used as a recovery fallback when DB size metadata is missing.
+func (s *fsWitnessStore) readWitnessSizeFromFile(hash common.Hash) *uint64 {
+	info, err := os.Stat(witnessFilePath(s.dir, hash))
+	if err != nil || !info.Mode().IsRegular() {
+		return nil
+	}
+	size := uint64(info.Size())
+	return &size
+}
+
 func (s *fsWitnessStore) WriteWitness(hash common.Hash, witness []byte) {
 	dir := witnessDir(s.dir, hash)
 	if err := os.MkdirAll(dir, 0755); err != nil {


### PR DESCRIPTION
 # Description
                                                                                                                                                                                               
  This PR fixes a data-consistency bug in filesystem-backed witness storage.                                                                                                                   
                                                                                                                                                                                               
  fsWitnessStore.WriteWitness writes witness blobs to disk first (tmp + rename) and writes witnessSizeKey to DB afterward. If the file write succeeds but DB Put fails, the process exits via log.Crit. After restart, the file may exist while DB size metadata is missing.                                                                                                               
                                                                                                                                                                                               
  Before this change, ReadWitnessSize only read DB metadata and returned nil when missing. In WIT pagination/metadata paths, that becomes 0/unavailable, which can silently fail witness page  serving for data that is actually present on disk.                                                                                                                                           
                                                                                                                                                                                               
  This PR adds a fallback in ReadWitnessSize: when DB size metadata is missing and witness storage is filesystem-backed, size is recovered from os.Stat on the witness file. A unit test was  added to validate this crash-residue scenario (file exists + size key missing).                                                                                                              
                                                                                                                                                                                               
  # Changes                                                                                                                                                                                    
                                                                                                                                                                                               
  - [x] Bugfix (non-breaking change that solves an issue)                                                                                                                                      
  - [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)                                                                                                          
  - [ ] New feature (non-breaking change that adds functionality)                                                                                                                              
  - [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)                                                                                         
  - [x] Changes only for a subset of nodes                                                                                                                                                     
                                                                                                                                                                                               
  # Breaking changes                                                                                                                                                                           
                                                                                                                                                                                               
  None.                                                                                                                                                                                        
                                                                                                                                                                                               
  # Nodes audience                                                                                                                                                                             
                                                                                                                                                                                               
  This primarily affects nodes using filesystem witness storage (--witness.filestore) and only on recovery paths where DB size metadata is missing while witness files exist on disk.          
                                                                                                                                                                                               
  No new flags or config behavior changes were introduced.                                                                                                                                     
                                                                                                                                                                                               
  # Checklist                                                                                                                                                                                  
                                                                                                                                                                                               
  - [ ] I have added at least 2 reviewer or the whole pos-v1 team                                                                                                                              
  - [x] I have added sufficient documentation in code                                                                                                                                          
  - [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply                                                      
  - [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)                                                                                       
  - [ ] Includes RPC methods changes, and the Notion documentation has been updated                                                                                                            
                                                                                                                                                                                               
  # Cross repository changes                                                                                                                                                                   
                                                                                                                                                                                               
  - [ ] This PR requires changes to heimdall                                                                                                                                                   
    Heimdall PR link: N/A                                                                                                                                                                      
  - [ ] This PR requires changes to matic-cli                                                                                                                                                  
    matic-cli PR link: N/A                                                                                                                                                                     
                                                                                                                                                                                               
  ## Testing                                                                                                                                                                                   
                                                                                                                                                                                               
  - [x] I have added unit tests                                                                                                                                                                
  - [ ] I have added tests to CI                                                                                                                                                               
  - [ ] I have tested this code manually on local environment                                                                                                                                  
  - [ ] I have tested this code manually on remote devnet using express-cli                                                                                                                    
  - [ ] I have tested this code manually on amoy                                                                                                                                               
  - [ ] I have created new e2e tests into express-cli                                                                                                                                          
                                                                                                                                                                                               
  ### Manual tests                                                                                                                                                                             
                                                                                                                                                                                               
  Not executed in this cycle.                                                                                                                                                                  
  Note: full Go test/build validation is currently blocked unless Go >=1.26.2 toolchain is available (project go.mod requirement).                                                             
                                                                                                                                                                                               
  # Additional comments                                                                                                                                                                        
                                                                                                                                                                                               
  Added unit test:                                                                                                                                                                             
                                                                                                                                                                                               
  - core/rawdb/database_witness_test.go                                                                                                                                                        
  - TestOpen_FSWitnessStore_ReadWitnessSizeFallbackToFile   