### PR TITLE
Revert #2237 — forkid wire-format change is a breaking p2p change

### DIFF
--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -78,7 +78,7 @@ func NewID(config *params.ChainConfig, genesis *types.Block, head, time uint64) 
 	hash := crc32.ChecksumIEEE(genesis.Hash().Bytes())
 
 	// Calculate the current fork checksum and the next fork block
-	forksByBlock, forksByTime := GatherForks(config, genesis.Time())
+	forksByBlock, forksByTime := gatherForks(config, genesis.Time())
 	for _, fork := range forksByBlock {
 		if fork <= head {
 			// Fork already passed, checksum the previous hash and the fork number
@@ -139,7 +139,7 @@ func NewStaticFilter(config *params.ChainConfig, genesis *types.Block) Filter {
 func newFilter(config *params.ChainConfig, genesis *types.Block, headfn func() (uint64, uint64)) Filter {
 	// Calculate the all the valid fork hash and fork next combos
 	var (
-		forksByBlock, forksByTime = GatherForks(config, genesis.Time())
+		forksByBlock, forksByTime = gatherForks(config, genesis.Time())
 		forks                     = append(append([]uint64{}, forksByBlock...), forksByTime...)
 		sums                      = make([][4]byte, len(forks)+1) // 0th is the genesis
 	)


### PR DESCRIPTION
## Summary

Reverts #2237 ("core/forkid: include polygon-specific forks in wire forkid").

**This is a breaking p2p change that was not flagged as such when #2237 merged.**

## What went wrong

#2237 swapped `gatherForks` (lowercase, reflection-based, outer ChainConfig only) for `GatherForks` (uppercase, polygon-aware — also walks `config.Bor.{Jaipur,Delhi,Indore,Ahmedabad,Bhilai,Rio,Madhugiri,MadhugiriPro,Dandeli,Lisovo,LisovoPro,Giugliano,Chicago}Block`) in the wire-forkid path (`core/forkid/forkid.go::NewID`, `NewStaticFilter`).

This is correct in intent — bor's old forkid was lying about which forks were active and erigon ≥3.6.0 already includes these blocks — but **changing what gets hashed in the wire forkid is, by definition, a coordinated-upgrade event**. Any node running the new code computes a different forkid than nodes running the old code on the same chain, and the eth handshake fails with `fork ID rejected: local incompatible or needs update`.

## Live evidence

Deployed v2.8.3-beta3 (which contains #2237) to an Amoy observation node (`posdevnodes-amoy-2`) on 2026-05-27. Symptoms within 5 minutes:

- Peer count oscillated 0 ↔ 1 (no stable handshakes).
- `Looking for peers peercount=0 tried=10–35 static=13` every 10 s — static peers being dialed continuously, all dropped immediately.
- Chain stuck at the same block; no new imports.
- No errors at INFO level — silent rejection at the handshake layer.

Rolling the same node back to v2.8.0-beta2 (which does **not** contain #2237) restored peers to ~18 within seconds. Confirms the diagnosis: it's the forkid hash mismatch, not anything else in the beta3 delta.

This will affect mainnet identically the moment a v2.8.3 (with #2237) bor talks to any v2.8.2-or-older bor, because every Polygon-specific fork above is also activated on mainnet at non-zero blocks.

## Why a plain revert, not a fix-forward

There is no algorithmic trick that makes a forkid hash change non-breaking on a chain where the affected forks have already activated. The only valid rollout strategies are:

1. **Gate the new `GatherForks` behavior on a future fork block.** Introduce a new `BorConfig.ForkidFixBlock` (or piggyback on the next planned consensus fork). Before that block: use legacy `gatherForks` for wire forkid computation. At and after: use `GatherForks`. Everyone deploys the binary well in advance; the protocol-level switchover is atomic at the block boundary. This is the canonical Ethereum pattern.
2. **Coordinate a flag-day rollout** with a config flag defaulting to legacy, flipped chain-wide on a known date.

Either approach should be a follow-up PR, designed and reviewed as a network upgrade. This PR just unblocks the existing release line.

## What needs to follow

- [ ] Follow-up PR re-introducing the polygon-aware forkid behavior gated on a `ForkidFixBlock` (or equivalent) — must include chain-config entries for mainnet and amoy, an explicit announcement to operators, and a soak period on devnet first.
- [ ] Release notes for the upcoming v2.8.x lineage should call out that the forkid fix is deferred to a coordinated upgrade.

## Test plan

- [x] `go build ./...` passes after revert
- [x] Same revert applied to `v2.8.3-candidate` and shipped as `v2.8.3-beta4` — node recovered peers + chain progression on Amoy
- [ ] Reviewer to confirm `core/forkid/forkid.go` matches pre-#2237 state (only the two `GatherForks` → `gatherForks` call sites)
