### PR TITLE
feat: add p2p observability metrics

### DIFF
--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -40,6 +40,8 @@ var (
 	activePeerGauge         = metrics.NewRegisteredGauge("p2p/peers", nil)
 	activeInboundPeerGauge  = metrics.NewRegisteredGauge("p2p/peers/inbound", nil)
 	activeOutboundPeerGauge = metrics.NewRegisteredGauge("p2p/peers/outbound", nil)
+	peerDropMeter           = metrics.NewRegisteredMeter("p2p/peers/drops", nil)
+	peerPingLatencyTimer    = metrics.NewRegisteredTimer("p2p/peers/ping/latency", nil)
 
 	ingressTrafficMeter = metrics.NewRegisteredMeter("p2p/ingress", nil)
 	egressTrafficMeter  = metrics.NewRegisteredMeter("p2p/egress", nil)

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -113,6 +113,7 @@ type Peer struct {
 	protoErr chan error
 	closed   chan struct{}
 	pingRecv chan struct{}
+	pongRecv chan struct{}
 	disc     chan DiscReason
 
 	// events receives message send / receive events if set
@@ -258,6 +259,7 @@ func newPeer(log log.Logger, conn *conn, protocols []Protocol) *Peer {
 		protoErr: make(chan error, len(protomap)+1), // protocols + pingLoop
 		closed:   make(chan struct{}),
 		pingRecv: make(chan struct{}, 16),
+		pongRecv: make(chan struct{}, 1),
 		log:      log.New("id", conn.node.ID(), "conn", conn.flags),
 	}
 	return p
@@ -328,24 +330,56 @@ loop:
 }
 
 func (p *Peer) pingLoop() {
+	p.pingLoopWithInterval(pingInterval)
+}
+
+func (p *Peer) pingLoopWithInterval(interval time.Duration) {
 	defer p.wg.Done()
 
-	ping := time.NewTimer(pingInterval)
+	ping := time.NewTimer(interval)
 	defer ping.Stop()
+
+	var pingSent time.Time
 
 	for {
 		select {
 		case <-ping.C:
+			measure := metrics.Enabled() && pingSent.IsZero()
+			if measure {
+				drainStalePongs(p.pongRecv)
+			}
 			if err := SendItems(p.rw, pingMsg); err != nil {
 				p.protoErr <- err
 				return
 			}
-			ping.Reset(pingInterval)
+			if measure {
+				pingSent = time.Now()
+			}
+			ping.Reset(interval)
 
 		case <-p.pingRecv:
-			SendItems(p.rw, pongMsg)
+			if err := SendItems(p.rw, pongMsg); err != nil {
+				p.protoErr <- err
+				return
+			}
+
+		case <-p.pongRecv:
+			if !pingSent.IsZero() {
+				peerPingLatencyTimer.Update(time.Since(pingSent))
+				pingSent = time.Time{}
+			}
 
 		case <-p.closed:
+			return
+		}
+	}
+}
+
+func drainStalePongs(pongRecv <-chan struct{}) {
+	for {
+		select {
+		case <-pongRecv:
+		default:
 			return
 		}
 	}
@@ -374,6 +408,13 @@ func (p *Peer) handle(msg Msg) error {
 		select {
 		case p.pingRecv <- struct{}{}:
 		case <-p.closed:
+		}
+	case msg.Code == pongMsg:
+		msg.Discard()
+		select {
+		case p.pongRecv <- struct{}{}:
+		case <-p.closed:
+		default:
 		}
 	case msg.Code == discMsg:
 		// This is the last message. We don't need to discard or

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -17,6 +17,7 @@
 package p2p
 
 import (
+	"crypto/ecdsa"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -29,9 +30,26 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 )
+
+type pipeTransport struct {
+	*MsgPipeRW
+}
+
+func (*pipeTransport) doEncHandshake(*ecdsa.PrivateKey) (*ecdsa.PublicKey, error) {
+	return nil, nil
+}
+
+func (*pipeTransport) doProtoHandshake(*protoHandshake) (*protoHandshake, error) {
+	return nil, nil
+}
+
+func (pt *pipeTransport) close(error) {
+	pt.Close()
+}
 
 var discard = Protocol{
 	Name:   "discard",
@@ -186,6 +204,155 @@ func TestPeerPing(t *testing.T) {
 
 	if err := ExpectMsg(rw, pongMsg, nil); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestPeerPongDoesNotBlock(t *testing.T) {
+	peer := &Peer{
+		closed:   make(chan struct{}),
+		pongRecv: make(chan struct{}, 1),
+	}
+	done := make(chan error, 1)
+	go func() {
+		for i := 0; i < 100; i++ {
+			if err := peer.handle(Msg{Code: pongMsg, Payload: strings.NewReader("")}); err != nil {
+				done <- err
+				return
+			}
+		}
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("pong handling blocked")
+	}
+	if got := len(peer.pongRecv); got > 1 {
+		t.Fatalf("pongRecv buffered %d messages, want at most 1", got)
+	}
+}
+
+func TestPeerPongOnClosedPeerDoesNotQueue(t *testing.T) {
+	closed := make(chan struct{})
+	close(closed)
+	peer := &Peer{
+		closed:   closed,
+		pongRecv: make(chan struct{}),
+	}
+
+	if err := peer.handle(Msg{Code: pongMsg, Payload: strings.NewReader("")}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-peer.pongRecv:
+		t.Fatal("pong queued after peer closed")
+	default:
+	}
+}
+
+func TestPeerOutstandingPing(t *testing.T) {
+	metrics.Enable()
+
+	interval := 10 * time.Millisecond
+	peer, rw, cleanup := testPingLoopPeer(interval)
+	defer cleanup()
+
+	expectPipeMsg(t, rw, pingMsg, 3*interval)
+	expectPipeMsg(t, rw, pingMsg, 3*interval)
+
+	peer.pongRecv <- struct{}{}
+	expectPipeMsg(t, rw, pingMsg, 3*interval)
+}
+
+func TestPeerPingLoopReportsPingWriteError(t *testing.T) {
+	interval := 10 * time.Millisecond
+	peer, rw, cleanup := testPingLoopPeer(interval)
+	defer cleanup()
+
+	rw.Close()
+	err := expectProtoErr(t, peer, 500*time.Millisecond)
+	if !errors.Is(err, ErrPipeClosed) {
+		t.Fatalf("protoErr = %v, want %v", err, ErrPipeClosed)
+	}
+}
+
+func TestPeerPingLoopReportsPongWriteError(t *testing.T) {
+	interval := time.Hour
+	peer, rw, cleanup := testPingLoopPeer(interval)
+	defer cleanup()
+
+	rw.Close()
+	peer.pingRecv <- struct{}{}
+	err := expectProtoErr(t, peer, 500*time.Millisecond)
+	if !errors.Is(err, ErrPipeClosed) {
+		t.Fatalf("protoErr = %v, want %v", err, ErrPipeClosed)
+	}
+}
+
+func TestDrainStalePongs(t *testing.T) {
+	pongRecv := make(chan struct{}, 3)
+	pongRecv <- struct{}{}
+	pongRecv <- struct{}{}
+	pongRecv <- struct{}{}
+
+	drainStalePongs(pongRecv)
+	if len(pongRecv) != 0 {
+		t.Fatalf("stale pong buffer length = %d, want 0", len(pongRecv))
+	}
+}
+
+func expectProtoErr(t *testing.T, peer *Peer, timeout time.Duration) error {
+	t.Helper()
+
+	select {
+	case err := <-peer.protoErr:
+		if err == nil {
+			t.Fatal("protoErr returned nil")
+		}
+		return err
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for protoErr")
+	}
+	return nil
+}
+
+func testPingLoopPeer(interval time.Duration) (*Peer, *MsgPipeRW, func()) {
+	local, remote := MsgPipe()
+	peer := &Peer{
+		rw:       &conn{transport: &pipeTransport{MsgPipeRW: local}},
+		protoErr: make(chan error, 1),
+		closed:   make(chan struct{}),
+		pingRecv: make(chan struct{}, 16),
+		pongRecv: make(chan struct{}, 1),
+	}
+	peer.wg.Add(1)
+	go peer.pingLoopWithInterval(interval)
+
+	return peer, remote, func() {
+		close(peer.closed)
+		local.Close()
+		remote.Close()
+		peer.wg.Wait()
+	}
+}
+
+func expectPipeMsg(t *testing.T, rw *MsgPipeRW, code uint64, timeout time.Duration) {
+	t.Helper()
+
+	select {
+	case msg := <-rw.r:
+		if err := msg.Discard(); err != nil {
+			t.Fatal(err)
+		}
+		if msg.Code != code {
+			t.Fatalf("message code = %d, want %d", msg.Code, code)
+		}
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for message %d", code)
 	}
 }
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -877,6 +877,7 @@ running:
 		case pd := <-srv.delpeer:
 			// A peer disconnected.
 			d := common.PrettyDuration(mclock.Now() - pd.created)
+			peerDropMeter.Mark(1)
 			delete(peers, pd.ID())
 			srv.log.Debug("Removing p2p peer", "peercount", len(peers), "id", pd.ID(), "inbound", pd.Inbound(), "duration", d, "req", pd.requested, "err", pd.err)
 			srv.dialsched.peerRemoved(pd.rw)


### PR DESCRIPTION
## Summary

Adds focused Bor P2P observability for peer-drop RCA: a peer disconnect counter (p2p/peers/drops) and devp2p ping RTT timer (p2p/peers/ping/latency). This lets operators correlate peer-drop bursts with peer liveness/latency from without relying only on log scraping. 

## Executed tests

a. go test ./p2p
    Result: pass.

b. Kurtosis Polygon PoS devnet stress test with Amoy configuration:
    4 Bor validators, 6 Bor RPC nodes
    distributed polycli loadtest across all 6 RPC endpoints
    load window: 2026-05-26T14:47:45Z to 2026-05-26T14:52:47Z

## Rollout notes
No coordinated upgr
ade required.