### PR TITLE
miner: format build-block log times as RFC3339Nano, gate on IsRunning

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -2315,23 +2315,25 @@ func (w *worker) buildAndCommitBlock(interrupt *atomic.Int32, noempty bool, genP
 		stopFn()
 	}()
 
-	timeUntilInterrupt := time.Until(work.header.GetActualTime())
-	if timeUntilInterrupt > time.Second {
-		timeUntilInterrupt -= interruptBuffer
+	if w.IsRunning() {
+		timeUntilInterrupt := time.Until(work.header.GetActualTime())
+		if timeUntilInterrupt > time.Second {
+			timeUntilInterrupt -= interruptBuffer
+		}
+		parent := w.chain.CurrentBlock()
+		log.Info("Starting to build block", "number", work.header.Number.Uint64(),
+			"buildStart", prepareWorkStart.Format(time.RFC3339Nano),
+			"preBuild", common.PrettyDuration(genParams.preBuildDuration), // time spent before `buildAndCommitBlock` is called
+			"prepareWork", common.PrettyDuration(prepareWorkDuration), // total time spent in prepare work
+			"makeEnv", common.PrettyDuration(work.makeEnvDuration), // total time spent in `makeEnv` inside prepare work
+			"makeHeader", common.PrettyDuration(work.makeHeaderDuration), // total time spent in `makeHeader` inside prepare work includes bor.Prepare call
+			"parentTime", time.Unix(int64(parent.Time), 0).Format(time.RFC3339Nano),
+			"parentActualTime", parent.GetActualTime().Format(time.RFC3339Nano),
+			"headerTime", time.Unix(int64(work.header.Time), 0).Format(time.RFC3339Nano),
+			"headerActualTime", work.header.GetActualTime().Format(time.RFC3339Nano),
+			"timeUntilInterrupt", common.PrettyDuration(timeUntilInterrupt), // time left before block building will be interrupted
+		)
 	}
-	parent := w.chain.CurrentBlock()
-	log.Info("Starting to build block", "number", work.header.Number.Uint64(),
-		"buildStart(ms)", prepareWorkStart.UnixMilli(),
-		"preBuild", common.PrettyDuration(genParams.preBuildDuration), // time spent before `buildAndCommitBlock` is called
-		"prepareWork", common.PrettyDuration(prepareWorkDuration), // total time spent in prepare work
-		"makeEnv", common.PrettyDuration(work.makeEnvDuration), // total time spent in `makeEnv` inside prepare work
-		"makeHeader", common.PrettyDuration(work.makeHeaderDuration), // total time spent in `makeHeader` inside prepare work includes bor.Prepare call
-		"parentTime", parent.Time,
-		"parentActualTime(ms)", parent.GetActualTime().UnixMilli(),
-		"headerTime", work.header.Time,
-		"headerActualTime(ms)", work.header.GetActualTime().UnixMilli(),
-		"timeUntilInterrupt", common.PrettyDuration(timeUntilInterrupt), // time left before block building will be interrupted
-	)
 
 	if !noempty && w.interruptCommitFlag {
 		// Start the timer for block building

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -2322,15 +2322,15 @@ func (w *worker) buildAndCommitBlock(interrupt *atomic.Int32, noempty bool, genP
 		}
 		parent := w.chain.CurrentBlock()
 		log.Info("Starting to build block", "number", work.header.Number.Uint64(),
-			"buildStart", prepareWorkStart.Format(time.RFC3339Nano),
+			"buildStart", prepareWorkStart.UTC().Format(time.RFC3339Nano),
 			"preBuild", common.PrettyDuration(genParams.preBuildDuration), // time spent before `buildAndCommitBlock` is called
 			"prepareWork", common.PrettyDuration(prepareWorkDuration), // total time spent in prepare work
 			"makeEnv", common.PrettyDuration(work.makeEnvDuration), // total time spent in `makeEnv` inside prepare work
 			"makeHeader", common.PrettyDuration(work.makeHeaderDuration), // total time spent in `makeHeader` inside prepare work includes bor.Prepare call
-			"parentTime", time.Unix(int64(parent.Time), 0).Format(time.RFC3339Nano),
-			"parentActualTime", parent.GetActualTime().Format(time.RFC3339Nano),
-			"headerTime", time.Unix(int64(work.header.Time), 0).Format(time.RFC3339Nano),
-			"headerActualTime", work.header.GetActualTime().Format(time.RFC3339Nano),
+			"parentTime", time.Unix(int64(parent.Time), 0).UTC().Format(time.RFC3339Nano),
+			"parentActualTime", parent.GetActualTime().UTC().Format(time.RFC3339Nano),
+			"headerTime", time.Unix(int64(work.header.Time), 0).UTC().Format(time.RFC3339Nano),
+			"headerActualTime", work.header.GetActualTime().UTC().Format(time.RFC3339Nano),
 			"timeUntilInterrupt", common.PrettyDuration(timeUntilInterrupt), // time left before block building will be interrupted
 		)
 	}


### PR DESCRIPTION
## Summary

The "Starting to build block" log previously emitted epoch milliseconds (`buildStart(ms)`, `parentActualTime(ms)`, `headerActualTime(ms)`) and raw Unix seconds for `parentTime`/`headerTime`, with Go's default comma-grouped formatting making the values awkward to parse and hard to correlate across services. Switch every timestamp field to `time.RFC3339Nano` for human-readable, parser-friendly output that matches the rest of the bor log surface and lines up with Heimdall.

Also wrap the log in `w.IsRunning()` so non-mining nodes don't emit it on every prepare cycle.
