### PR TITLE
consensus/bor: fix race in SpanStore.PurgeCache

### DIFF
--- a/consensus/bor/span_store.go
+++ b/consensus/bor/span_store.go
@@ -400,6 +400,10 @@ func (s *SpanStore) PurgeCache() {
 	s.lastUsedSpan.Store(nil)
 	// Reset the latest known span ID
 	s.latestKnownSpanId.Store(0)
+	// Clear cached heimdall status. With the poll loop stopped, a stale
+	// CatchingUp:false would otherwise let waitUntilHeimdallIsSynced skip
+	// refreshing status against a newly-swapped heimdall client.
+	s.heimdallStatus.Store(nil)
 }
 
 // getMockSpan0 constructs a mock span 0 by fetching validator set from genesis state. This should

--- a/consensus/bor/span_store.go
+++ b/consensus/bor/span_store.go
@@ -3,6 +3,7 @@ package bor
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -41,11 +42,14 @@ type SpanStore struct {
 
 	// cancel function to stop the background routine
 	cancel context.CancelFunc
+	// pollWg tracks the background polling goroutine so PurgeCache and Close
+	// can wait for it to exit before touching shared state.
+	pollWg sync.WaitGroup
 }
 
 func NewSpanStore(heimdallClient IHeimdallClient, spanner Spanner, chainId string) *SpanStore {
 	cache, _ := lru.NewARC(10)
-	store := SpanStore{
+	store := &SpanStore{
 		store:           cache,
 		heimdallClient:  heimdallClient,
 		spanner:         spanner,
@@ -53,42 +57,59 @@ func NewSpanStore(heimdallClient IHeimdallClient, spanner Spanner, chainId strin
 		latestSpanCache: atomic.Pointer[borTypes.Span]{},
 		lastUsedSpan:    atomic.Pointer[borTypes.Span]{},
 	}
+	store.startPollLoop()
+	return store
+}
 
-	ctx, cancel := context.WithCancel(context.Background())
-
-	store.cancel = cancel
-
-	if heimdallClient != nil {
-		go func() {
-			errorLogInterval := 10 * time.Second
-			var lastSpanErrorLogTime time.Time
-			var lastHeimdallErrorLogTime time.Time
-
-			for {
-				err := store.updateLatestSpan(ctx)
-				if err != nil {
-					if time.Since(lastSpanErrorLogTime) >= errorLogInterval {
-						log.Error("Failed to update latest span", "err", err)
-						lastSpanErrorLogTime = time.Now()
-					}
-				}
-				err = store.updateHeimdallStatus(ctx)
-				if err != nil {
-					if time.Since(lastHeimdallErrorLogTime) >= errorLogInterval {
-						log.Error("Failed to update heimdall status", "err", err)
-						lastHeimdallErrorLogTime = time.Now()
-					}
-				}
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(200 * time.Millisecond):
-				}
-			}
-		}()
+// startPollLoop spawns the background goroutine that periodically refreshes
+// latestSpanCache and heimdallStatus. No-op when heimdallClient is nil.
+func (s *SpanStore) startPollLoop() {
+	if s.heimdallClient == nil {
+		return
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	s.pollWg.Add(1)
+	go s.runPollLoop(ctx)
+}
 
-	return &store
+func (s *SpanStore) runPollLoop(ctx context.Context) {
+	defer s.pollWg.Done()
+	const errorLogInterval = 10 * time.Second
+	var lastSpanErr, lastHeimdallErr time.Time
+
+	for {
+		if err := s.updateLatestSpan(ctx); err != nil {
+			logErrRateLimited(&lastSpanErr, errorLogInterval, "Failed to update latest span", err)
+		}
+		if err := s.updateHeimdallStatus(ctx); err != nil {
+			logErrRateLimited(&lastHeimdallErr, errorLogInterval, "Failed to update heimdall status", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+// logErrRateLimited logs err at most once per interval, updating lastLog when it does.
+func logErrRateLimited(lastLog *time.Time, interval time.Duration, msg string, err error) {
+	if time.Since(*lastLog) >= interval {
+		log.Error(msg, "err", err)
+		*lastLog = time.Now()
+	}
+}
+
+// stopPollLoop cancels the background goroutine and blocks until it exits.
+// Safe to call when the loop is not running.
+func (s *SpanStore) stopPollLoop() {
+	if s.cancel == nil {
+		return
+	}
+	s.cancel()
+	s.pollWg.Wait()
+	s.cancel = nil
 }
 
 func (s *SpanStore) getLatestSpan(ctx context.Context) (*borTypes.Span, error) {
@@ -362,7 +383,14 @@ func (s *SpanStore) setHeimdallClient(client IHeimdallClient) {
 
 // PurgeCache clears all cached spans and resets state. This is useful in tests
 // when the mock heimdall client is changed and old cached data needs to be invalidated.
+//
+// The background poll loop is stopped before the reset so it can't race in and
+// re-populate latestSpanCache after the clear. PurgeCache leaves the poll loop
+// stopped — on-demand reads via getLatestSpan/spanById still work because they
+// fall back to updateLatestSpan inline when the cache is empty.
 func (s *SpanStore) PurgeCache() {
+	s.stopPollLoop()
+
 	// Create a new cache to replace the old one
 	newCache, _ := lru.NewARC(10)
 	s.store = newCache
@@ -406,9 +434,7 @@ func getMockSpan0(ctx context.Context, spanner Spanner, chainId string) (*borTyp
 
 // Close cancels the background routine and cleans up resources
 func (s *SpanStore) Close() {
-	if s.cancel != nil {
-		s.cancel()
-	}
+	s.stopPollLoop()
 }
 
 // Wait for a new span whose selected producers are different from the current header author

--- a/consensus/bor/span_store_test.go
+++ b/consensus/bor/span_store_test.go
@@ -1528,6 +1528,41 @@ func TestSpanStore_HeimdallDownTimeout(t *testing.T) {
 	})
 }
 
+// TestSpanStore_PurgeCache_RaceWithPollLoop deterministically demonstrates the
+// race between PurgeCache and the background polling goroutine started by
+// NewSpanStore (span_store.go:62-89). The goroutine ticks every 200ms and calls
+// updateLatestSpan, which writes the latest span back into latestSpanCache. If a
+// tick falls between PurgeCache and the caller's next read, the "purge" is
+// silently undone. Sleeping >200ms after PurgeCache forces the race to fire
+// every run, exposing the flake that occasionally hits CI on TestSpanStore_PurgeCache.
+func TestSpanStore_PurgeCache_RaceWithPollLoop(t *testing.T) {
+	t.Parallel()
+	spanStore := NewSpanStore(&MockHeimdallClient{}, nil, "1337")
+	defer spanStore.Close()
+	ctx := t.Context()
+
+	// Prime caches.
+	span, err := spanStore.spanById(ctx, 2)
+	require.NoError(t, err)
+	spanStore.lastUsedSpan.Store(span)
+	spanStore.latestKnownSpanId.Store(4)
+	spanStore.latestSpanCache.Store(span)
+
+	spanStore.PurgeCache()
+
+	// Wait past one tick of the background poll loop (200ms). On unpatched
+	// SpanStore the loop re-populates latestSpanCache during this sleep,
+	// silently undoing the purge.
+	time.Sleep(300 * time.Millisecond)
+
+	require.Nil(t, spanStore.latestSpanCache.Load(),
+		"latestSpanCache must stay nil after PurgeCache — background poll loop is racing with the purge")
+	require.Nil(t, spanStore.lastUsedSpan.Load(),
+		"lastUsedSpan must stay nil after PurgeCache")
+	require.Equal(t, uint64(0), spanStore.latestKnownSpanId.Load(),
+		"latestKnownSpanId must stay 0 after PurgeCache")
+}
+
 func TestSpanStore_PurgeCache(t *testing.T) {
 	t.Parallel()
 	spanStore := NewSpanStore(&MockHeimdallClient{}, nil, "1337")

--- a/consensus/bor/span_store_test.go
+++ b/consensus/bor/span_store_test.go
@@ -1541,12 +1541,15 @@ func TestSpanStore_PurgeCache_RaceWithPollLoop(t *testing.T) {
 	defer spanStore.Close()
 	ctx := t.Context()
 
-	// Prime caches.
+	// Prime caches and let the poll loop populate heimdallStatus.
 	span, err := spanStore.spanById(ctx, 2)
 	require.NoError(t, err)
 	spanStore.lastUsedSpan.Store(span)
 	spanStore.latestKnownSpanId.Store(4)
 	spanStore.latestSpanCache.Store(span)
+	require.Eventually(t, func() bool { return spanStore.heimdallStatus.Load() != nil },
+		500*time.Millisecond, 20*time.Millisecond,
+		"heimdallStatus must be populated by the poll loop before purge")
 
 	spanStore.PurgeCache()
 
@@ -1561,6 +1564,9 @@ func TestSpanStore_PurgeCache_RaceWithPollLoop(t *testing.T) {
 		"lastUsedSpan must stay nil after PurgeCache")
 	require.Equal(t, uint64(0), spanStore.latestKnownSpanId.Load(),
 		"latestKnownSpanId must stay 0 after PurgeCache")
+	require.Nil(t, spanStore.heimdallStatus.Load(),
+		"heimdallStatus must be cleared by PurgeCache — otherwise stale CatchingUp:false "+
+			"lets waitUntilHeimdallIsSynced skip refreshing against a swapped heimdall client")
 }
 
 func TestSpanStore_PurgeCache(t *testing.T) {


### PR DESCRIPTION
## Summary

`SpanStore.PurgeCache` clears `latestSpanCache` (and the other cache fields) via an atomic `Store(nil)`, but does not stop the background polling goroutine that `NewSpanStore` spawns ([span_store.go:62-89](https://github.com/0xPolygon/bor/blob/develop/consensus/bor/span_store.go#L62-L89)). That goroutine ticks every 200ms and writes the latest span back into `latestSpanCache`. If a tick lands between the clear and the caller's next read, the \"purge\" is silently undone.

The window is microscopic in the original test (the assertion runs in microseconds after the clear), so this manifests as a low-rate CI flake on `TestSpanStore_PurgeCache` rather than a consistent failure.

## Where it showed up

Caught while iterating on #2192:

- Failing CI run: https://github.com/0xPolygon/bor/actions/runs/26121340018/job/76823989362
- Failure signature: `latestSpanCache` contained `span Id:0x2` — the exact value the mock heimdall client returns from `GetLatestSpan`, confirming the polling goroutine wrote it back after the purge.

`PurgeCache` is test-only — it is only invoked from `bor_test.go`, `tests/bor/bor_test.go`, and the span-store test itself — so changing its lifecycle behavior is low-risk.

## Fix

- Extract the poll loop into a `runPollLoop` method tracked by a `sync.WaitGroup`.
- Have `PurgeCache` cancel the context and `Wait()` for the goroutine to exit *before* resetting state. `Close()` uses the same path (`stopPollLoop`) so it's also race-safe.
- `PurgeCache` no longer restarts the loop. On-demand reads via `getLatestSpan`/`spanById` fall back to inline `updateLatestSpan` when the cache is empty, so callers still get fresh data — they just don't get background warming until the next `NewSpanStore`. This matches the test-only use case.

Also slimmed the loop body by extracting the rate-limited error logger into a small helper so the new method stays under diffguard's cognitive-complexity threshold.

## Reproducer

`TestSpanStore_PurgeCache_RaceWithPollLoop` sleeps 300ms after `PurgeCache` (past one tick of the 200ms poll). On `develop` it fails 5/5 with the same `span Id:0x2` signature as the CI flake; with the fix it passes deterministically.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=20 -run TestSpanStore_PurgeCache ./consensus/bor/` — 40/40 pass (new reproducer + original)
- [x] `go test -race ./consensus/bor/...` — 526 tests pass
- [x] `diffguard --base origin/develop --skip-mutation .` — all sections PASS