### PR TITLE
docs, .claude: add hardfork rollout review guidance

### DIFF
--- a/.claude/rules/hardfork-rollout.md
+++ b/.claude/rules/hardfork-rollout.md
@@ -5,11 +5,7 @@ paths:
   - "core/forkid/forkid.go"
   - "internal/cli/server/chains/*.go"
   - "builder/files/genesis-*.json"
-  - "core/vm/contracts.go"
-  - "core/vm/eips.go"
-  - "core/vm/gas_table.go"
-  - "core/vm/jump_table.go"
-  - "core/vm/operations_acl.go"
+  - "core/vm/*.go"
   - "consensus/bor/bor.go"
   - "miner/worker.go"
 ---

--- a/.claude/rules/hardfork-rollout.md
+++ b/.claude/rules/hardfork-rollout.md
@@ -1,0 +1,95 @@
+---
+paths:
+  - "params/config.go"
+  - "params/protocol_params.go"
+  - "core/forkid/forkid.go"
+  - "internal/cli/server/chains/*.go"
+  - "builder/files/genesis-*.json"
+  - "core/vm/contracts.go"
+  - "core/vm/eips.go"
+  - "core/vm/gas_table.go"
+  - "core/vm/jump_table.go"
+  - "core/vm/operations_acl.go"
+  - "consensus/bor/bor.go"
+  - "miner/worker.go"
+---
+# Hardfork Rollout Review
+
+Hardfork changes are consensus-critical. A hardfork is not safely wired until
+every network config surface, runtime activation path, compatibility check, and
+boundary test agrees on the same fork name and activation height.
+
+The failure mode to prevent: a fork block is added to the packaged genesis JSON
+files but not to the normal server runtime presets. A node started through
+`bor server --config ...` with `chain = "mainnet"` or `chain = "amoy"` then
+loads the Go preset with `Bor.<Fork>Block == nil`, so `Bor.Is<Fork>(num)` never
+activates even though the genesis file looks correct.
+
+## Trigger Conditions
+
+Apply this rule whenever a change:
+
+- Adds, renames, or modifies a hardfork block, fork method, or fork-specific
+  `params.Rules` field.
+- Changes EVM opcode gas, SLOAD/SSTORE behavior, precompile gas, precompile
+  activation, transaction validation, receipt/block encoding, or fork ID.
+- Changes Bor consensus or miner behavior gated by a fork, including header
+  extra fields, producer timing, early block announcement, or prefetch logic.
+- Touches mainnet or Amoy chain presets, packaged genesis JSON, startup banner
+  output, or config compatibility checks.
+- Introduces release-only fork wiring that must remain equivalent across
+  public Bor, private Bor, devnets, and alternate clients.
+
+## Required Wiring
+
+For every new or changed fork, verify all of these surfaces before approving:
+
+- `params.BorMainnetChainConfig` and `params.AmoyChainConfig` in
+  `params/config.go` include the correct `Bor.<Fork>Block` values.
+- Runtime server presets in `internal/cli/server/chains/mainnet.go` and
+  `internal/cli/server/chains/amoy.go` include the same fork values as
+  `params/config.go`.
+- Packaged genesis files under `builder/files/`, especially
+  `genesis-mainnet-v1.json` and `genesis-amoy.json`, include the same fork
+  values when those files are part of the rollout.
+- `BorConfig` has the new field, JSON tag, nil-safe `Is<Fork>(num)` helper,
+  copy/equality handling, config validation, and config compatibility logic.
+- `ChainConfig.Rules` exposes the fork state where EVM, tx, block, or
+  precompile code needs it.
+- Fork ID calculation includes the fork only when configured and at the correct
+  height, so peer compatibility matches the rollout plan.
+- Startup banner or config logging prints the new fork. For mainnet and Amoy,
+  a normal server startup path should show the expected `#<block>` value.
+
+## Execution Semantics
+
+- Fork activation boundaries must be tested at `N-1`, `N`, and `N+1` for each
+  network-specific activation height.
+- EVM gas schedule changes must be gated only by the fork rules, not by local
+  node configuration, wall clock time, sync mode, or mining mode.
+- Precompile additions, removals, and gas changes must update
+  `core/vm/contracts.go` registration, `ActivePrecompiles`, initialization,
+  gas tables, and tests for both pre- and post-fork behavior.
+- Any change that affects block validity, transaction validity, receipt roots,
+  state roots, logs bloom, RLP encoding, or fork ID must have cross-client
+  parity tracked for Polygon Erigon before the rollout is considered complete.
+- Release branches and private security branches must carry the same fork
+  constants and activation logic as the public branch they are meant to ship.
+
+## Review Checks
+
+- [ ] Does `git diff` show a new fork name or block value? If yes, list every
+      config surface that must contain it and compare the values directly.
+- [ ] Can a normal `chain = "mainnet"` or `chain = "amoy"` startup load a nil
+      fork block while the packaged genesis JSON has a value? If yes, this is a
+      blocking consensus bug.
+- [ ] Are mainnet and Amoy values intentionally different, and are both present
+      everywhere they are needed?
+- [ ] Are devnet/local genesis or config presets deliberately included or
+      deliberately excluded? The PR should make that choice obvious.
+- [ ] Do tests cover the exact activation boundary and the unchanged
+      pre-activation behavior?
+- [ ] Does the startup banner, config dump, or equivalent smoke test prove that
+      the runtime-loaded chain config contains the new fork value?
+- [ ] If the fork changes EVM behavior or protocol encoding, is there a
+      matching Erigon compatibility note, issue, or implementation?

--- a/.claude/rules/hardfork-rollout.md
+++ b/.claude/rules/hardfork-rollout.md
@@ -5,6 +5,7 @@ paths:
   - "core/forkid/forkid.go"
   - "internal/cli/server/chains/*.go"
   - "builder/files/genesis-*.json"
+  - "core/vm/**/*.go"
   - "core/vm/*.go"
   - "consensus/bor/bor.go"
   - "miner/worker.go"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ Detailed, path-scoped security rules are in `.claude/rules/`:
 | `evm-security.md`                  | `core/vm/`                                                             | Gas accounting, opcode correctness, precompile safety, EIP gating          |
 | `txpool-security.md`               | `core/txpool/`                                                         | Pool limits, validation ordering, eviction gaming, blob handling           |
 | `state-security.md`                | `core/state/`, `blockstm/`, `trie/`                                    | Parallel execution safety, state root determinism, journal correctness     |
-| `hardfork-rollout.md`              | `params/{config,protocol_params}.go`, `internal/cli/server/chains/*.go`, genesis JSON, `core/forkid/forkid.go`, `core/vm/*.go`, `consensus/bor/bor.go`, `miner/worker.go` | Hardfork activation wiring, runtime/genesis parity, fork ID, EVM and miner gates |
+| `hardfork-rollout.md`              | `params/config.go`, `params/protocol_params.go`, `internal/cli/server/chains/*.go`, `builder/files/genesis-*.json`, `core/forkid/forkid.go`, `core/vm/`, `consensus/bor/bor.go`, `miner/worker.go` | Hardfork activation wiring, runtime/genesis parity, fork ID, EVM and miner gates |
 
 These rules load automatically when Claude works on files matching their path patterns. Some files match multiple rules (e.g., `consensus/bor/contract/` matches both `consensus-security.md` and `contract-interaction-security.md`) — all matching rules apply simultaneously.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,11 +143,15 @@ Detailed, path-scoped security rules are in `.claude/rules/`:
 | `evm-security.md`                  | `core/vm/`                                                             | Gas accounting, opcode correctness, precompile safety, EIP gating          |
 | `txpool-security.md`               | `core/txpool/`                                                         | Pool limits, validation ordering, eviction gaming, blob handling           |
 | `state-security.md`                | `core/state/`, `blockstm/`, `trie/`                                    | Parallel execution safety, state root determinism, journal correctness     |
-| `hardfork-rollout.md`              | `params/config.go`, `internal/cli/server/chains/*.go`, genesis JSON, `core/forkid/forkid.go`, `core/vm/*.go`, `consensus/bor/bor.go`, `miner/worker.go` | Hardfork activation wiring, runtime/genesis parity, fork ID, EVM and miner gates |
+| `hardfork-rollout.md`              | `params/{config,protocol_params}.go`, `internal/cli/server/chains/*.go`, genesis JSON, `core/forkid/forkid.go`, `core/vm/*.go`, `consensus/bor/bor.go`, `miner/worker.go` | Hardfork activation wiring, runtime/genesis parity, fork ID, EVM and miner gates |
 
 These rules load automatically when Claude works on files matching their path patterns. Some files match multiple rules (e.g., `consensus/bor/contract/` matches both `consensus-security.md` and `contract-interaction-security.md`) — all matching rules apply simultaneously.
 
 #### Standalone Hardfork Rollout Review
+
+This section intentionally summarizes `.claude/rules/hardfork-rollout.md` for
+agents launched directly in this repo. Keep both surfaces in sync when changing
+hardfork rollout guidance.
 
 Even outside the PoS team workspace, treat every new or modified hardfork as
 consensus-critical. A diff is hardfork-shaped if it adds or changes fork names,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ Detailed, path-scoped security rules are in `.claude/rules/`:
 | `evm-security.md`                  | `core/vm/`                                                             | Gas accounting, opcode correctness, precompile safety, EIP gating          |
 | `txpool-security.md`               | `core/txpool/`                                                         | Pool limits, validation ordering, eviction gaming, blob handling           |
 | `state-security.md`                | `core/state/`, `blockstm/`, `trie/`                                    | Parallel execution safety, state root determinism, journal correctness     |
-| `hardfork-rollout.md`              | `params/config.go`, `internal/cli/server/chains/*.go`, genesis JSON, `core/forkid/forkid.go`, `core/vm/{contracts,eips,gas_table,jump_table,operations_acl}.go`, `consensus/bor/bor.go`, `miner/worker.go` | Hardfork activation wiring, runtime/genesis parity, fork ID, EVM and miner gates |
+| `hardfork-rollout.md`              | `params/config.go`, `internal/cli/server/chains/*.go`, genesis JSON, `core/forkid/forkid.go`, `core/vm/*.go`, `consensus/bor/bor.go`, `miner/worker.go` | Hardfork activation wiring, runtime/genesis parity, fork ID, EVM and miner gates |
 
 These rules load automatically when Claude works on files matching their path patterns. Some files match multiple rules (e.g., `consensus/bor/contract/` matches both `consensus-security.md` and `contract-interaction-security.md`) — all matching rules apply simultaneously.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,8 +143,39 @@ Detailed, path-scoped security rules are in `.claude/rules/`:
 | `evm-security.md`                  | `core/vm/`                                                             | Gas accounting, opcode correctness, precompile safety, EIP gating          |
 | `txpool-security.md`               | `core/txpool/`                                                         | Pool limits, validation ordering, eviction gaming, blob handling           |
 | `state-security.md`                | `core/state/`, `blockstm/`, `trie/`                                    | Parallel execution safety, state root determinism, journal correctness     |
+| `hardfork-rollout.md`              | `params/config.go`, `internal/cli/server/chains/*.go`, genesis JSON, `core/forkid/forkid.go`, `core/vm/{contracts,eips,gas_table,jump_table,operations_acl}.go`, `consensus/bor/bor.go`, `miner/worker.go` | Hardfork activation wiring, runtime/genesis parity, fork ID, EVM and miner gates |
 
 These rules load automatically when Claude works on files matching their path patterns. Some files match multiple rules (e.g., `consensus/bor/contract/` matches both `consensus-security.md` and `contract-interaction-security.md`) — all matching rules apply simultaneously.
+
+#### Standalone Hardfork Rollout Review
+
+Even outside the PoS team workspace, treat every new or modified hardfork as
+consensus-critical. A diff is hardfork-shaped if it adds or changes fork names,
+fork block values, `BorConfig` fields, `Is<Fork>()`, `params.Rules`, fork ID
+inputs, startup banners, chain config compatibility, EVM gas/opcode/precompile
+behavior, header extra fields, producer timing, early block announcement, or
+fork-gated miner behavior.
+
+For every hardfork-shaped diff, explicitly compare the fork name and activation
+block across all runtime and packaged config surfaces:
+
+- `params.BorMainnetChainConfig` and `params.AmoyChainConfig` in
+  `params/config.go`
+- `internal/cli/server/chains/mainnet.go` and `internal/cli/server/chains/amoy.go`
+- `builder/files/genesis-mainnet-v1.json` and `builder/files/genesis-amoy.json`
+- `core/forkid/forkid.go`, `ChainConfig.Rules`, startup banner output, and
+  config compatibility / fork ordering checks
+
+The specific failure class to prevent is a fork block present only in packaged
+genesis JSON while normal `bor server --config ...` startup still loads a Go
+runtime preset with `Bor.<Fork>Block == nil`. In that case
+`c.Bor.Is<Fork>(num)` never activates on the normal startup path even though the
+genesis file looks correct.
+
+Fork-gated EVM, precompile, consensus, and miner behavior must be tested at
+`N-1`, `N`, and `N+1` for each network activation block. If the fork changes
+consensus output, track Polygon Erigon parity before treating the rollout as
+complete.
 
 ### Before Making Changes
 


### PR DESCRIPTION
## Summary

Adds standalone hardfork rollout review guidance for Bor.

Hardforks in Bor require coordinated wiring across runtime chain presets, packaged genesis files, fork ID calculation, config compatibility, startup visibility, EVM/precompile behavior, consensus logic, and miner behavior. This PR adds a
path-scoped Claude rule plus repo-level AGENTS guidance so AI-assisted reviews can catch incomplete hardfork rollouts even when run directly inside this repository.

The new guidance specifically calls out the drift class where a fork block is present in packaged genesis JSON but missing from the normal runtime Go chain presets. In that case a node started through the normal `bor server --config ...`
path can load `Bor.<Fork>Block == nil`, so fork checks such as `Bor.Is<Fork>(num)` never activate on the standard startup path.

## What changed

- Added `.claude/rules/hardfork-rollout.md` with a path-scoped frontmatter that auto-loads on edits to `params/`, `internal/cli/server/chains/`, `builder/files/genesis-*.json`, `core/forkid/forkid.go`, fork-gated files under `core/vm/`,
`consensus/bor/bor.go`, and `miner/worker.go`.
- Added the new rule to the `AGENTS.md` security rules table.
- Added a Standalone Hardfork Rollout Review subsection to `AGENTS.md` so the guidance applies even when an AI agent is launched directly inside this repository, outside the PoS team workspace.
- Documented required cross-checks across:
  - `params.BorMainnetChainConfig`
  - `params.AmoyChainConfig`
  - `internal/cli/server/chains/mainnet.go`
  - `internal/cli/server/chains/amoy.go`
  - packaged genesis JSON files
  - fork ID inputs
  - startup banner / config output
  - EVM gas / opcode / precompile gates
  - consensus and miner fork-gated behavior
  - `N-1` / `N` / `N+1` activation-boundary test coverage
  - cross-client (Erigon) parity tracking

## Executed tests

Docs / rules-only change; no runtime code touched.

```bash
git diff --check
```

Also checked the updated markdown files for trailing whitespace.

The rule body was empirically validated by running fresh-context AI reviews against three historical hardfork-shaped PRs across bor and heimdall-v2. Each case was flagged at CRITICAL severity with concrete file:line evidence; per-case
verdicts and full findings live in the corresponding workspace PR.

## Rollout notes

No runtime behavior changes. This only affects repo-local AI guidance and review checklists.

Future hardfork PRs should use this rule to verify activation blocks, runtime config parity, packaged genesis parity, fork ID behavior, startup visibility, N-1/N/N+1 boundary tests, and cross-client parity where consensus output changes.

## Related PRs

- https://github.com/0xPolygon/pos-team-workspace/pull/2 - adds the corresponding workspace-level steering, the /pos-code-review skill triage step, and the empirical backtest detail.
- https://github.com/0xPolygon/heimdall-v2/pull/590 - adds the corresponding height-gated rollout review rule.