### PR TITLE
core/forkid: include polygon-specific forks in wire forkid

### DIFF
--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -139,7 +139,7 @@ func NewStaticFilter(config *params.ChainConfig, genesis *types.Block) Filter {
 func newFilter(config *params.ChainConfig, genesis *types.Block, headfn func() (uint64, uint64)) Filter {
 	// Calculate the all the valid fork hash and fork next combos
 	var (
-		forksByBlock, forksByTime = gatherForks(config, genesis.Time())
+		forksByBlock, forksByTime = GatherForks(config, genesis.Time())
 		forks                     = append(append([]uint64{}, forksByBlock...), forksByTime...)
 		sums                      = make([][4]byte, len(forks)+1) // 0th is the genesis
 	)

--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -78,7 +78,7 @@ func NewID(config *params.ChainConfig, genesis *types.Block, head, time uint64) 
 	hash := crc32.ChecksumIEEE(genesis.Hash().Bytes())
 
 	// Calculate the current fork checksum and the next fork block
-	forksByBlock, forksByTime := gatherForks(config, genesis.Time())
+	forksByBlock, forksByTime := GatherForks(config, genesis.Time())
 	for _, fork := range forksByBlock {
 		if fork <= head {
 			// Fork already passed, checksum the previous hash and the fork number


### PR DESCRIPTION
NewID computes the eth p2p handshake forkid by calling gatherForks (lowercase), which uses reflection over the outer ChainConfig struct and is blind to the polygon-specific block fields nested under config.Bor (RioBlock, MadhugiriBlock, DandeliBlock, LisovoBlock, LisovoProBlock, GiuglianoBlock, ChicagoBlock). The polygon-aware GatherForks (uppercase) was added in #2063 to expose fork data via the new bor_forks RPC, but the wire path was never updated to use it.

As a result, bor's wire forkid does not include any polygon-specific fork activation in its checksum. On chains where polygon forks activate at non-zero blocks (devnets, testnets, mainnet post-fork), bor's wire forkid is inconsistent with what the bor_forks RPC reports for the same node.

This was latent until erigon v3.6.0 [started including the new polygon forks](https://github.com/0xPolygon/erigon/commit/e49fac84cf14becdbb67efc35ee956153a933fcb#diff-a1bc98c190055d6bca83b928cfe97c415b929bfd03e91cbaaa00f6a5008f4fd9) (see `p2p/forkid/forkid.go`), Lisovo, LisovoPro, Giugliano and Chicago in its own GatherForks. erigon's wire forkid now correctly hashes those blocks while bor's still does not, causing the eth handshake to fail with `fork ID rejected: local incompatible or needs update` on any deployment combining bor v2.8.0 with erigon v3.6.0 on a chain where those forks activate above block 0.

> Written by claude