### PR TITLE
ethclient: bound tx indexing wait in tests

### DIFF
--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -124,10 +124,24 @@ func newTestBackend(config *node.Config) (*node.Node, []*types.Block, error) {
 		return nil, nil, fmt.Errorf("can't import test blocks: %v", err)
 	}
 	// Ensure the tx indexing is fully generated
-	for ; ; time.Sleep(time.Millisecond * 100) {
+	timeout := time.NewTimer(30 * time.Second)
+	defer timeout.Stop()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	var lastErr error
+	for {
 		progress, err := ethservice.BlockChain().TxIndexProgress()
+		lastErr = err
 		if err == nil && progress.Done() {
 			break
+		}
+		select {
+		case <-timeout.C:
+			if lastErr != nil {
+				return nil, nil, fmt.Errorf("tx indexing did not complete within 30s: %v", lastErr)
+			}
+			return nil, nil, fmt.Errorf("tx indexing did not complete within 30s")
+		case <-ticker.C:
 		}
 	}
 	return n, blocks, nil


### PR DESCRIPTION
# Description

Adds a bounded wait around the ethclient test backend's transaction indexing poll. The helper now returns a clear setup error if indexing does not complete within 30 seconds instead of allowing the test process to hang until the CI job timeout.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

None.

# Nodes audience

Not applicable; this is a test-only change.

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

- `gofmt -w ethclient/ethclient_test.go`
- `git diff --check -- ethclient/ethclient_test.go`
- `go test ./ethclient`

# Additional comments

Test-only change; no runtime behavior changes.