### PR TITLE
internal/ethapi: unify relay endpoints and rate limit tx submissions

### DIFF
--- a/eth/api_backend_test.go
+++ b/eth/api_backend_test.go
@@ -295,7 +295,7 @@ func TestRelayMethodWiring(t *testing.T) {
 
 	t.Run("all flags enabled", func(t *testing.T) {
 		t.Parallel()
-		rs := relay.Init(true, true, true, true, nil)
+		rs := relay.Init(true, true, true, true, nil, 0, 0)
 		defer rs.Close()
 		b := &EthAPIBackend{relay: rs}
 
@@ -307,7 +307,7 @@ func TestRelayMethodWiring(t *testing.T) {
 
 	t.Run("all flags disabled", func(t *testing.T) {
 		t.Parallel()
-		rs := relay.Init(false, false, false, false, nil)
+		rs := relay.Init(false, false, false, false, nil, 0, 0)
 		defer rs.Close()
 		b := &EthAPIBackend{relay: rs}
 
@@ -321,7 +321,7 @@ func TestRelayMethodWiring(t *testing.T) {
 		t.Parallel()
 		// Init with enablePreconf=true, enablePrivateTx=true but no URLs
 		// → txRelay created with nil multiclient → methods return errors, proving wiring works
-		rs := relay.Init(true, true, false, false, nil)
+		rs := relay.Init(true, true, false, false, nil, 0, 0)
 		defer rs.Close()
 		b := &EthAPIBackend{relay: rs}
 
@@ -339,7 +339,7 @@ func TestRelayMethodWiring(t *testing.T) {
 
 	t.Run("record and purge private tx do not panic", func(t *testing.T) {
 		t.Parallel()
-		rs := relay.Init(false, false, false, true, nil) // creates privateTxStore
+		rs := relay.Init(false, false, false, true, nil, 0, 0) // creates privateTxStore
 		defer rs.Close()
 		b := &EthAPIBackend{relay: rs}
 
@@ -368,7 +368,7 @@ func TestRelayGracefulShutdownOnStop(t *testing.T) {
 		t.Parallel()
 		// enablePreconf=true creates a Service with background goroutines
 		// (processPreconfTasks, cleanup). Close() must signal them and wait.
-		rs := relay.Init(true, true, true, true, nil)
+		rs := relay.Init(true, true, true, true, nil, 0, 0)
 		b := &EthAPIBackend{relay: rs}
 
 		require.True(t, b.PreconfEnabled(), "relay should be operational before shutdown")

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -230,7 +230,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		closeCh:         make(chan struct{}),
 	}
 
-	relayService := relay.Init(config.EnablePreconfs, config.EnablePrivateTx, config.AcceptPreconfTx, config.AcceptPrivateTx, config.BlockProducerRpcEndpoints)
+	relayService := relay.Init(config.EnablePreconfs, config.EnablePrivateTx, config.AcceptPreconfTx, config.AcceptPrivateTx, config.BlockProducerRpcEndpoints, config.MaxConcurrentPreconfs, config.MaxConcurrentPrivateTxs)
 	privateTxGetter := relayService.GetPrivateTxGetter()
 
 	// START: Bor changes

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -324,6 +324,8 @@ type Config struct {
 	EnablePreconfs            bool
 	EnablePrivateTx           bool
 	BlockProducerRpcEndpoints []string
+	MaxConcurrentPreconfs     uint64
+	MaxConcurrentPrivateTxs   uint64
 
 	// Preconf / Private transaction related settings for block producers
 	AcceptPreconfTx bool

--- a/eth/relay/relay.go
+++ b/eth/relay/relay.go
@@ -32,7 +32,7 @@ type RelayService struct {
 	txRelay        *Service
 }
 
-func Init(enablePreconf, enablePrivateTx, acceptPreconfTx, acceptPrivateTx bool, blockProducerURLs []string) *RelayService {
+func Init(enablePreconf, enablePrivateTx, acceptPreconfTx, acceptPrivateTx bool, blockProducerURLs []string, maxConcurrentPreconfs, maxConcurrentPrivateTxs uint64) *RelayService {
 	config := Config{
 		enablePreconf:   enablePreconf,
 		enablePrivateTx: enablePrivateTx,
@@ -48,7 +48,16 @@ func Init(enablePreconf, enablePrivateTx, acceptPreconfTx, acceptPrivateTx bool,
 		if len(blockProducerURLs) == 0 {
 			log.Warn("Relay service enabled but no block producer URLs provided; relay will be non-functional")
 		}
-		txRelay = NewService(blockProducerURLs, nil)
+		// Build a service config from defaults, then override the two
+		// operator-tunable concurrency caps when callers supplied non-zero values.
+		serviceConfig := DefaultServiceConfig
+		if maxConcurrentPreconfs > 0 {
+			serviceConfig.maxConcurrentPreconfs = maxConcurrentPreconfs
+		}
+		if maxConcurrentPrivateTxs > 0 {
+			serviceConfig.maxConcurrentPrivateTxs = maxConcurrentPrivateTxs
+		}
+		txRelay = NewService(blockProducerURLs, &serviceConfig)
 	}
 	return &RelayService{
 		config:         config,

--- a/eth/relay/relay_test.go
+++ b/eth/relay/relay_test.go
@@ -12,7 +12,7 @@ func TestInit(t *testing.T) {
 	t.Parallel()
 
 	t.Run("all flags disabled creates neither component", func(t *testing.T) {
-		rs := Init(false, false, false, false, nil)
+		rs := Init(false, false, false, false, nil, 0, 0)
 		defer rs.Close()
 
 		require.Nil(t, rs.txRelay, "expected nil txRelay when all flags disabled")
@@ -20,7 +20,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("enablePreconf only creates txRelay", func(t *testing.T) {
-		rs := Init(true, false, false, false, nil)
+		rs := Init(true, false, false, false, nil, 0, 0)
 		defer rs.Close()
 
 		require.NotNil(t, rs.txRelay, "expected txRelay when enablePreconf is true")
@@ -28,7 +28,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("enablePrivateTx creates both components", func(t *testing.T) {
-		rs := Init(false, true, false, false, nil)
+		rs := Init(false, true, false, false, nil, 0, 0)
 		defer rs.Close()
 
 		require.NotNil(t, rs.txRelay, "expected txRelay when enablePrivateTx is true")
@@ -36,7 +36,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("acceptPreconfTx only creates neither component", func(t *testing.T) {
-		rs := Init(false, false, true, false, nil)
+		rs := Init(false, false, true, false, nil, 0, 0)
 		defer rs.Close()
 
 		require.Nil(t, rs.txRelay, "expected nil txRelay when only acceptPreconfTx is true")
@@ -44,7 +44,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("acceptPrivateTx only creates store", func(t *testing.T) {
-		rs := Init(false, false, false, true, nil)
+		rs := Init(false, false, false, true, nil, 0, 0)
 		defer rs.Close()
 
 		require.Nil(t, rs.txRelay, "expected nil txRelay when only acceptPrivateTx is true")
@@ -55,7 +55,7 @@ func TestInit(t *testing.T) {
 		server := newMockRpcServer()
 		defer server.close()
 
-		rs := Init(true, true, true, true, []string{server.server.URL})
+		rs := Init(true, true, true, true, []string{server.server.URL}, 0, 0)
 		defer rs.Close()
 
 		require.NotNil(t, rs.txRelay, "expected txRelay when all flags enabled")
@@ -63,7 +63,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("empty URLs creates txRelay with nil multiclient", func(t *testing.T) {
-		rs := Init(true, false, false, false, []string{})
+		rs := Init(true, false, false, false, []string{}, 0, 0)
 		defer rs.Close()
 
 		require.NotNil(t, rs.txRelay, "expected txRelay to be created")
@@ -74,7 +74,7 @@ func TestInit(t *testing.T) {
 		server := newMockRpcServer()
 		defer server.close()
 
-		rs := Init(true, false, false, false, []string{server.server.URL})
+		rs := Init(true, false, false, false, []string{server.server.URL}, 0, 0)
 		defer rs.Close()
 
 		require.NotNil(t, rs.txRelay, "expected txRelay to be created")
@@ -85,7 +85,7 @@ func TestInit(t *testing.T) {
 func TestConfigAccessors(t *testing.T) {
 	t.Parallel()
 
-	rs := Init(true, false, true, false, nil)
+	rs := Init(true, false, true, false, nil, 0, 0)
 	defer rs.Close()
 
 	require.True(t, rs.PreconfEnabled(), "expected PreconfEnabled to be true")
@@ -98,7 +98,7 @@ func TestRelaySubmitPreconfTransaction(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns wrapped error when txRelay is nil", func(t *testing.T) {
-		rs := Init(false, false, false, false, nil)
+		rs := Init(false, false, false, false, nil, 0, 0)
 		defer rs.Close()
 
 		tx := types.NewTransaction(1, common.Address{}, nil, 0, nil, nil)
@@ -110,7 +110,7 @@ func TestRelaySubmitPreconfTransaction(t *testing.T) {
 
 	t.Run("wraps underlying service error", func(t *testing.T) {
 		// Empty URLs → nil multiclient → SubmitTransactionForPreconf returns errRpcClientUnavailable
-		rs := Init(true, false, false, false, []string{})
+		rs := Init(true, false, false, false, []string{}, 0, 0)
 		defer rs.Close()
 
 		tx := types.NewTransaction(1, common.Address{}, nil, 0, nil, nil)
@@ -124,7 +124,7 @@ func TestRelaySubmitPreconfTransaction(t *testing.T) {
 		server := newMockRpcServer()
 		defer server.close()
 
-		rs := Init(true, false, false, false, []string{server.server.URL})
+		rs := Init(true, false, false, false, []string{server.server.URL}, 0, 0)
 		defer rs.Close()
 
 		tx := types.NewTransaction(1, common.Address{}, nil, 0, nil, nil)
@@ -137,7 +137,7 @@ func TestRelaySubmitPrivateTransaction(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns wrapped error when txRelay is nil", func(t *testing.T) {
-		rs := Init(false, false, false, false, nil)
+		rs := Init(false, false, false, false, nil, 0, 0)
 		defer rs.Close()
 
 		tx := types.NewTransaction(1, common.Address{}, nil, 0, nil, nil)
@@ -150,7 +150,7 @@ func TestRelaySubmitPrivateTransaction(t *testing.T) {
 	t.Run("returns unwrapped error from underlying service", func(t *testing.T) {
 		// Empty URLs → nil multiclient → SubmitPrivateTx returns errRpcClientUnavailable
 		// SubmitPrivateTransaction returns it as-is (no "request dropped:" wrapping)
-		rs := Init(false, true, false, false, []string{})
+		rs := Init(false, true, false, false, []string{}, 0, 0)
 		defer rs.Close()
 
 		tx := types.NewTransaction(1, common.Address{}, nil, 0, nil, nil)
@@ -165,7 +165,7 @@ func TestRelaySubmitPrivateTransaction(t *testing.T) {
 		server := newMockRpcServer()
 		defer server.close()
 
-		rs := Init(false, true, false, false, []string{server.server.URL})
+		rs := Init(false, true, false, false, []string{server.server.URL}, 0, 0)
 		defer rs.Close()
 
 		tx := types.NewTransaction(1, common.Address{}, nil, 0, nil, nil)
@@ -178,7 +178,7 @@ func TestRelayCheckPreconfStatus(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns wrapped error when txRelay is nil", func(t *testing.T) {
-		rs := Init(false, false, false, false, nil)
+		rs := Init(false, false, false, false, nil, 0, 0)
 		defer rs.Close()
 
 		hash := common.HexToHash("0x1")
@@ -191,7 +191,7 @@ func TestRelayCheckPreconfStatus(t *testing.T) {
 
 	t.Run("wraps underlying service error", func(t *testing.T) {
 		// Empty URLs → nil multiclient → CheckTxPreconfStatus returns errRpcClientUnavailable
-		rs := Init(true, false, false, false, []string{})
+		rs := Init(true, false, false, false, []string{}, 0, 0)
 		defer rs.Close()
 
 		hash := common.HexToHash("0x1")
@@ -207,7 +207,7 @@ func TestRelayCheckPreconfStatus(t *testing.T) {
 		server := newMockRpcServer()
 		defer server.close()
 
-		rs := Init(true, false, false, false, []string{server.server.URL})
+		rs := Init(true, false, false, false, []string{server.server.URL}, 0, 0)
 		defer rs.Close()
 
 		hash := common.HexToHash("0x1")
@@ -221,7 +221,7 @@ func TestRelayClose(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no panic when both components are nil", func(t *testing.T) {
-		rs := Init(false, false, false, false, nil)
+		rs := Init(false, false, false, false, nil, 0, 0)
 		require.Nil(t, rs.txRelay)
 		require.Nil(t, rs.privateTxStore)
 
@@ -234,7 +234,7 @@ func TestRelayClose(t *testing.T) {
 		server := newMockRpcServer()
 		defer server.close()
 
-		rs := Init(true, true, true, true, []string{server.server.URL})
+		rs := Init(true, true, true, true, []string{server.server.URL}, 0, 0)
 		require.NotNil(t, rs.txRelay)
 		require.NotNil(t, rs.privateTxStore)
 
@@ -244,7 +244,7 @@ func TestRelayClose(t *testing.T) {
 	})
 
 	t.Run("no panic when only privateTxStore exists", func(t *testing.T) {
-		rs := Init(false, false, false, true, nil)
+		rs := Init(false, false, false, true, nil, 0, 0)
 		require.Nil(t, rs.txRelay)
 		require.NotNil(t, rs.privateTxStore)
 
@@ -258,7 +258,7 @@ func TestGetPrivateTxGetter(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns nil interface when store is nil", func(t *testing.T) {
-		rs := Init(false, false, false, false, nil)
+		rs := Init(false, false, false, false, nil, 0, 0)
 		defer rs.Close()
 
 		getter := rs.GetPrivateTxGetter()
@@ -266,7 +266,7 @@ func TestGetPrivateTxGetter(t *testing.T) {
 	})
 
 	t.Run("returns working getter when store exists", func(t *testing.T) {
-		rs := Init(false, false, false, true, nil)
+		rs := Init(false, false, false, true, nil, 0, 0)
 		defer rs.Close()
 
 		getter := rs.GetPrivateTxGetter()
@@ -285,7 +285,7 @@ func TestRelayNilSafety(t *testing.T) {
 	t.Parallel()
 
 	t.Run("RecordPrivateTx with nil store", func(t *testing.T) {
-		rs := Init(false, false, false, false, nil)
+		rs := Init(false, false, false, false, nil, 0, 0)
 		defer rs.Close()
 
 		require.Nil(t, rs.privateTxStore)
@@ -295,7 +295,7 @@ func TestRelayNilSafety(t *testing.T) {
 	})
 
 	t.Run("PurgePrivateTx with nil store", func(t *testing.T) {
-		rs := Init(false, false, false, false, nil)
+		rs := Init(false, false, false, false, nil, 0, 0)
 		defer rs.Close()
 
 		require.Nil(t, rs.privateTxStore)
@@ -305,7 +305,7 @@ func TestRelayNilSafety(t *testing.T) {
 	})
 
 	t.Run("SetTxGetter with nil txRelay", func(t *testing.T) {
-		rs := Init(false, false, false, false, nil)
+		rs := Init(false, false, false, false, nil, 0, 0)
 		defer rs.Close()
 
 		require.Nil(t, rs.txRelay)
@@ -317,7 +317,7 @@ func TestRelayNilSafety(t *testing.T) {
 	})
 
 	t.Run("SetchainEventSubFn with nil store", func(t *testing.T) {
-		rs := Init(false, false, false, false, nil)
+		rs := Init(false, false, false, false, nil, 0, 0)
 		defer rs.Close()
 
 		require.Nil(t, rs.privateTxStore)
@@ -330,7 +330,7 @@ func TestRelayNilSafety(t *testing.T) {
 func TestRecordAndPurgePrivateTx(t *testing.T) {
 	t.Parallel()
 
-	rs := Init(false, false, false, true, nil)
+	rs := Init(false, false, false, true, nil, 0, 0)
 	defer rs.Close()
 
 	getter := rs.GetPrivateTxGetter()

--- a/eth/relay/service.go
+++ b/eth/relay/service.go
@@ -39,17 +39,19 @@ var (
 type TxGetter func(hash common.Hash) (bool, *types.Transaction, common.Hash, uint64, uint64)
 
 type ServiceConfig struct {
-	expiryTickerInterval time.Duration
-	expiryInterval       time.Duration
-	maxQueuedTasks       int
-	maxConcurrentTasks   int
+	expiryTickerInterval    time.Duration
+	expiryInterval          time.Duration
+	maxQueuedTasks          int
+	maxConcurrentPreconfs   uint64
+	maxConcurrentPrivateTxs uint64
 }
 
 var DefaultServiceConfig = ServiceConfig{
-	expiryTickerInterval: time.Minute,
-	expiryInterval:       10 * time.Minute,
-	maxQueuedTasks:       40_000,
-	maxConcurrentTasks:   1024,
+	expiryTickerInterval:    time.Minute,
+	expiryInterval:          10 * time.Minute,
+	maxQueuedTasks:          40_000,
+	maxConcurrentPreconfs:   512,
+	maxConcurrentPrivateTxs: 2048,
 }
 
 // TxTask represents a transaction submission task
@@ -63,14 +65,15 @@ type TxTask struct {
 }
 
 type Service struct {
-	config      *ServiceConfig
-	multiclient *multiClient
-	store       map[common.Hash]TxTask
-	storeMu     sync.RWMutex
-	wg          sync.WaitGroup // tracks all active goroutines for clean shutdown
-	taskCh      chan TxTask    // channel to queue new tasks
-	semaphore   chan struct{}
-	closeCh     chan struct{} // to limit concurrent tasks
+	config           *ServiceConfig
+	multiclient      *multiClient
+	store            map[common.Hash]TxTask
+	storeMu          sync.RWMutex
+	wg               sync.WaitGroup // tracks all active goroutines for clean shutdown
+	taskCh           chan TxTask    // channel to queue new tasks
+	preconfSemaphore chan struct{}  // bounds concurrent preconf BP submissions
+	privateSemaphore chan struct{}  // bounds concurrent private-tx BP submissions
+	closeCh          chan struct{}
 
 	txGetter TxGetter // function to get transaction from local database
 }
@@ -81,12 +84,13 @@ func NewService(urls []string, config *ServiceConfig) *Service {
 		config = &defaultConfig
 	}
 	s := &Service{
-		config:      config,
-		multiclient: newMultiClient(urls),
-		store:       make(map[common.Hash]TxTask),
-		taskCh:      make(chan TxTask, config.maxQueuedTasks),
-		semaphore:   make(chan struct{}, config.maxConcurrentTasks),
-		closeCh:     make(chan struct{}),
+		config:           config,
+		multiclient:      newMultiClient(urls),
+		store:            make(map[common.Hash]TxTask),
+		taskCh:           make(chan TxTask, config.maxQueuedTasks),
+		preconfSemaphore: make(chan struct{}, config.maxConcurrentPreconfs),
+		privateSemaphore: make(chan struct{}, config.maxConcurrentPrivateTxs),
+		closeCh:          make(chan struct{}),
 	}
 	s.wg.Add(2)
 	go func() { defer s.wg.Done(); s.processPreconfTasks() }()
@@ -140,7 +144,7 @@ func (s *Service) processPreconfTasks() {
 		case task := <-s.taskCh:
 			// Acquire semaphore to limit concurrent submissions
 			select {
-			case s.semaphore <- struct{}{}:
+			case s.preconfSemaphore <- struct{}{}:
 			case <-s.closeCh:
 				log.Info("[tx-relay] Stopping preconf task processing, service closing")
 				return
@@ -148,7 +152,7 @@ func (s *Service) processPreconfTasks() {
 			s.wg.Add(1)
 			go func(task TxTask) {
 				defer s.wg.Done()
-				defer func() { <-s.semaphore }()
+				defer func() { <-s.preconfSemaphore }()
 				s.processPreconfTask(task)
 			}(task)
 		case <-s.closeCh:
@@ -282,6 +286,15 @@ func (s *Service) SubmitPrivateTx(tx *types.Transaction, retry bool) error {
 		log.Warn("[tx-relay] Failed to marshal transaction", "hash", tx.Hash(), "err", err)
 		return err
 	}
+
+	// Bound concurrent private-tx BP submissions. Block until a slot is free
+	// or the service is closing.
+	select {
+	case s.privateSemaphore <- struct{}{}:
+	case <-s.closeCh:
+		return errRpcClientUnavailable
+	}
+	defer func() { <-s.privateSemaphore }()
 
 	uniquePrivateTxRequestMeter.Mark(1)
 	start := time.Now()

--- a/eth/relay/service_test.go
+++ b/eth/relay/service_test.go
@@ -38,7 +38,8 @@ func TestNewService(t *testing.T) {
 		require.NotNil(t, service.store, "expected non-nil store")
 		require.NotNil(t, service.taskCh, "expected non-nil task channel")
 		require.Equal(t, defaultConfig.maxQueuedTasks, cap(service.taskCh), "expected task channel capacity to match maxQueuedTasks")
-		require.Equal(t, defaultConfig.maxConcurrentTasks, cap(service.semaphore), "expected semaphore capacity to match maxConcurrentTasks")
+		require.Equal(t, defaultConfig.maxConcurrentPreconfs, cap(service.preconfSemaphore), "expected preconf semaphore capacity to match maxConcurrentPreconfs")
+		require.Equal(t, defaultConfig.maxConcurrentPrivateTxs, cap(service.privateSemaphore), "expected private semaphore capacity to match maxConcurrentPrivateTxs")
 
 		service.close()
 	})
@@ -123,14 +124,14 @@ func TestSubmitTransactionForPreconf(t *testing.T) {
 		// Update the config to a reasonable size for testing
 		config := DefaultServiceConfig
 		config.maxQueuedTasks = 10
-		config.maxConcurrentTasks = 5
+		config.maxConcurrentPreconfs = 5
 
 		service := NewService(urls, &config)
 		defer service.close()
 
-		// Block the semaphore so that tasks are queued entirely
-		for i := 0; i < config.maxConcurrentTasks; i++ {
-			service.semaphore <- struct{}{}
+		// Block the preconf semaphore so that tasks are queued entirely
+		for i := 0; i < int(config.maxConcurrentPreconfs); i++ {
+			service.preconfSemaphore <- struct{}{}
 		}
 
 		// Fill the queue to full capacity. We need to do config.maxQueuedTasks+1 because
@@ -156,7 +157,7 @@ func TestSubmitTransactionForPreconf(t *testing.T) {
 		// Update the config to a reasonable size for testing
 		config := DefaultServiceConfig
 		config.maxQueuedTasks = 10
-		config.maxConcurrentTasks = 5
+		config.maxConcurrentPreconfs = 5
 
 		// Update the rpc server handlers to have a delay in processing tasks
 		for _, s := range rpcServers {
@@ -169,8 +170,8 @@ func TestSubmitTransactionForPreconf(t *testing.T) {
 		service := NewService(urls, &config)
 		defer service.close()
 
-		// Start sending `maxConcurrentTasks` tasks to block the queue
-		for i := 0; i <= config.maxConcurrentTasks; i++ {
+		// Start sending `maxConcurrentPreconfs` tasks to block the queue
+		for i := 0; i <= int(config.maxConcurrentPreconfs); i++ {
 			tx := types.NewTransaction(1, common.Address{}, nil, 0, nil, nil)
 			err := service.SubmitTransactionForPreconf(tx)
 			require.NoError(t, err, "expected no error for task %d", i)
@@ -334,6 +335,62 @@ func TestServiceSubmitPrivateTx(t *testing.T) {
 
 		wg.Wait()
 		require.Equal(t, int32(numTxs), successCount.Load(), "expected all private txs to be submitted successfully")
+	})
+
+	t.Run("releases the semaphore slot on success and on error", func(t *testing.T) {
+		service := NewService(urls, nil)
+		defer service.close()
+
+		tx := types.NewTransaction(1, common.Address{}, nil, 0, nil, nil)
+
+		// Success path: slot must be released after a clean submission.
+		err := service.SubmitPrivateTx(tx, false)
+		require.NoError(t, err, "expected clean submission")
+		require.Equal(t, 0, len(service.privateSemaphore), "private semaphore must be drained after success")
+
+		// Error path: slot must still be released when submission fails.
+		rpcServers[0].setHandleSendPrivateTx(func(w http.ResponseWriter, id int, params json.RawMessage) {
+			defaultSendError(w, id, -32601, "internal server error")
+		})
+		err = service.SubmitPrivateTx(tx, false)
+		require.Equal(t, errPrivateTxSubmissionFailed, err, "expected errPrivateTxSubmissionFailed")
+		require.Equal(t, 0, len(service.privateSemaphore), "private semaphore must be drained after error")
+		rpcServers[0].setHandleSendPrivateTx(defaultHandleSendPrivateTx)
+	})
+
+	t.Run("blocks while semaphore is full and unblocks when a slot frees", func(t *testing.T) {
+		config := DefaultServiceConfig
+		config.maxConcurrentPrivateTxs = 1
+		service := NewService(urls, &config)
+		defer service.close()
+
+		// Fill the only slot manually.
+		service.privateSemaphore <- struct{}{}
+
+		tx := types.NewTransaction(1, common.Address{}, nil, 0, nil, nil)
+		done := make(chan error, 1)
+		go func() {
+			done <- service.SubmitPrivateTx(tx, false)
+		}()
+
+		// Submission must not complete while the semaphore is full.
+		select {
+		case <-done:
+			t.Fatal("SubmitPrivateTx returned while semaphore was full")
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		// Free the slot; submission should now proceed.
+		<-service.privateSemaphore
+
+		select {
+		case err := <-done:
+			require.NoError(t, err, "expected submission to succeed once a slot freed")
+		case <-time.After(2 * time.Second):
+			t.Fatal("SubmitPrivateTx did not return after semaphore drained")
+		}
+
+		require.Equal(t, 0, len(service.privateSemaphore), "private semaphore must be drained after completion")
 	})
 }
 

--- a/eth/relay/service_test.go
+++ b/eth/relay/service_test.go
@@ -37,9 +37,9 @@ func TestNewService(t *testing.T) {
 		require.NotNil(t, service.multiclient, "expected non-nil multiclient")
 		require.NotNil(t, service.store, "expected non-nil store")
 		require.NotNil(t, service.taskCh, "expected non-nil task channel")
-		require.Equal(t, defaultConfig.maxQueuedTasks, cap(service.taskCh), "expected task channel capacity to match maxQueuedTasks")
-		require.Equal(t, defaultConfig.maxConcurrentPreconfs, cap(service.preconfSemaphore), "expected preconf semaphore capacity to match maxConcurrentPreconfs")
-		require.Equal(t, defaultConfig.maxConcurrentPrivateTxs, cap(service.privateSemaphore), "expected private semaphore capacity to match maxConcurrentPrivateTxs")
+		require.Equal(t, int(defaultConfig.maxQueuedTasks), cap(service.taskCh), "expected task channel capacity to match maxQueuedTasks")
+		require.Equal(t, int(defaultConfig.maxConcurrentPreconfs), cap(service.preconfSemaphore), "expected preconf semaphore capacity to match maxConcurrentPreconfs")
+		require.Equal(t, int(defaultConfig.maxConcurrentPrivateTxs), cap(service.privateSemaphore), "expected private semaphore capacity to match maxConcurrentPrivateTxs")
 
 		service.close()
 	})

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -805,6 +805,12 @@ type RelayConfig struct {
 
 	// BlockProducerRpcEndpoints is a list of block producer rpc endpoints to submit transactions to
 	BlockProducerRpcEndpoints []string `hcl:"bp-rpc-endpoints,optional" toml:"bp-rpc-endpoints,optional"`
+
+	// MaxConcurrentPreconfs caps concurrent preconf submissions to block producers.
+	MaxConcurrentPreconfs uint64 `hcl:"max-concurrent-preconfs,optional" toml:"max-concurrent-preconfs,optional"`
+
+	// MaxConcurrentPrivateTxs caps concurrent private-tx submissions to block producers.
+	MaxConcurrentPrivateTxs uint64 `hcl:"max-concurrent-private-tx,optional" toml:"max-concurrent-private-tx,optional"`
 }
 
 func DefaultConfig() *Config {
@@ -1066,6 +1072,8 @@ func DefaultConfig() *Config {
 			EnablePreconfs:            false,
 			EnablePrivateTx:           false,
 			BlockProducerRpcEndpoints: []string{},
+			MaxConcurrentPreconfs:     512,
+			MaxConcurrentPrivateTxs:   2048,
 		},
 	}
 }
@@ -1695,6 +1703,8 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 	n.EnablePreconfs = c.Relay.EnablePreconfs
 	n.EnablePrivateTx = c.Relay.EnablePrivateTx
 	n.BlockProducerRpcEndpoints = c.Relay.BlockProducerRpcEndpoints
+	n.MaxConcurrentPreconfs = c.Relay.MaxConcurrentPreconfs
+	n.MaxConcurrentPrivateTxs = c.Relay.MaxConcurrentPrivateTxs
 
 	// Set preconf / private transaction flags for block producers
 	n.AcceptPreconfTx = c.JsonRPC.AcceptPreconfTx

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -1424,6 +1424,20 @@ func (c *Command) Flags(config *Config) *flagset.Flagset {
 		Default: c.cliConfig.Relay.BlockProducerRpcEndpoints,
 		Group:   "P2P",
 	})
+	f.Uint64Flag(&flagset.Uint64Flag{
+		Name:    "relay.max-concurrent-preconfs",
+		Usage:   "Maximum number of concurrent preconf submissions to block producers",
+		Value:   &c.cliConfig.Relay.MaxConcurrentPreconfs,
+		Default: c.cliConfig.Relay.MaxConcurrentPreconfs,
+		Group:   "P2P",
+	})
+	f.Uint64Flag(&flagset.Uint64Flag{
+		Name:    "relay.max-concurrent-private-tx",
+		Usage:   "Maximum number of concurrent private transaction submissions to block producers",
+		Value:   &c.cliConfig.Relay.MaxConcurrentPrivateTxs,
+		Default: c.cliConfig.Relay.MaxConcurrentPrivateTxs,
+		Group:   "P2P",
+	})
 
 	return f
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2189,13 +2189,37 @@ func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil
 		}
 	}
 
-	hash, err := SubmitTransaction(ctx, api.b, tx)
+	isPrivateTxEnabled := api.b.PrivateTxEnabled()
+	if isPrivateTxEnabled {
+		// Track the tx hash to ensure it is not gossiped in public
+		api.b.RecordPrivateTx(tx.Hash())
+	}
 
-	// If preconf is enabled, submit tx directly to BP
+	hash, err := SubmitTransaction(ctx, api.b, tx)
+	if err != nil {
+		// Purge tx from private tx tracker if submission failed. Don't purge
+		// if `ErrAlreadyKnown` is being returned.
+		if isPrivateTxEnabled && !errors.Is(err, txpool.ErrAlreadyKnown) {
+			api.b.PurgePrivateTx(tx.Hash())
+		}
+		return hash, err
+	}
+
+	// If preconf is enabled, submit it to BPs
 	if api.b.PreconfEnabled() {
 		// Preconf processing mostly happens in background so don't float the error back to user
 		if err := api.b.SubmitTxForPreconf(tx); err != nil {
-			log.Error("Transaction accepted locally but submission for preconf failed", "err", err)
+			log.Error("Transaction accepted locally but submission for preconf failed", "hash", tx.Hash(), "err", err)
+		}
+	}
+
+	// Submit the private transaction directly to BPs
+	if isPrivateTxEnabled {
+		// Return an error here to inform user that private tx submission failed as it is critical.
+		// Note that it will be retried in background.
+		if err := api.b.SubmitPrivateTx(tx); err != nil {
+			log.Error("Private tx accepted locally but submission to bp failed", "hash", tx.Hash(), "err", err)
+			return tx.Hash(), fmt.Errorf("tx accepted locally, submission failed. reason: %w", err)
 		}
 	}
 
@@ -2300,7 +2324,8 @@ func (api *TransactionAPI) SendRawTransactionSync(ctx context.Context, input hex
 }
 
 // SendRawTransactionForPreconf will accept a preconf transaction from relay if enabled. It will
-// offer a soft inclusion confirmation if the transaction is accepted into the pending pool.
+// offer a soft inclusion confirmation if the transaction is accepted into the pending pool. Note
+// that this is an internal endpoint used by relay to submit transactions to block producers.
 func (api *TransactionAPI) SendRawTransactionForPreconf(ctx context.Context, input hexutil.Bytes) (map[string]interface{}, error) {
 	if !api.b.AcceptPreconfTxs() {
 		return nil, errors.New("preconf transactions are not accepted on this node")
@@ -2355,10 +2380,12 @@ func (api *TransactionAPI) SendRawTransactionPrivate(ctx context.Context, input 
 	api.b.RecordPrivateTx(tx.Hash())
 
 	hash, err := SubmitTransaction(ctx, api.b, tx)
-	// Purge tx from private tx tracker if submission failed. Don't purge
-	// if `ErrAlreadyKnown` is being returned.
-	if err != nil && !errors.Is(err, txpool.ErrAlreadyKnown) {
-		api.b.PurgePrivateTx(tx.Hash())
+	if err != nil {
+		// Purge tx from private tx tracker if submission failed. Don't purge
+		// if `ErrAlreadyKnown` is being returned.
+		if !errors.Is(err, txpool.ErrAlreadyKnown) {
+			api.b.PurgePrivateTx(tx.Hash())
+		}
 		return hash, err
 	}
 
@@ -2367,8 +2394,8 @@ func (api *TransactionAPI) SendRawTransactionPrivate(ctx context.Context, input 
 		// Return an error here to inform user that private tx submission failed as it is critical.
 		// Note that it will be retried in background.
 		if err := api.b.SubmitPrivateTx(tx); err != nil {
-			log.Error("Private tx accepted locally but submission to bp failed", "err", err)
-			return tx.Hash(), fmt.Errorf("private tx accepted locally, submission failed. reason: %w", err)
+			log.Error("Private tx accepted locally but submission to bp failed", "hash", tx.Hash(), "err", err)
+			return tx.Hash(), fmt.Errorf("tx accepted locally, submission failed. reason: %w", err)
 		}
 	}
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -4802,7 +4802,7 @@ func TestSendRawTransactionPrivate(t *testing.T) {
 
 		hash, err := api.SendRawTransactionPrivate(context.Background(), raw)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "private tx accepted locally, submission failed")
+		require.Contains(t, err.Error(), "tx accepted locally, submission failed")
 		require.Contains(t, err.Error(), "relay down")
 		require.Equal(t, tx.Hash(), hash, "hash should be returned even on SubmitPrivateTx failure")
 	})
@@ -4942,24 +4942,28 @@ func TestTxPoolAPI_TxStatus(t *testing.T) {
 func TestSendRawTransaction_PreconfPath(t *testing.T) {
 	t.Parallel()
 
-	t.Run("preconf disabled, SubmitTxForPreconf not called", func(t *testing.T) {
+	t.Run("neither flag enabled, no relay calls", func(t *testing.T) {
 		t.Parallel()
 		genesis := &core.Genesis{Config: params.TestChainConfig, Alloc: types.GenesisAlloc{}}
 		b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
-		// preconfEnabled defaults to false
+		// preconfEnabled and privateTxEnabled both default to false
 
-		var preconfCount atomic.Int32
-		b.submitTxForPreconfFn = func(tx *types.Transaction) error {
-			preconfCount.Add(1)
-			return nil
-		}
+		var preconfCount, submitPrivateCount, recordCount, purgeCount atomic.Int32
+		b.submitTxForPreconfFn = func(*types.Transaction) error { preconfCount.Add(1); return nil }
+		b.submitPrivateTxFn = func(*types.Transaction) error { submitPrivateCount.Add(1); return nil }
+		b.recordPrivateTxFn = func(common.Hash) { recordCount.Add(1) }
+		b.purgePrivateTxFn = func(common.Hash) { purgeCount.Add(1) }
 
 		api := NewTransactionAPI(b, new(AddrLocker))
-		raw, _ := makeSelfSignedRaw(t, api, b.acc.Address)
+		raw, tx := makeSelfSignedRaw(t, api, b.acc.Address)
 
-		_, err := api.SendRawTransaction(context.Background(), raw)
-		require.NoError(t, err)
+		hash, err := api.SendRawTransaction(context.Background(), raw)
+		require.NoError(t, err, "endpoint must work for non-relay nodes")
+		require.Equal(t, tx.Hash(), hash)
 		require.Equal(t, int32(0), preconfCount.Load(), "SubmitTxForPreconf should NOT be called when preconf is disabled")
+		require.Equal(t, int32(0), submitPrivateCount.Load(), "SubmitPrivateTx should NOT be called when private is disabled")
+		require.Equal(t, int32(0), recordCount.Load(), "RecordPrivateTx should NOT be called when private is disabled")
+		require.Equal(t, int32(0), purgeCount.Load(), "PurgePrivateTx should NOT be called when private is disabled")
 	})
 
 	t.Run("preconf enabled, SubmitTxForPreconf called", func(t *testing.T) {
@@ -5001,6 +5005,194 @@ func TestSendRawTransaction_PreconfPath(t *testing.T) {
 		hash, err := api.SendRawTransaction(context.Background(), raw)
 		require.NoError(t, err, "SendRawTransaction should NOT propagate SubmitTxForPreconf errors")
 		require.Equal(t, tx.Hash(), hash)
+	})
+}
+
+func TestSendRawTransaction_Unified(t *testing.T) {
+	t.Parallel()
+
+	t.Run("private only, success path", func(t *testing.T) {
+		t.Parallel()
+		genesis := &core.Genesis{Config: params.TestChainConfig, Alloc: types.GenesisAlloc{}}
+		b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+		b.privateTxEnabled = true
+
+		var recordCount, submitPrivateCount, preconfCount atomic.Int32
+		b.recordPrivateTxFn = func(common.Hash) { recordCount.Add(1) }
+		b.submitPrivateTxFn = func(*types.Transaction) error { submitPrivateCount.Add(1); return nil }
+		b.submitTxForPreconfFn = func(*types.Transaction) error { preconfCount.Add(1); return nil }
+
+		api := NewTransactionAPI(b, new(AddrLocker))
+		raw, tx := makeSelfSignedRaw(t, api, b.acc.Address)
+
+		hash, err := api.SendRawTransaction(context.Background(), raw)
+		require.NoError(t, err)
+		require.Equal(t, tx.Hash(), hash)
+		require.Equal(t, int32(1), recordCount.Load(), "RecordPrivateTx should be called once")
+		require.Equal(t, int32(1), submitPrivateCount.Load(), "SubmitPrivateTx should be called once")
+		require.Equal(t, int32(0), preconfCount.Load(), "SubmitTxForPreconf should not be called when preconf is disabled")
+	})
+
+	t.Run("private only, SubmitPrivateTx fails returns wrapped error", func(t *testing.T) {
+		t.Parallel()
+		genesis := &core.Genesis{Config: params.TestChainConfig, Alloc: types.GenesisAlloc{}}
+		b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+		b.privateTxEnabled = true
+		b.submitPrivateTxFn = func(*types.Transaction) error { return errors.New("relay down") }
+
+		api := NewTransactionAPI(b, new(AddrLocker))
+		raw, tx := makeSelfSignedRaw(t, api, b.acc.Address)
+
+		hash, err := api.SendRawTransaction(context.Background(), raw)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tx accepted locally, submission failed")
+		require.Contains(t, err.Error(), "relay down")
+		require.Equal(t, tx.Hash(), hash, "hash should be returned even on SubmitPrivateTx failure")
+	})
+
+	t.Run("private only, SubmitTransaction fails (non-AlreadyKnown) purges record", func(t *testing.T) {
+		t.Parallel()
+		genesis := &core.Genesis{Config: params.TestChainConfig, Alloc: types.GenesisAlloc{}}
+		b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+		b.privateTxEnabled = true
+		b.sendTxErr = errors.New("pool full")
+
+		var recordCount, purgeCount, submitPrivateCount, preconfCount atomic.Int32
+		b.recordPrivateTxFn = func(common.Hash) { recordCount.Add(1) }
+		b.purgePrivateTxFn = func(common.Hash) { purgeCount.Add(1) }
+		b.submitPrivateTxFn = func(*types.Transaction) error { submitPrivateCount.Add(1); return nil }
+		b.submitTxForPreconfFn = func(*types.Transaction) error { preconfCount.Add(1); return nil }
+
+		api := NewTransactionAPI(b, new(AddrLocker))
+		raw, _ := makeSelfSignedRaw(t, api, b.acc.Address)
+
+		_, err := api.SendRawTransaction(context.Background(), raw)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "pool full")
+		// Record-before-submit invariant: record count == 1 even though
+		// SendTx failed proves RecordPrivateTx ran before SubmitTransaction.
+		require.Equal(t, int32(1), recordCount.Load(), "RecordPrivateTx should be called before SubmitTransaction")
+		require.Equal(t, int32(1), purgeCount.Load(), "PurgePrivateTx should be called on non-AlreadyKnown failure")
+		require.Equal(t, int32(0), submitPrivateCount.Load(), "SubmitPrivateTx should not be called when local pool rejects")
+		require.Equal(t, int32(0), preconfCount.Load(), "SubmitTxForPreconf should not be called when local pool rejects")
+	})
+
+	t.Run("private only, ErrAlreadyKnown short-circuits BP submit no purge", func(t *testing.T) {
+		t.Parallel()
+		genesis := &core.Genesis{Config: params.TestChainConfig, Alloc: types.GenesisAlloc{}}
+		b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+		b.privateTxEnabled = true
+		b.sendTxErr = txpool.ErrAlreadyKnown
+
+		var recordCount, purgeCount, submitPrivateCount, preconfCount atomic.Int32
+		b.recordPrivateTxFn = func(common.Hash) { recordCount.Add(1) }
+		b.purgePrivateTxFn = func(common.Hash) { purgeCount.Add(1) }
+		b.submitPrivateTxFn = func(*types.Transaction) error { submitPrivateCount.Add(1); return nil }
+		b.submitTxForPreconfFn = func(*types.Transaction) error { preconfCount.Add(1); return nil }
+
+		api := NewTransactionAPI(b, new(AddrLocker))
+		raw, _ := makeSelfSignedRaw(t, api, b.acc.Address)
+
+		_, err := api.SendRawTransaction(context.Background(), raw)
+		require.ErrorIs(t, err, txpool.ErrAlreadyKnown)
+		require.Equal(t, int32(1), recordCount.Load(), "RecordPrivateTx should still be called")
+		require.Equal(t, int32(0), purgeCount.Load(), "PurgePrivateTx should NOT be called for ErrAlreadyKnown")
+		require.Equal(t, int32(0), submitPrivateCount.Load(), "SubmitPrivateTx should NOT be called on ErrAlreadyKnown")
+		require.Equal(t, int32(0), preconfCount.Load(), "SubmitTxForPreconf should NOT be called on ErrAlreadyKnown")
+	})
+
+	t.Run("both flags on, both submits called", func(t *testing.T) {
+		t.Parallel()
+		genesis := &core.Genesis{Config: params.TestChainConfig, Alloc: types.GenesisAlloc{}}
+		b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+		b.preconfEnabled = true
+		b.privateTxEnabled = true
+
+		var preconfCount, submitPrivateCount atomic.Int32
+		b.submitTxForPreconfFn = func(*types.Transaction) error { preconfCount.Add(1); return nil }
+		b.submitPrivateTxFn = func(*types.Transaction) error { submitPrivateCount.Add(1); return nil }
+
+		api := NewTransactionAPI(b, new(AddrLocker))
+		raw, tx := makeSelfSignedRaw(t, api, b.acc.Address)
+
+		hash, err := api.SendRawTransaction(context.Background(), raw)
+		require.NoError(t, err)
+		require.Equal(t, tx.Hash(), hash)
+		require.Equal(t, int32(1), preconfCount.Load(), "SubmitTxForPreconf should be called once")
+		require.Equal(t, int32(1), submitPrivateCount.Load(), "SubmitPrivateTx should be called once")
+	})
+
+	t.Run("both flags on, preconf fails private succeeds no error to user", func(t *testing.T) {
+		t.Parallel()
+		genesis := &core.Genesis{Config: params.TestChainConfig, Alloc: types.GenesisAlloc{}}
+		b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+		b.preconfEnabled = true
+		b.privateTxEnabled = true
+
+		var preconfCount, submitPrivateCount atomic.Int32
+		b.submitTxForPreconfFn = func(*types.Transaction) error {
+			preconfCount.Add(1)
+			return errors.New("preconf relay down")
+		}
+		b.submitPrivateTxFn = func(*types.Transaction) error { submitPrivateCount.Add(1); return nil }
+
+		api := NewTransactionAPI(b, new(AddrLocker))
+		raw, tx := makeSelfSignedRaw(t, api, b.acc.Address)
+
+		hash, err := api.SendRawTransaction(context.Background(), raw)
+		require.NoError(t, err, "preconf failures should be swallowed when private succeeds")
+		require.Equal(t, tx.Hash(), hash)
+		require.Equal(t, int32(1), preconfCount.Load())
+		require.Equal(t, int32(1), submitPrivateCount.Load(), "private submit should still run after preconf failure")
+	})
+
+	t.Run("both flags on, preconf succeeds private fails returns wrapped error", func(t *testing.T) {
+		t.Parallel()
+		genesis := &core.Genesis{Config: params.TestChainConfig, Alloc: types.GenesisAlloc{}}
+		b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+		b.preconfEnabled = true
+		b.privateTxEnabled = true
+
+		var preconfCount, submitPrivateCount atomic.Int32
+		b.submitTxForPreconfFn = func(*types.Transaction) error { preconfCount.Add(1); return nil }
+		b.submitPrivateTxFn = func(*types.Transaction) error {
+			submitPrivateCount.Add(1)
+			return errors.New("private relay down")
+		}
+
+		api := NewTransactionAPI(b, new(AddrLocker))
+		raw, tx := makeSelfSignedRaw(t, api, b.acc.Address)
+
+		hash, err := api.SendRawTransaction(context.Background(), raw)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tx accepted locally, submission failed")
+		require.Contains(t, err.Error(), "private relay down")
+		require.Equal(t, tx.Hash(), hash)
+		require.Equal(t, int32(1), preconfCount.Load(), "preconf submit should run before private submit")
+		require.Equal(t, int32(1), submitPrivateCount.Load())
+	})
+
+	t.Run("both flags on, ErrAlreadyKnown short-circuits both BP submits", func(t *testing.T) {
+		t.Parallel()
+		genesis := &core.Genesis{Config: params.TestChainConfig, Alloc: types.GenesisAlloc{}}
+		b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+		b.preconfEnabled = true
+		b.privateTxEnabled = true
+		b.sendTxErr = txpool.ErrAlreadyKnown
+
+		var preconfCount, submitPrivateCount, purgeCount atomic.Int32
+		b.submitTxForPreconfFn = func(*types.Transaction) error { preconfCount.Add(1); return nil }
+		b.submitPrivateTxFn = func(*types.Transaction) error { submitPrivateCount.Add(1); return nil }
+		b.purgePrivateTxFn = func(common.Hash) { purgeCount.Add(1) }
+
+		api := NewTransactionAPI(b, new(AddrLocker))
+		raw, _ := makeSelfSignedRaw(t, api, b.acc.Address)
+
+		_, err := api.SendRawTransaction(context.Background(), raw)
+		require.ErrorIs(t, err, txpool.ErrAlreadyKnown)
+		require.Equal(t, int32(0), preconfCount.Load(), "SubmitTxForPreconf should NOT be called on ErrAlreadyKnown")
+		require.Equal(t, int32(0), submitPrivateCount.Load(), "SubmitPrivateTx should NOT be called on ErrAlreadyKnown")
+		require.Equal(t, int32(0), purgeCount.Load(), "PurgePrivateTx should NOT be called for ErrAlreadyKnown")
 	})
 }
 func (b *testBackend) ProtocolVersion() uint {


### PR DESCRIPTION
# Description

This PR does the following things:
- Updates the `eth_sendRawTransaction` endpoint to be used for both preconf and private transaction submission instead of using separate endpoints for both of them.
- The existing `eth_sendRawTransactionPrivate` endpoint will still operate as it does now. 
- Adds rate limiting on submitting transactions to block producers. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
