### PR TITLE
miner: disable tracer in vm.Config to prevent conflicts during block synchronization

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -3029,6 +3029,12 @@ func (w *worker) deletePendingTask(sealHash common.Hash) bool {
 // vmConfig returns the VM config.
 func (w *worker) vmConfig() vm.Config {
 	cfg := *w.chain.GetVMConfig()
+	// Miner pulls its vm.Config from the chain instance, this brought up the vm.Config.Tracer
+	// in which should be active only for live tracing and no for mining. So here, we explicitly
+	// sets the tracer to nil to avoid having the miner tracing a block while it's produced conflicting
+	// with the live tracing.
+	cfg.Tracer = nil
+
 	return cfg
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -3029,10 +3029,10 @@ func (w *worker) deletePendingTask(sealHash common.Hash) bool {
 // vmConfig returns the VM config.
 func (w *worker) vmConfig() vm.Config {
 	cfg := *w.chain.GetVMConfig()
-	// Miner pulls its vm.Config from the chain instance, this brought up the vm.Config.Tracer
-	// in which should be active only for live tracing and no for mining. So here, we explicitly
-	// sets the tracer to nil to avoid having the miner tracing a block while it's produced conflicting
-	// with the live tracing.
+	// The miner copies its vm.Config from the chain instance, which may include
+	// a vm.Config.Tracer intended only for live tracing, not for mining. Clear
+	// the tracer here to prevent the miner from tracing block production and
+	// conflicting with live tracing.
 	cfg.Tracer = nil
 
 	return cfg

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -2372,6 +2372,12 @@ func (w *worker) clearPending(number uint64) {
 // vmConfig returns the VM config.
 func (w *worker) vmConfig() vm.Config {
 	cfg := *w.chain.GetVMConfig()
+	// Miner pulls its vm.Config from the chain instance, this brought up the vm.Config.Tracer
+	// in which should be active only for live tracing and no for mining. So here, we explicitly
+	// sets the tracer to nil to avoid having the miner tracing a block while it's produced conflicting
+	// with the live tracing.
+	cfg.Tracer = nil
+
 	return cfg
 }
 

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/blockstm"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/txpool/legacypool"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -3795,4 +3796,22 @@ func TestDisablePendingBlock(t *testing.T) {
 			return block != nil && receipts != nil && stateDB != nil
 		}, 2*time.Second, 100*time.Millisecond, "pending block, receipts and state should not be nil when DisablePendingBlock is false")
 	})
+}
+
+// TestVMConfigTracerStripped verifies that vmConfig() always returns a vm.Config
+// with Tracer == nil, even when the chain's VMConfig has a non-nil tracer set
+// (e.g. during live tracing). The chain's own VMConfig must remain unchanged.
+func TestVMConfigTracerStripped(t *testing.T) {
+	engine := clique.New(cliqueChainConfig.Clique, rawdb.NewMemoryDatabase())
+	defer engine.Close()
+
+	w, b, cleanup := newTestWorker(t, DefaultTestConfig(), cliqueChainConfig, engine, rawdb.NewMemoryDatabase(), false, 0)
+	defer cleanup()
+
+	sentinel := &tracing.Hooks{}
+	b.chain.GetVMConfig().Tracer = sentinel
+
+	got := w.vmConfig()
+	require.Nil(t, got.Tracer, "vmConfig() must strip the tracer so the miner does not conflict with live tracing")
+	require.Same(t, sentinel, b.chain.GetVMConfig().Tracer, "chain VMConfig tracer must remain unchanged after vmConfig() call")
 }


### PR DESCRIPTION
# Description

If running `bor` with live tracing enabled, once reaching live, miner starts to also call the live tracing hooks causing problems because only the block synchronization should call the live tracer.

# Changes

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

None

# Nodes audience

People running Live Tracing + bor

## Testing
- [X] I have tested this code manually on Mainnet
