### PR TITLE
miner: drop PeerCount==0 gate in mainLoop

### DIFF
--- a/miner/fake_miner.go
+++ b/miner/fake_miner.go
@@ -221,9 +221,8 @@ func (m *mockBackendBor) BlockChain() *core.BlockChain {
 	return m.bc
 }
 
-// PeerCount implements Backend. Returns 1 so the worker's mainLoop sees the
-// node as peered — tests using mockBackendBor are not exercising the
-// PeerCount==0 gate.
+// PeerCount implements Backend. Returns a constant; tests using
+// mockBackendBor don't drive the peer count.
 func (*mockBackendBor) PeerCount() int {
 	return 1
 }

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -49,8 +49,8 @@ func (m *mockBackend) BlockChain() *core.BlockChain {
 	return m.bc
 }
 
-// PeerCount implements Backend. Returns 1 so the worker's mainLoop sees the
-// node as peered — miner_test.go is not exercising the PeerCount==0 gate.
+// PeerCount implements Backend. Returns a constant; tests in this file
+// don't drive the peer count.
 func (*mockBackend) PeerCount() int {
 	return 1
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -892,13 +892,6 @@ func (w *worker) mainLoop() {
 		w.currentMu.Unlock()
 	}()
 
-	bor, isBor := w.engine.(*bor.Bor)
-	devFakeAuthor := isBor && bor != nil && bor.DevFakeAuthor
-	// "real-network node" = Bor engine wired to a live heimdall. Test /
-	// dev setups (--bor.withoutheimdall, Clique, Ethash) leave the
-	// HeimdallClient nil and bypass the PeerCount gate so single-node
-	// and intentional-disconnection tests keep producing.
-	realNetworkNode := isBor && bor != nil && bor.HeimdallClient != nil
 	for {
 		select {
 		case req := <-w.newWorkCh:
@@ -910,21 +903,8 @@ func (w *worker) mainLoop() {
 				continue
 			}
 
-			// PeerCount gate applies only to real-network Bor nodes
-			// (heimdall configured). Test / dev setups
-			// (--bor.withoutheimdall, Clique, Ethash, etc.) commit
-			// unconditionally — single-node and intentional-disconnection
-			// tests rely on producing without peers.
-			if realNetworkNode && w.eth.PeerCount() == 0 && !devFakeAuthor {
-				// Drop the request and unblock the veblop fallback retry.
-				// In steady state peers > 0, so this firing means we
-				// tried to commit during a peer outage — worth surfacing.
-				w.pendingWorkBlock.Store(0)
-				log.Warn("Dropped newWorkReq: no peers", "head", w.chain.CurrentBlock().Number.Uint64())
-			} else {
-				//nolint:contextcheck
-				w.commitWork(req.interrupt, req.noempty, req.timestamp)
-			}
+			//nolint:contextcheck
+			w.commitWork(req.interrupt, req.noempty, req.timestamp)
 
 		case req := <-w.getWorkCh:
 			req.result <- w.generateWork(req.params, false)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -1587,13 +1587,13 @@ func TestVeblopTimerSkipsWhenPendingTasks(t *testing.T) {
 	}
 }
 
-// TestCommitWorkLeaksPendingWorkBlockWhenSyncing exercises a distinct leak
-// path for `pendingWorkBlock` (separate from the PeerCount==0 race fixed for
-// the 2026-05-07 incident). It does NOT cleanly explain val4's stall because
-// `miner.update()` unsubscribes from downloader events after the first
-// DoneEvent, so for a node that's been running past initial sync, `w.syncing`
-// is permanently false. The bug is still real for fresh-startup paths and
-// worth fixing as a code-hygiene issue.
+// TestCommitWorkLeaksPendingWorkBlockWhenSyncing exercises a leak path for
+// `pendingWorkBlock`: when `commitWork` early-returns because the node is
+// still syncing, the value reserved by `newWorkLoop` is never cleared.
+// In production `miner.update()` unsubscribes from downloader events after
+// the first DoneEvent, so for a node past initial sync `w.syncing` is
+// permanently false — this bug only surfaces on fresh-startup paths, but
+// the leak is still worth fixing as a code-hygiene issue.
 //
 // Bug: commitWork's pre-fix layout read:
 //
@@ -1657,8 +1657,7 @@ func TestCommitWorkLeaksPendingWorkBlockWhenSyncing(t *testing.T) {
 	got := w.pendingWorkBlock.Load()
 	if got != 0 {
 		t.Fatalf("pendingWorkBlock leaked while syncing: expected 0, got %d. "+
-			"commitWork's early return on w.syncing.Load()==true skips the defer that clears the flag — "+
-			"the same class of leak (different trigger) as the 2026-05-07 incident.", got)
+			"commitWork's early return on w.syncing.Load()==true skips the defer that clears the flag.", got)
 	}
 }
 

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -321,9 +321,6 @@ func newTestWorkerBackend(t TensingObject, chainConfig *params.ChainConfig, engi
 		txPool:  txpool,
 		genesis: gspec,
 	}
-	// Default to "peered" so tests that don't care about the PeerCount gate
-	// in mainLoop don't accidentally hit the dropped-newWorkReq branch.
-	// Tests targeting the PeerCount==0 race must call b.peerCount.Store(0).
 	b.peerCount.Store(1)
 	return b
 }
@@ -1592,78 +1589,6 @@ func TestVeblopTimerSkipsWhenPendingTasks(t *testing.T) {
 	}
 }
 
-// TestMainLoopClearsPendingWorkBlockOnPeerCountZero is a regression test
-// for the wedge that caused the 2026-05-07 Amoy chain halt.
-//
-// Bug: when mainLoop receives a newWorkReq while PeerCount()==0 on a
-// real-network Bor node (heimdall configured), it silently drops the
-// request. newWorkLoop had already written pendingWorkBlock = head+1
-// before sending, so without the corresponding clear here, that value
-// stays wedged at head+1 forever. The veblop fallback timer then
-// short-circuits on every tick (`if pendingWorkBlock == currentBlock+1
-// { reset; continue }`), silently disabling the only recovery mechanism
-// that exists when no chainHeadCh events arrive.
-//
-// This test:
-//  1. Builds a worker on a Bor engine with a non-nil mock heimdall client
-//     (so the production gate `realNetworkNode := bor.HeimdallClient != nil`
-//     trips). Rio is active so the veblop fallback runs.
-//  2. Holds PeerCount at 0 and leaves DevFakeAuthor=false (the constructor
-//     default — see test setup notes below).
-//  3. Triggers the worker startup path (`init=true` → startCh → newWorkLoop
-//     writes pendingWorkBlock and sends to newWorkCh → mainLoop receives).
-//  4. Asserts that after mainLoop processes the request, pendingWorkBlock
-//     is back to 0 (not wedged at 1).
-//
-// Pre-fix: pendingWorkBlock stays at 1 → test fails.
-// Post-fix: pendingWorkBlock cleared to 0 → test passes.
-func TestMainLoopClearsPendingWorkBlockOnPeerCountZero(t *testing.T) {
-	var (
-		engine      consensus.Engine
-		chainConfig *params.ChainConfig
-		db          = rawdb.NewMemoryDatabase()
-		ctrl        *gomock.Controller
-	)
-
-	// Rio active from genesis so the veblop fallback retries after the drop.
-	chainConfig = &params.ChainConfig{}
-	*chainConfig = *params.BorUnittestChainConfig
-	borCfg := *chainConfig.Bor
-	chainConfig.Bor = &borCfg
-	chainConfig.Bor.RioBlock = big.NewInt(0)
-
-	engine, ctrl = getFakeBorFromConfig(t, chainConfig)
-	defer engine.Close()
-	defer ctrl.Finish()
-
-	config := DefaultTestConfig()
-	config.Recommit = 10 * time.Second
-
-	w, backend, _ := newTestWorker(t, config, chainConfig, engine, db, false, 0)
-	defer w.close()
-
-	// Bug-trigger conditions: PeerCount==0 AND DevFakeAuthor=false.
-	// DevFakeAuthor=false is the default constructed in NewFakeBor; we
-	// don't reassign it here because mainLoop has already captured the
-	// value at startup and a post-construction write would data-race.
-	// The gate in mainLoop's newWorkCh case reads:
-	//     if realNetworkNode && peers==0 && !devFakeAuthor { drop }
-	//     else { commitWork(...) }
-	backend.peerCount.Store(0)
-
-	// newWorker(init=true) pushes to startCh during construction; newWorkLoop
-	// then sets pendingWorkBlock = head+1 and sends to newWorkCh. Wait
-	// briefly so mainLoop can drain the request.
-	w.start()
-	time.Sleep(500 * time.Millisecond)
-
-	got := w.pendingWorkBlock.Load()
-	if got != 0 {
-		t.Fatalf("pendingWorkBlock leaked: expected 0 after mainLoop drops a newWorkReq on PeerCount==0, got %d. "+
-			"This means the worker's veblop fallback timer in newWorkLoop will permanently short-circuit — the wedge that halted Amoy on 2026-05-07.", got)
-	}
-}
-
 // TestCommitWorkLeaksPendingWorkBlockWhenSyncing exercises a distinct leak
 // path for `pendingWorkBlock` (separate from the PeerCount==0 race fixed for
 // the 2026-05-07 incident). It does NOT cleanly explain val4's stall because
@@ -1728,9 +1653,7 @@ func TestCommitWorkLeaksPendingWorkBlockWhenSyncing(t *testing.T) {
 	// reserved the next block number.
 	w.pendingWorkBlock.Store(42)
 
-	// Call commitWork directly. mainLoop reaches this with PeerCount>0
-	// during sync (the node has peers — that's where it's pulling blocks
-	// from), so the PeerCount gate is not what's at play here.
+	// Call commitWork directly to drive the in-sync early-return path.
 	w.commitWork(nil, false, time.Now().Unix())
 
 	got := w.pendingWorkBlock.Load()

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -278,11 +278,10 @@ func DefaultTestConfig() *Config {
 
 // testWorkerBackend implements worker.Backend interfaces and wraps all information needed during the testing.
 type testWorkerBackend struct {
-	db        ethdb.Database
-	txPool    *txpool.TxPool
-	chain     *core.BlockChain
-	genesis   *core.Genesis
-	peerCount atomic.Int32 // settable by tests; PeerCount() returns int(peerCount.Load())
+	db      ethdb.Database
+	txPool  *txpool.TxPool
+	chain   *core.BlockChain
+	genesis *core.Genesis
 }
 
 func newTestWorkerBackend(t TensingObject, chainConfig *params.ChainConfig, engine consensus.Engine, db ethdb.Database) *testWorkerBackend {
@@ -321,14 +320,13 @@ func newTestWorkerBackend(t TensingObject, chainConfig *params.ChainConfig, engi
 		txPool:  txpool,
 		genesis: gspec,
 	}
-	b.peerCount.Store(1)
 	return b
 }
 
 func (b *testWorkerBackend) BlockChain() *core.BlockChain { return b.chain }
 func (b *testWorkerBackend) TxPool() *txpool.TxPool       { return b.txPool }
 func (b *testWorkerBackend) PeerCount() int {
-	return int(b.peerCount.Load())
+	return 1
 }
 
 func (b *testWorkerBackend) newRandomTx(creation bool) *types.Transaction {

--- a/tests/bor/bor_test.go
+++ b/tests/bor/bor_test.go
@@ -2944,27 +2944,23 @@ func getMockedSpannerWithSpanRotation(t *testing.T, validator1, validator2 commo
 // family should be able to permanently wedge the producer state machine
 // across a restart.
 //
-// The four leak paths that the unit tests precisely cover and that this
+// The leak paths that the unit tests precisely cover and that this
 // integration test exercises behaviorally:
 //
-//  1. miner.mainLoop dropped-newWorkReq on PeerCount==0 (unit test:
-//     TestMainLoopClearsPendingWorkBlockOnPeerCountZero).
-//  2. miner.commitWork syncing-leak early return (unit test:
+//  1. miner.commitWork syncing-leak early return (unit test:
 //     TestCommitWorkLeaksPendingWorkBlockWhenSyncing).
-//  3. miner.taskLoop missing pendingTasks cleanup on Bor.Seal stop-branch
+//  2. miner.taskLoop missing pendingTasks cleanup on Bor.Seal stop-branch
 //     exits (cleanup wired via SealWithStopHook onStopExit callback;
 //     unit test: TestTaskLoopInterruptPreservesPendingTasks).
-//  4. Bor.Seal second-select silent default drop (unit test:
+//  3. Bor.Seal second-select silent default drop (unit test:
 //     TestSeal_BlocksOnFullResultChannelInsteadOfSilentDrop).
 //
+// A fourth leak path — the mainLoop PeerCount==0 dropped-newWorkReq — was
+// closed in the same family by removing the gate entirely; the path no
+// longer exists, so there's no unit test pair for it.
+//
 // Integration-level limitations:
-//   - This test calls InitMiner with withoutHeimdall=true (no real heimdall
-//     wired up), so the production PeerCount==0 gate
-//     (`realNetworkNode := bor.HeimdallClient != nil`) doesn't trip and
-//     Bug 1's specific drop branch is NOT exercised. The precise unit test
-//     (TestMainLoopClearsPendingWorkBlockOnPeerCountZero) uses a mock
-//     heimdall client to enable the gate.
-//   - The race conditions for (3) and the resultCh-full condition for (4)
+//   - The race condition for (2) and the resultCh-full condition for (3)
 //     are timing-sensitive and not reliably reproduced in a 2-node test
 //     without artificial backpressure.
 //

--- a/tests/bor/bor_test.go
+++ b/tests/bor/bor_test.go
@@ -2939,8 +2939,8 @@ func getMockedSpannerWithSpanRotation(t *testing.T, validator1, validator2 commo
 //
 // Behavioral property under test: after a brief mining stop/start cycle on
 // an active block producer — which closes the worker's startup race window
-// (the same window where Bug 1 fired in production) — the producer must
-// eventually seal blocks again. None of the four leak-paths fixed in this
+// (the same window the leak family exercised in production) — the producer
+// must eventually seal blocks again. None of the leak paths fixed in this
 // family should be able to permanently wedge the producer state machine
 // across a restart.
 //
@@ -3032,8 +3032,8 @@ func TestProducerRecoversAfterMiningRestart(t *testing.T) {
 	waitForBlock(5, 30*time.Second)
 
 	// Phase 2: stop mining on node 0 and remove its peer link to node 1.
-	// This recreates the "producer is briefly isolated" condition that
-	// triggered Bug 1 in production (the startup race against P2P peer
+	// This recreates the "producer is briefly isolated" condition the
+	// leak family hit in production (the startup race against P2P peer
 	// establishment). With node 0 stopped, node 1 should continue alone.
 	headBeforeStop := nodes[0].BlockChain().CurrentHeader().Number.Uint64()
 	t.Logf("phase 2: head before stop=%d, stopping mining on node 0 and removing peer", headBeforeStop)
@@ -3047,10 +3047,10 @@ func TestProducerRecoversAfterMiningRestart(t *testing.T) {
 	// reusable on the next StartMining.
 	time.Sleep(2 * time.Second)
 
-	// Phase 3: re-add peer, restart mining on node 0. With Bug 1 (or the
-	// other leak paths) present, node 0 could sit silently — no seals —
-	// until the process is restarted. With the fixes, node 0 must
-	// produce blocks again within a short recovery window.
+	// Phase 3: re-add peer, restart mining on node 0. With any of the
+	// leak paths present, node 0 could sit silently — no seals — until
+	// the process is restarted. With the fixes, node 0 must produce
+	// blocks again within a short recovery window.
 	stacks[0].Server().AddPeer(enodes[1])
 	if err := nodes[0].StartMining(); err != nil {
 		t.Fatalf("StartMining (restart) failed: %v", err)


### PR DESCRIPTION
The peer-count drop branch in `mainLoop` was introduced in #977 to delay block production until at least one peer was connected, scoped to BorMainnet/Mumbai (Amoy was added later in e8157bbe6). #2220 widened the gate from a chain-ID list to "any heimdall-connected node", which drew kurtosis devnets into the gate for the first time: in a single-validator kurtosis devnet PeerCount() is 0 by design (no other node to peer with), the gate drops every newWorkReq, and the veblop fallback timer re-fires straight back into the same drop.

Veblop's primary/backup producer election already handles outage safety at the protocol level — peer count adds no safety, only a foot-gun. Strip the gate; `mainLoop` now routes every newWorkReq directly to `commitWork` (except the pre-existing
DisablePendingBlock-on-non-validator short-circuit).

Verified end-to-end on a kurtosis 1-validator devnet (chain ID 4927, veblop active).
