### PR TITLE
Raise payload error to Warn

### DIFF
--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -263,7 +263,7 @@ func (w *worker) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload, e
 				if r.err == nil {
 					payload.update(r, time.Since(start))
 				} else {
-					log.Info("Error while generating work", "id", payload.id, "err", r.err)
+					log.Warn("Error while generating work", "id", payload.id, "err", r.err)
 				}
 				timer.Reset(w.config.Recommit)
 			case <-payload.stop:


### PR DESCRIPTION
  ## Description                                                                                                                                                                                 
                                                                                                                                                                                                 
  This PR fixes a logging-semantics bug in payload building. In miner/payload_building.go, the explicit error branch (r.err != nil) logged "Error while generating work" with log.Info, which can  be missed by common alerting filters that watch warn/error levels.                                                                                                                             
                                                                                                                                                                                                 
  What was changed:                                                                                                                                                                              
                                                                                                                                                                                                 
  - Updated that single error-path log from log.Info(...) to log.Warn(...).                                                                                                                      
                                                                                                                                                                                                 
  Why this is necessary:                                                                                                                                                                         
                                                                                                                                                                                                 
  - This path is already classified as an error by code (r.err) and message text.
  - Keeping it at Info can hide real payload build failures from ops monitoring.                                                                                                                 
                                                                                                                                                                                                 
  Why this is safe:                                                                                                                                                                              
                                                                                                                                                                                                 
  - No control flow, retry, timing, or payload logic changed.                                                                                                                                    
  - Only log severity was corrected in one line.                                                                                                                                                 
                                                                                                                                                                                                 
  ## Changes
                                                                                                                                                                                                 
  - [x] Bugfix (non-breaking change that solves an issue)                                                                                                                                        
  - [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)                                                                                                            
  - [ ] New feature (non-breaking change that adds functionality)                                                                                                                                
  - [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)                                                                                           
  - [ ] Changes only for a subset of nodes                                                                                                                                                       
                                                                                                                                                                                                 
  ## Nodes audience                                                                                                                                                                              
                                                                                                                                                                                                 
  Applies to all nodes using this code path; no subset-specific handling is required.                                                                                                            
                                                                                                                                                                                                 
  ## Checklist                                                                                                                                                                                   
                                                                                                                                                                                                 
  - [ ] I have added at least 2 reviewer or the whole pos-v1 team                                                                                                                                
  - [ ] I have added sufficient documentation in code                                                                                                                                            
  - [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply                                                        
  - [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)                                                                                         
  - [ ] Includes RPC methods changes, and the Notion documentation has been updated                                                                                                              
                                                                                                                                                                                                 
  ## Cross repository changes                                                                                                                                                                    
                                                                                                                                                                                                 
  - [ ] This PR requires changes to heimdall                                                                                                                                                     
      - In case link the PR here:                                                                                                                                                                
  - [ ] This PR requires changes to matic-cli                                                                                                                                                    
      - In case link the PR here:                                                                                                                                                                
                                                                                                                                                                                                 
  ## Testing                                                                                                                                                                                     
                                                                                                                                                                                                 
  - [ ] I have added unit tests                                                                                                                                                                  
  - [ ] I have added tests to CI                                                                                                                                                                 
  - [x] I have tested this code manually on local environment                                                                                                                                    
  - [ ] I have tested this code manually on remote devnet using express-cli                                                                                                                      
  - [ ] I have tested this code manually on amoy                                                                                                                                                 
  - [ ] I have created new e2e tests into express-cli                                                                                                                                            
                                                                                                                                                                                                 
  ### Manual tests                                                                                                                                                                               
                                                                                                                                                                                                 
  1. Verified the error branch in miner/payload_building.go now logs with log.Warn instead of log.Info.                                                                                          
  2. Verified diff scope is one-line severity change only (Info -> Warn) in one file.                                                                                                            
  3. Attempted go test ./miner -count=1; blocked by local toolchain/network constraint (go1.26.2 download timeout).                                                                              
                                                                                                                                                                                                 
  ## Additional comments                                                                                                                                                                         
                                                                                                                                                                                                 
  No functional behavior changes are introduced; this is a targeted observability/correctness fix for error-level signaling. 