### PR TITLE
feat: add peer jailing on downloader

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -3578,7 +3578,7 @@ func (bc *BlockChain) insertSideChain(block *types.Block, it *insertIterator, ma
 				// If someone legitimately side-mines blocks, they would still be imported as usual. However,
 				// we cannot risk writing unverified blocks to disk when they obviously target the pruning
 				// mechanism.
-				return nil, it.index, errors.New("sidechain ghost-state attack")
+				return nil, it.index, types.ErrSidechainGhostState
 			}
 		}
 		if externTd == nil {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -20,6 +20,7 @@ package types
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -40,6 +41,8 @@ import (
 var (
 	ExtraVanityLength = 32 // Fixed number of extra-data prefix bytes reserved for signer vanity
 	ExtraSealLength   = 65 // Fixed number of extra-data suffix bytes reserved for signer seal
+
+	ErrSidechainGhostState = errors.New("sidechain ghost-state attack")
 )
 
 // A BlockNonce is a 64-bit hash which proves (combined with the

--- a/eth/downloader/bor_downloader.go
+++ b/eth/downloader/bor_downloader.go
@@ -383,8 +383,12 @@ func (d *Downloader) UnregisterPeer(id string) error {
 func (d *Downloader) LegacySync(id string, head common.Hash, td, ttd *big.Int, mode SyncMode) error {
 	err := d.synchronise(id, head, td, ttd, mode, false, nil)
 
+	if errors.Is(err, errPeerBackedOff) {
+		return err
+	}
+
 	switch err {
-	case nil, errBusy, errCanceled, errPeerBackedOff:
+	case nil, errBusy, errCanceled:
 		return err
 	}
 
@@ -436,6 +440,13 @@ func (d *Downloader) backoffPeer(id string, duration time.Duration) {
 	}
 }
 
+func (d *Downloader) IsPeerBackedOff(id string) bool {
+	if peer := d.peers.Peer(id); peer != nil {
+		return peer.backedOff()
+	}
+	return false
+}
+
 // synchronise will select the peer and use it for synchronising. If an empty string is given
 // it will use the best peer possible and synchronize if its TD is higher than our own. If any of the
 // checks fail an error will be returned. This method is synchronous
@@ -467,6 +478,14 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td, ttd *big.Int, 
 	// Post a user notification of the sync (only once per session)
 	if d.notified.CompareAndSwap(false, true) {
 		log.Info("Block synchronisation started")
+	}
+	if !beaconMode {
+		if p := d.peers.Peer(id); p == nil {
+			return errUnknownPeer
+		} else if p.backedOff() {
+			log.Debug("Skipping backed-off peer for sync", "peer", id)
+			return errPeerBackedOff
+		}
 	}
 	if mode == SnapSync {
 		// Snap sync will directly modify the persistent state, making the entire
@@ -521,10 +540,6 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td, ttd *big.Int, 
 		p = d.peers.Peer(id)
 		if p == nil {
 			return errUnknownPeer
-		}
-		if p.backedOff() {
-			log.Debug("Skipping backed-off peer for sync", "peer", id)
-			return errPeerBackedOff
 		}
 	}
 
@@ -1511,7 +1526,7 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, head uint64) e
 			filled, hashset, proced, err := d.fillHeaderSkeleton(from, headers)
 			if err != nil {
 				p.log.Debug("Skeleton chain invalid", "err", err)
-				return fmt.Errorf("%w: %v", errInvalidChain, err)
+				return fmt.Errorf("%w: %w", errInvalidChain, err)
 			}
 
 			headers = filled[proced:]

--- a/eth/downloader/bor_downloader.go
+++ b/eth/downloader/bor_downloader.go
@@ -391,7 +391,6 @@ func (d *Downloader) LegacySync(id string, head common.Hash, td, ttd *big.Int, m
 	if errors.Is(err, errInvalidChain) || errors.Is(err, errBadPeer) || errors.Is(err, errTimeout) ||
 		errors.Is(err, errStallingPeer) || errors.Is(err, errUnsyncedPeer) || errors.Is(err, errEmptyHeaderSet) ||
 		errors.Is(err, errPeersUnavailable) || errors.Is(err, errTooOld) || errors.Is(err, errInvalidAncestor) {
-
 		if isSidechainGhostStateError(err) {
 			log.Warn("Synchronisation failed, backing off peer", "peer", id, "err", err, "mode", d.getMode(), "duration", common.PrettyDuration(sidechainGhostStatePeerBackoff))
 			d.backoffPeer(id, sidechainGhostStatePeerBackoff)

--- a/eth/downloader/bor_downloader.go
+++ b/eth/downloader/bor_downloader.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -87,8 +88,11 @@ var (
 	errTooOld                  = errors.New("peer's protocol version too old")
 	errNoAncestorFound         = errors.New("no common ancestor found")
 	errNoPivotHeader           = errors.New("pivot header is not found")
+	errPeerBackedOff           = errors.New("peer is temporarily backed off")
 	ErrMergeTransition         = errors.New("legacy sync reached the merge")
 )
+
+const sidechainGhostStatePeerBackoff = 5 * time.Minute
 
 // peerDropFn is a callback type for dropping a peer detected as malicious.
 type peerDropFn func(id string)
@@ -381,13 +385,20 @@ func (d *Downloader) LegacySync(id string, head common.Hash, td, ttd *big.Int, m
 	err := d.synchronise(id, head, td, ttd, mode, false, nil)
 
 	switch err {
-	case nil, errBusy, errCanceled:
+	case nil, errBusy, errCanceled, errPeerBackedOff:
 		return err
 	}
 
 	if errors.Is(err, errInvalidChain) || errors.Is(err, errBadPeer) || errors.Is(err, errTimeout) ||
 		errors.Is(err, errStallingPeer) || errors.Is(err, errUnsyncedPeer) || errors.Is(err, errEmptyHeaderSet) ||
 		errors.Is(err, errPeersUnavailable) || errors.Is(err, errTooOld) || errors.Is(err, errInvalidAncestor) {
+
+		if isSidechainGhostStateError(err) {
+			log.Warn("Synchronisation failed, backing off peer", "peer", id, "err", err, "mode", d.getMode(), "duration", common.PrettyDuration(sidechainGhostStatePeerBackoff))
+			d.backoffPeer(id, sidechainGhostStatePeerBackoff)
+			return err
+		}
+
 		log.Warn("Synchronisation failed, dropping peer", "peer", id, "err", err, "mode", d.getMode())
 
 		if d.dropPeer == nil {
@@ -414,6 +425,16 @@ func (d *Downloader) LegacySync(id string, head common.Hash, td, ttd *big.Int, m
 	log.Warn("Synchronisation failed, retrying", "peer", id, "err", err)
 
 	return err
+}
+
+func isSidechainGhostStateError(err error) bool {
+	return errors.Is(err, errInvalidChain) && strings.Contains(err.Error(), "sidechain ghost-state attack")
+}
+
+func (d *Downloader) backoffPeer(id string, duration time.Duration) {
+	if peer := d.peers.Peer(id); peer != nil {
+		peer.backoff(duration)
+	}
 }
 
 // synchronise will select the peer and use it for synchronising. If an empty string is given
@@ -501,6 +522,9 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td, ttd *big.Int, 
 		p = d.peers.Peer(id)
 		if p == nil {
 			return errUnknownPeer
+		}
+		if p.backedOff() {
+			return errPeerBackedOff
 		}
 	}
 

--- a/eth/downloader/bor_downloader.go
+++ b/eth/downloader/bor_downloader.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -428,12 +427,13 @@ func (d *Downloader) LegacySync(id string, head common.Hash, td, ttd *big.Int, m
 }
 
 func isSidechainGhostStateError(err error) bool {
-	return errors.Is(err, errInvalidChain) && strings.Contains(err.Error(), "sidechain ghost-state attack")
+	return errors.Is(err, types.ErrSidechainGhostState)
 }
 
 func (d *Downloader) backoffPeer(id string, duration time.Duration) {
 	if peer := d.peers.Peer(id); peer != nil {
 		peer.backoff(duration)
+		peerGhostStateBackoffMeter.Mark(1)
 	}
 }
 
@@ -524,6 +524,7 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td, ttd *big.Int, 
 			return errUnknownPeer
 		}
 		if p.backedOff() {
+			log.Debug("Skipping backed-off peer for sync", "peer", id)
 			return errPeerBackedOff
 		}
 	}
@@ -1923,7 +1924,7 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 			return fmt.Errorf("%v: %w", errInvalidChain, err)
 		}
 
-		return fmt.Errorf("%w: %v", errInvalidChain, err)
+		return fmt.Errorf("%w: %w", errInvalidChain, err)
 	}
 
 	return nil

--- a/eth/downloader/bor_downloader_test.go
+++ b/eth/downloader/bor_downloader_test.go
@@ -1113,7 +1113,7 @@ func TestSidechainGhostStateBacksOffPeerInsteadOfDropping(t *testing.T) {
 	tester.newPeer(id, eth.ETH69, chain.blocks[1:])
 
 	tester.downloader.synchroniseMock = func(string, common.Hash) error {
-		return fmt.Errorf("%w: sidechain ghost-state attack", errInvalidChain)
+		return fmt.Errorf("%w: %w", errInvalidChain, types.ErrSidechainGhostState)
 	}
 
 	err := tester.downloader.LegacySync(id, tester.chain.Genesis().Hash(), big.NewInt(1000), nil, FullSync)

--- a/eth/downloader/bor_downloader_test.go
+++ b/eth/downloader/bor_downloader_test.go
@@ -1151,6 +1151,19 @@ func TestBackedOffPeerIsNotUsedForLegacySync(t *testing.T) {
 	}
 }
 
+func TestPeerBackedOffClearsExpiredDeadline(t *testing.T) {
+	peer := &peerConnection{
+		backoffUntil: time.Now().Add(-time.Second),
+	}
+
+	if peer.backedOff() {
+		t.Fatalf("expired backoff reported peer as backed off")
+	}
+	if !peer.backoffUntil.IsZero() {
+		t.Fatalf("expired backoff deadline was not cleared: %v", peer.backoffUntil)
+	}
+}
+
 // Tests that synchronisation progress (origin block number, current block number
 // and highest block number) is tracked and updated correctly.
 func TestSyncProgress68Full(t *testing.T) { testSyncProgress(t, eth.ETH68, FullSync) }

--- a/eth/downloader/bor_downloader_test.go
+++ b/eth/downloader/bor_downloader_test.go
@@ -1104,6 +1104,53 @@ func testBlockHeaderAttackerDropping(t *testing.T, protocol uint) {
 	}
 }
 
+func TestSidechainGhostStateBacksOffPeerInsteadOfDropping(t *testing.T) {
+	tester := newTester(t)
+	defer tester.terminate()
+
+	id := "ghost-state-peer"
+	chain := testChainBase.shorten(1)
+	tester.newPeer(id, eth.ETH69, chain.blocks[1:])
+
+	tester.downloader.synchroniseMock = func(string, common.Hash) error {
+		return fmt.Errorf("%w: sidechain ghost-state attack", errInvalidChain)
+	}
+
+	err := tester.downloader.LegacySync(id, tester.chain.Genesis().Hash(), big.NewInt(1000), nil, FullSync)
+	if !errors.Is(err, errInvalidChain) {
+		t.Fatalf("sync error mismatch: have %v, want %v", err, errInvalidChain)
+	}
+	if _, ok := tester.peers[id]; !ok {
+		t.Fatalf("ghost-state peer was hard dropped")
+	}
+	peer := tester.downloader.peers.Peer(id)
+	if peer == nil {
+		t.Fatalf("ghost-state peer missing from downloader peer set")
+	}
+	if !peer.backedOff() {
+		t.Fatalf("ghost-state peer was not backed off")
+	}
+}
+
+func TestBackedOffPeerIsNotUsedForLegacySync(t *testing.T) {
+	tester := newTester(t)
+	defer tester.terminate()
+
+	id := "ghost-state-peer"
+	chain := testChainBase.shorten(1)
+	tester.newPeer(id, eth.ETH69, chain.blocks[1:])
+
+	tester.downloader.backoffPeer(id, sidechainGhostStatePeerBackoff)
+
+	err := tester.downloader.LegacySync(id, tester.chain.Genesis().Hash(), big.NewInt(1000), nil, FullSync)
+	if !errors.Is(err, errPeerBackedOff) {
+		t.Fatalf("sync error mismatch: have %v, want %v", err, errPeerBackedOff)
+	}
+	if _, ok := tester.peers[id]; !ok {
+		t.Fatalf("backed off peer was hard dropped")
+	}
+}
+
 // Tests that synchronisation progress (origin block number, current block number
 // and highest block number) is tracked and updated correctly.
 func TestSyncProgress68Full(t *testing.T) { testSyncProgress(t, eth.ETH68, FullSync) }

--- a/eth/downloader/bor_fetchers_concurrent.go
+++ b/eth/downloader/bor_fetchers_concurrent.go
@@ -177,25 +177,30 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 			isWitnessQueue := queue.kind() == witnessQueueKind
 			isReceiptQueue := queue.kind() == receiptQueueKind
 
+			capable := func(peer *peerConnection) bool {
+				switch {
+				case peer.backedOff():
+					return false
+				case isWitnessQueue && !peer.peer.SupportsWitness():
+					peer.log.Trace("Skipping peer for witness fetch - no witness support", "peer", peer.id)
+					return false
+				case isReceiptQueue && peer.version < eth.ETH69:
+					peer.log.Trace("Skipping peer for fetching receipts - version below eth/69", "peer", peer.id)
+					return false
+				default:
+					return true
+				}
+			}
+
+			var capablePeers []*peerConnection
 			for _, peer := range d.peers.AllPeers() {
-				if peer.backedOff() {
+				if !capable(peer) {
 					continue
 				}
+				capablePeers = append(capablePeers, peer)
+
 				pending, stale := pending[peer.id], stales[peer.id]
 				if pending == nil && stale == nil {
-					// For witness fetching, skip peers that don't support the witness protocol
-					if isWitnessQueue && !peer.peer.SupportsWitness() {
-						peer.log.Trace("Skipping peer for witness fetch - no witness support", "peer", peer.id)
-						continue
-					}
-
-					// eth/69 handlers also sends bor receipts via p2p. Skip peers
-					// below that to avoid missing bor receipts.
-					if isReceiptQueue && peer.version < eth.ETH69 {
-						peer.log.Trace("Skipping peer for fetching receipts - version below eth/69", "peer", peer.id)
-						continue
-					}
-
 					idles = append(idles, peer)
 					caps = append(caps, queue.capacity(peer, time.Second))
 				} else if stale != nil {
@@ -269,27 +274,7 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 			}
 			// Make sure that we have peers available for fetching. If all peers have been tried
 			// and all failed throw an error
-			var capablePeers int
-			if isWitnessQueue {
-				// For witness fetching, only count peers that support the witness protocol
-				for _, peer := range d.peers.AllPeers() {
-					if peer.peer.SupportsWitness() {
-						capablePeers++
-					}
-				}
-			} else if isReceiptQueue {
-				// For receipt fetching, only count eth/69+ peers that include bor receipts
-				for _, peer := range d.peers.AllPeers() {
-					if peer.version >= eth.ETH69 {
-						capablePeers++
-					}
-				}
-			} else {
-				// For other queues, all peers are capable
-				capablePeers = d.peers.Len()
-			}
-
-			if !progressed && !throttled && len(pending) == 0 && len(idles) == capablePeers && queued > 0 && !beaconMode {
+			if !progressed && !throttled && len(pending) == 0 && len(idles) == len(capablePeers) && queued > 0 && !beaconMode {
 				return errPeersUnavailable
 			}
 		}

--- a/eth/downloader/bor_fetchers_concurrent.go
+++ b/eth/downloader/bor_fetchers_concurrent.go
@@ -177,10 +177,8 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 			isWitnessQueue := queue.kind() == witnessQueueKind
 			isReceiptQueue := queue.kind() == receiptQueueKind
 
-			capable := func(peer *peerConnection) bool {
+			eligible := func(peer *peerConnection) bool {
 				switch {
-				case peer.backedOff():
-					return false
 				case isWitnessQueue && !peer.peer.SupportsWitness():
 					peer.log.Trace("Skipping peer for witness fetch - no witness support", "peer", peer.id)
 					return false
@@ -192,9 +190,17 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 				}
 			}
 
-			var capablePeers []*peerConnection
+			var (
+				eligiblePeers []*peerConnection
+				capablePeers  []*peerConnection
+			)
 			for _, peer := range d.peers.AllPeers() {
-				if !capable(peer) {
+				if !eligible(peer) {
+					continue
+				}
+				eligiblePeers = append(eligiblePeers, peer)
+
+				if peer.backedOff() {
 					continue
 				}
 				capablePeers = append(capablePeers, peer)
@@ -275,6 +281,9 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 			// Make sure that we have peers available for fetching. If all peers have been tried
 			// and all failed throw an error
 			if !progressed && !throttled && len(pending) == 0 && len(idles) == len(capablePeers) && queued > 0 && !beaconMode {
+				if len(capablePeers) < len(eligiblePeers) {
+					return errPeerBackedOff
+				}
 				return errPeersUnavailable
 			}
 		}

--- a/eth/downloader/bor_fetchers_concurrent.go
+++ b/eth/downloader/bor_fetchers_concurrent.go
@@ -178,6 +178,9 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 			isReceiptQueue := queue.kind() == receiptQueueKind
 
 			for _, peer := range d.peers.AllPeers() {
+				if peer.backedOff() {
+					continue
+				}
 				pending, stale := pending[peer.id], stales[peer.id]
 				if pending == nil && stale == nil {
 					// For witness fetching, skip peers that don't support the witness protocol

--- a/eth/downloader/bor_fetchers_concurrent_test.go
+++ b/eth/downloader/bor_fetchers_concurrent_test.go
@@ -99,6 +99,46 @@ func TestConcurrentFetchReceipts_OnlyEth68Peers(t *testing.T) {
 	}
 }
 
+func TestConcurrentFetchReceipts_AllPeersBackedOff(t *testing.T) {
+	d := newTestDownloader()
+	scheduleReceiptTask(d)
+
+	var mockPeers = make([]*mockPeer, 2)
+	mockPeers[0] = &mockPeer{id: "peer-a", protocol: eth.ETH69}
+	mockPeers[1] = &mockPeer{id: "peer-b", protocol: eth.ETH69}
+
+	for _, peer := range mockPeers {
+		pc := newPeerConnection(peer.id, peer.protocol, peer, log.New("peer", peer.id))
+		if err := d.peers.Register(pc); err != nil {
+			t.Fatal(err)
+		}
+		pc.backoff(time.Hour)
+	}
+
+	if d.queue.PendingReceipts() == 0 {
+		t.Fatal("expected pending receipts in queue")
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- d.concurrentFetch((*receiptQueue)(d), false) }()
+
+	select {
+	case err := <-errCh:
+		if err != errPeerBackedOff {
+			t.Fatalf("expected errPeerBackedOff, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		close(d.cancelCh)
+		t.Fatal("concurrentFetch stalled with all peers backed off")
+	}
+
+	for _, peer := range mockPeers {
+		if peer.receiptRequested.Load() {
+			t.Errorf("backed-off peer %s should NOT have received a receipt request", peer.id)
+		}
+	}
+}
+
 // TestConcurrentFetchReceipts_MixedPeers verifies that concurrentFetch
 // dispatches receipt requests only to eth/69 peers, skipping eth/68 ones.
 func TestConcurrentFetchReceipts_MixedPeers(t *testing.T) {

--- a/eth/downloader/metrics.go
+++ b/eth/downloader/metrics.go
@@ -40,6 +40,10 @@ var (
 
 	throttleCounter = metrics.NewRegisteredCounter("eth/downloader/throttle", nil)
 
+	// peerGhostStateBackoffMeter counts peers temporarily backed off due to a
+	// sidechain ghost-state attack error instead of being permanently dropped.
+	peerGhostStateBackoffMeter = metrics.NewRegisteredMeter("eth/downloader/peers/ghoststate/backoff", nil)
+
 	// Amortized per-item download durations (batch duration / item count).
 	headerItemDownloadTimer  = metrics.NewRegisteredTimer("eth/downloader/headers/item_download_duration", nil)
 	bodyItemDownloadTimer    = metrics.NewRegisteredTimer("eth/downloader/bodies/item_download_duration", nil)

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -51,9 +51,10 @@ type peerConnection struct {
 
 	peer Peer
 
-	version uint       // Eth protocol version number to switch strategies
-	log     log.Logger // Contextual logger to add extra infos to peer logs
-	lock    sync.RWMutex
+	version      uint       // Eth protocol version number to switch strategies
+	log          log.Logger // Contextual logger to add extra infos to peer logs
+	backoffUntil time.Time
+	lock         sync.RWMutex
 }
 
 // Peer encapsulates the methods required to synchronise with a remote full peer.
@@ -87,6 +88,27 @@ func (p *peerConnection) Reset() {
 	defer p.lock.Unlock()
 
 	p.lacking = make(map[common.Hash]struct{})
+}
+
+func (p *peerConnection) backoff(duration time.Duration) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.backoffUntil = time.Now().Add(duration)
+}
+
+func (p *peerConnection) backedOff() bool {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.backoffUntil.IsZero() {
+		return false
+	}
+	if time.Now().Before(p.backoffUntil) {
+		return true
+	}
+	p.backoffUntil = time.Time{}
+	return false
 }
 
 // UpdateHeaderRate updates the peer's estimated header retrieval throughput with

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -109,11 +109,13 @@ func (p *peerConnection) backedOff() bool {
 		return true
 	}
 	p.lock.Lock()
-	if !p.backoffUntil.IsZero() && !time.Now().Before(p.backoffUntil) {
+	defer p.lock.Unlock()
+
+	backedOff := time.Now().Before(p.backoffUntil)
+	if !backedOff {
 		p.backoffUntil = time.Time{}
 	}
-	p.lock.Unlock()
-	return false
+	return backedOff
 }
 
 // UpdateHeaderRate updates the peer's estimated header retrieval throughput with

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -98,16 +98,21 @@ func (p *peerConnection) backoff(duration time.Duration) {
 }
 
 func (p *peerConnection) backedOff() bool {
-	p.lock.Lock()
-	defer p.lock.Unlock()
+	p.lock.RLock()
+	until := p.backoffUntil
+	p.lock.RUnlock()
 
-	if p.backoffUntil.IsZero() {
+	if until.IsZero() {
 		return false
 	}
-	if time.Now().Before(p.backoffUntil) {
+	if time.Now().Before(until) {
 		return true
 	}
-	p.backoffUntil = time.Time{}
+	p.lock.Lock()
+	if !p.backoffUntil.IsZero() && !time.Now().Before(p.backoffUntil) {
+		p.backoffUntil = time.Time{}
+	}
+	p.lock.Unlock()
 	return false
 }
 

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -706,6 +706,9 @@ func (s *skeleton) assignTasks(success chan *headerResponse, fail chan *headerRe
 	targetTTL := s.peers.rates.TargetTimeout()
 
 	for _, peer := range s.idles {
+		if peer.backedOff() {
+			continue
+		}
 		idlers.peers = append(idlers.peers, peer)
 		idlers.caps = append(idlers.caps, s.peers.rates.Capacity(peer.id, eth.BlockHeadersMsg, targetTTL))
 	}

--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -219,6 +219,23 @@ func (p *skeletonTestPeer) SupportsWitness() bool {
 	return false
 }
 
+func TestSkeletonAssignTasksSkipsBackedOffPeers(t *testing.T) {
+	peer := newPeerConnection("backed-off", eth.ETH69, nil, log.New("id", "backed-off"))
+	peer.backoff(time.Minute)
+
+	skeleton := &skeleton{
+		peers: newPeerSet(),
+		idles: map[string]*peerConnection{
+			peer.id: peer,
+		},
+	}
+	skeleton.assignTasks(make(chan *headerResponse), make(chan *headerRequest), make(chan struct{}))
+
+	if _, ok := skeleton.idles[peer.id]; !ok {
+		t.Fatalf("backed off peer was assigned")
+	}
+}
+
 // Tests various sync initializations based on previous leftovers in the database
 // and announced heads.
 func TestSkeletonSyncInit(t *testing.T) {

--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -224,7 +224,10 @@ func TestSkeletonAssignTasksSkipsBackedOffPeers(t *testing.T) {
 	peer.backoff(time.Minute)
 
 	skeleton := &skeleton{
-		peers: newPeerSet(),
+		peers:         newPeerSet(),
+		requests:      make(map[uint64]*headerRequest),
+		scratchOwners: make([]string, scratchHeaders/requestHeaders),
+		scratchHead:   scratchHeaders,
 		idles: map[string]*peerConnection{
 			peer.id: peer,
 		},
@@ -233,6 +236,9 @@ func TestSkeletonAssignTasksSkipsBackedOffPeers(t *testing.T) {
 
 	if _, ok := skeleton.idles[peer.id]; !ok {
 		t.Fatalf("backed off peer was assigned")
+	}
+	if skeleton.scratchOwners[0] != "" {
+		t.Fatalf("task was assigned to backed off peer: owner=%q", skeleton.scratchOwners[0])
 	}
 }
 

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -402,7 +402,7 @@ func (ps *peerSet) getAllPeers() []*ethPeer {
 
 // peerWithHighestTD retrieves the known peer with the currently highest total
 // difficulty, but below the given PoS switchover threshold.
-func (ps *peerSet) peerWithHighestTD() *eth.Peer {
+func (ps *peerSet) peerWithHighestTD(skip func(id string) bool) *eth.Peer {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
@@ -412,6 +412,9 @@ func (ps *peerSet) peerWithHighestTD() *eth.Peer {
 	)
 
 	for _, p := range ps.peers {
+		if skip != nil && skip(p.ID()) {
+			continue
+		}
 		if _, td := p.Head(); bestPeer == nil || td.Cmp(bestTd) > 0 {
 			bestPeer, bestTd = p.Peer, td
 		}

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -163,7 +163,7 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 	// We have enough peers, pick the one with the highest TD, but avoid going
 	// over the terminal total difficulty. Above that we expect the consensus
 	// clients to direct the chain head to sync to.
-	peer := cs.handler.peers.peerWithHighestTD()
+	peer := cs.handler.peers.peerWithHighestTD(cs.handler.downloader.IsPeerBackedOff)
 	if peer == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary
This change keeps Bor’s sidechain ghost-state attack state-safety guard intact but changes the downloader response for that specific mismatch. Instead of hard-dropping the peer when the ghost-state error is wrapped as `errInvalidChain`, downloader now applies a temporary soft backoff. The peer stays connected and is skipped for downloader sync work during the backoff window, which should reduce avoidable P2P peer removals under load while still rejecting unsafe sidechain data.


## Executed tests
go test ./eth/downloader -run 'TestSidechainGhostState|TestBackedOffPeer|TestBlockHeaderAttackerDropping' -count=1
go test ./eth/downloader -count=1

Both passed.

## Rollout notes
This is not a consensus change. Bor still rejects the sidechain ghost-state block and does not change canonical state. The change is limited to downloader peer handling, so it is backwards-compatible and does not require a coordinated upgrade. Operators should see fewer hard peer removals for this specific ghost-state sync mismatch.





