### PR TITLE
core/types: guard (*Header).GetValidatorBytes against short Extra

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -506,7 +506,6 @@ func (b *Block) GetTxDependency() [][]uint64 {
 // to avoid redundant RLP decodes.
 func (h *Header) GetValidatorBytes(chainConfig *params.ChainConfig) []byte {
 	if len(h.Extra) < ExtraVanityLength+ExtraSealLength {
-		log.Error("length of extra less is than vanity and seal")
 		return nil
 	}
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -501,16 +501,17 @@ func (b *Block) GetTxDependency() [][]uint64 {
 }
 
 // GetValidatorBytes extracts validator bytes from the header's Extra field.
+// Returns nil if len(h.Extra) is shorter than ExtraVanityLength+ExtraSealLength.
 // If you need multiple fields from BlockExtraData, prefer DecodeBlockExtraData
 // to avoid redundant RLP decodes.
 func (h *Header) GetValidatorBytes(chainConfig *params.ChainConfig) []byte {
-	if !chainConfig.IsCancun(h.Number) {
-		return h.Extra[ExtraVanityLength : len(h.Extra)-ExtraSealLength]
-	}
-
 	if len(h.Extra) < ExtraVanityLength+ExtraSealLength {
 		log.Error("length of extra less is than vanity and seal")
 		return nil
+	}
+
+	if !chainConfig.IsCancun(h.Number) {
+		return h.Extra[ExtraVanityLength : len(h.Extra)-ExtraSealLength]
 	}
 
 	var blockExtraData BlockExtraData

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -931,3 +931,75 @@ func TestDecodeBlockExtraData(t *testing.T) {
 		t.Errorf("TxDependency mismatch: got %v, want %v", result.TxDependency, txDep)
 	}
 }
+
+// TestGetValidatorBytesShortExtra is a regression test for the pre-Cancun
+// branch of (*Header).GetValidatorBytes panicking with
+// `runtime error: slice bounds out of range` when len(Extra) < 97.
+//
+// Prior to the fix the pre-Cancun branch performed
+//
+//	return h.Extra[ExtraVanityLength : len(h.Extra)-ExtraSealLength]
+//
+// without any length guard. The post-Cancun branch already guarded this
+// path; this test exercises both branches across a range of short Extra
+// lengths plus a happy-path case.
+func TestGetValidatorBytesShortExtra(t *testing.T) {
+	t.Parallel()
+
+	preCancunCfg := &params.ChainConfig{
+		ChainID: big.NewInt(137),
+	}
+	postCancunCfg := &params.ChainConfig{
+		ChainID:     big.NewInt(137),
+		CancunBlock: big.NewInt(100),
+	}
+
+	cases := []struct {
+		name        string
+		cfg         *params.ChainConfig
+		blockNumber *big.Int
+	}{
+		{"pre-cancun", preCancunCfg, big.NewInt(50)},
+		{"post-cancun", postCancunCfg, big.NewInt(200)},
+	}
+
+	shortLens := []int{0, 1, 32, 64, 65, 80, 96}
+
+	for _, c := range cases {
+		for _, n := range shortLens {
+			h := &Header{
+				Number: c.blockNumber,
+				Extra:  make([]byte, n),
+			}
+			var got []byte
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("%s len(Extra)=%d: unexpected panic: %v", c.name, n, r)
+					}
+				}()
+				got = h.GetValidatorBytes(c.cfg)
+			}()
+			if got != nil {
+				t.Errorf("%s len(Extra)=%d: expected nil, got %x (len %d)",
+					c.name, n, got, len(got))
+			}
+		}
+	}
+
+	// Happy path (pre-Cancun): vanity + 40-byte validator entry + seal.
+	// Confirms the existing slice operation is preserved for valid input.
+	extra := make([]byte, ExtraVanityLength+40+ExtraSealLength)
+	for i := 0; i < 40; i++ {
+		extra[ExtraVanityLength+i] = byte(i + 1)
+	}
+	h := &Header{Number: big.NewInt(50), Extra: extra}
+	got := h.GetValidatorBytes(preCancunCfg)
+	if len(got) != 40 {
+		t.Fatalf("happy path: expected 40 bytes, got %d", len(got))
+	}
+	if !bytes.Equal(got, extra[ExtraVanityLength:ExtraVanityLength+40]) {
+		t.Errorf("happy path: validator bytes mismatch: got %x, want %x",
+			got, extra[ExtraVanityLength:ExtraVanityLength+40])
+	}
+}

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -934,7 +934,7 @@ func TestDecodeBlockExtraData(t *testing.T) {
 
 // TestGetValidatorBytesShortExtra is a regression test for the pre-Cancun
 // branch of (*Header).GetValidatorBytes panicking with
-// `runtime error: slice bounds out of range` when len(Extra) < 97.
+// `runtime error: slice bounds out of range` when len(Extra) < ExtraVanityLength+ExtraSealLength.
 //
 // Prior to the fix the pre-Cancun branch performed
 //


### PR DESCRIPTION
# Description

`(*Header).GetValidatorBytes` in `core/types/block.go` panics with `runtime error: slice bounds out of range` when called on a header whose `Extra` field is shorter than `ExtraVanityLength + ExtraSealLength` (< 97 bytes) and the chain configuration is pre-Cancun. The pre-Cancun branch performs the slice `h.Extra[ExtraVanityLength : len(h.Extra)-ExtraSealLength]` with no length guard, while the post-Cancun branch and the three companion helpers (`GetBaseFeeParams`, `DecodeBlockExtraData`, `(*Block).GetTxDependency`) all already guard this path. The comment at `consensus/bor/bor.go:670` acknowledges the function relies on upstream validation, but because the function is exported, any out-of-tree consumer (indexer, light client, block explorer, MEV tooling) that calls it on unvalidated headers will panic on attacker-controllable input.

This PR hoists the existing length check to the top of `GetValidatorBytes` so it covers both the pre-Cancun and post-Cancun branches uniformly. Behaviour for valid headers is unchanged.

Discovered with [Zorya](https://github.com/trufflesecurity/zorya), a concolic-execution engine for Go binaries. Zorya produced a Z3 witness `extra.len = 1` after 65.7 s; confirmed to reproduce natively as `slice bounds out of range [:-64]`. See issue #2221 for the full write-up, SAT witness, and reproduction steps.

Fixes #2221

# Changes

- [x] Bugfix (non-breaking change that solves an issue)

# Breaking changes

None. The only behavioural change is that `GetValidatorBytes` now returns `nil` instead of panicking when `len(h.Extra) < ExtraVanityLength + ExtraSealLength` on a pre-Cancun config. All in-tree call sites already guard against this condition via `validateHeaderExtraField`, so they are unaffected.

# Nodes audience

All nodes that import `core/types`. No flag or configuration change required.

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
- [ ] This PR requires changes to matic-cli

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment

### Manual tests

1. Checked out `develop`, appended `TestGetValidatorBytesShortExtraVerbose` to `core/types/block_test.go` (pre-fix). All 7 short-Extra lengths panicked as expected (`slice bounds out of range [:-65]` through `[32:31]`). Test passed, confirming the bug is present on unpatched code.
2. Applied this PR's patch to `block.go`. Re-ran `go test -v -run TestGetValidatorBytesShortExtra ./core/types/`. Test passed: no panics, all short-Extra cases returned `nil`, happy-path case returned correct 40 validator bytes.
3. Ran full `go test ./core/types/`, all existing tests pass.
