### PR TITLE
core/blockstm, core: order same-authority EIP-7702 txs in V2 execution

### DIFF
--- a/core/blockstm/v2_executor.go
+++ b/core/blockstm/v2_executor.go
@@ -22,9 +22,10 @@ type V2Task interface {
 	To() *common.Address // nil for contract creation
 	// Authorities returns the unique EIP-7702 authorities of this tx
 	// (signers in the SetCode auth list). Empty for non-SetCodeTx.
-	// V2 uses these to maintain per-address nonce deltas across the
-	// block, since each authority's nonce is bumped at apply time even
-	// though it isn't the tx sender.
+	// V2 uses these both for nonce publication and for execution ordering:
+	// each applied authorization mutates the authority account's nonce/code
+	// even though the authority may be neither the tx sender nor the call
+	// target.
 	Authorities() []common.Address
 }
 
@@ -86,6 +87,10 @@ type V2ExecutionResult struct {
 	ValWaitDur  time.Duration // time waiting for workers
 	ValCheckDur time.Duration // time doing validation checks
 	ValReexDur  time.Duration // time blocked on re-execution
+	// Same-authority EIP-7702 serialization cost: tasks that blocked on an
+	// authPrev predecessor, and aggregate wall time spent blocked.
+	AuthStallCount int
+	AuthStallDur   time.Duration
 	// Non-nil if runValidationLoop recovered from a panic; caller should
 	// discard this result and fall back to serial.
 	ValidationPanic any
@@ -156,11 +161,18 @@ type v2ExecCtx struct {
 	vfailIdxs    []int
 	vfailed      []atomic.Bool
 	toPrev       []int
+	authPrev     []int
 	completionCh []chan struct{}
 	finalized    []atomic.Bool
 	execDone     []chan struct{}
 	chSettle     chan int
 	reexecWg     sync.WaitGroup // re-exec goroutines launched by dispatchReexec
+
+	// authPrev serialization observability: how many tasks actually blocked
+	// on a same-authority predecessor and for how long in aggregate. Written
+	// from worker goroutines, so atomic.
+	authStallCount atomic.Int64
+	authStallNanos atomic.Int64
 
 	taskSenderNonces []map[common.Address]uint64
 
@@ -194,9 +206,27 @@ func newV2ExecCtx(tasks []V2Task, env V2Env, coinbase common.Address,
 	for i := range x.execDone {
 		x.execDone[i] = make(chan struct{})
 	}
-	x.taskSenderNonces = computeSenderNonces(tasks, env)
+	// Recover each task's EIP-7702 authorities once; both nonce-precompute
+	// and authority ordering consume the result so recovery (an ecrecover
+	// per authorization) isn't paid twice per block.
+	taskAuths := computeTaskAuthorities(tasks)
+	x.taskSenderNonces = computeSenderNonces(tasks, env, taskAuths)
 	x.toPrev = computeToPrev(tasks, conflictAddrs)
+	x.authPrev = computeAuthorityPrev(taskAuths)
 	return x
+}
+
+// computeTaskAuthorities recovers each task's EIP-7702 authorities exactly
+// once. Authority recovery is an ecrecover per authorization; both
+// computeSenderNonces (exclusion set) and computeAuthorityPrev (ordering)
+// need the same set, so recover here and share the slice rather than calling
+// V2Task.Authorities() twice per task.
+func computeTaskAuthorities(tasks []V2Task) [][]common.Address {
+	out := make([][]common.Address, len(tasks))
+	for i := range tasks {
+		out[i] = tasks[i].Authorities()
+	}
+	return out
 }
 
 // computeSenderNonces returns per-task per-sender pre-computed nonces for
@@ -215,14 +245,14 @@ func newV2ExecCtx(tasks []V2Task, env V2Env, coinbase common.Address,
 // Tasks with no chain and no auth-list interaction get nil — same as
 // the original optimisation, so PDB.GetNonce reads the base nonce
 // directly.
-func computeSenderNonces(tasks []V2Task, env V2Env) []map[common.Address]uint64 {
+func computeSenderNonces(tasks []V2Task, env V2Env, taskAuths [][]common.Address) []map[common.Address]uint64 {
 	// Any address that is an authority in any tx may have its nonce
 	// dynamically bumped by the auth-list applier. Don't pre-compute
 	// nonces for those addresses — let the MVStore-aware path handle
 	// the dependency.
 	var authoritySet map[common.Address]struct{}
-	for i := range tasks {
-		for _, auth := range tasks[i].Authorities() {
+	for i := range taskAuths {
+		for _, auth := range taskAuths[i] {
 			if authoritySet == nil {
 				authoritySet = make(map[common.Address]struct{})
 			}
@@ -336,6 +366,30 @@ func (c *chainState) predecessor(to *common.Address, i int,
 	return prev
 }
 
+// computeAuthorityPrev chains transactions that share an EIP-7702 authority.
+// Applying an authorization reads and then mutates the authority account's
+// nonce and code, even though that account is not necessarily the tx sender or
+// the call target. A later tx with the same authority must therefore observe
+// the earlier tx after validation/re-execution has settled, not merely after
+// the earlier first incarnation flushed speculative writes.
+func computeAuthorityPrev(taskAuths [][]common.Address) []int {
+	out := make([]int, len(taskAuths))
+	lastAuth := make(map[common.Address]int)
+	for i := range taskAuths {
+		out[i] = -1
+		auths := taskAuths[i]
+		for _, auth := range auths {
+			if prev, ok := lastAuth[auth]; ok && prev > out[i] {
+				out[i] = prev
+			}
+		}
+		for _, auth := range auths {
+			lastAuth[auth] = i
+		}
+	}
+	return out
+}
+
 // waitForTx blocks until the writer at writerIdx has at least executed
 // (its first FlushToMVStore is visible) — used by per-key pipelining.
 //
@@ -418,6 +472,22 @@ func (x *v2ExecCtx) execute(taskIdx, workerID int) {
 		case <-x.ctx.Done():
 			return
 		}
+	}
+	if prev := x.authPrev[taskIdx]; prev >= 0 && !x.finalized[prev].Load() {
+		// Same-authority EIP-7702 txs depend on the authority's nonce/code,
+		// which the earlier tx mutates even though the authority is neither its
+		// sender nor its call target — a dependency the toPrev/sender-chain
+		// hints don't capture. Wait for the earlier tx to finalize so this tx's
+		// authorization check runs against the committed authority state rather
+		// than racing its publication.
+		tStall := time.Now()
+		select {
+		case <-x.completionCh[prev]:
+		case <-x.ctx.Done():
+			return
+		}
+		x.authStallCount.Add(1)
+		x.authStallNanos.Add(int64(time.Since(tStall)))
 	}
 	st := x.env.Execute(x.tasks[taskIdx], workerID, x.incarnations[taskIdx],
 		x.taskSenderNonces[taskIdx], x.coinbase, x.waitForTx, x.waitForFinal, true)
@@ -598,13 +668,16 @@ func (x *v2ExecCtx) dispatchReexec(i int) chan struct{} {
 // every j < i-1. The loop preserves this by induction: validateOne(j+1)
 // always finishes reexecDone[j] (via the i-1 check below) before
 // returning, so by the time we reach validateOne(i), only reexecDone[i-1]
-// can be non-nil. The toPrev check below is a hint for predicted
-// predecessors and is redundant for ordering; the i-1 check carries the
+// can be non-nil. The toPrev/authPrev checks below are hints for predicted
+// predecessors and are redundant for ordering; the i-1 check carries the
 // invariant. A future "skip-ahead" optimisation that bypasses
 // validateOne(j) for some j would break settle order — keep this in mind.
 func (x *v2ExecCtx) validateOne(reexecDone []chan struct{}, i int) bool {
 	x.assertSettleOrder(reexecDone, i)
 	if prev := x.toPrev[i]; prev >= 0 && reexecDone[prev] != nil {
+		x.finishReexec(reexecDone, prev)
+	}
+	if prev := x.authPrev[i]; prev >= 0 && reexecDone[prev] != nil {
 		x.finishReexec(reexecDone, prev)
 	}
 	if i > 0 && x.vfailed[i-1].Load() && reexecDone[i-1] != nil {
@@ -637,7 +710,8 @@ func (x *v2ExecCtx) validateOne(reexecDone []chan struct{}, i int) bool {
 // runValidationLoop is the main validation goroutine. It validates each tx
 // in order, dispatching re-executions non-blocking and only stalling for
 // re-exec completion when a later tx depends on a still-pending one (via
-// toPrev or vfailed[i-1]). After the main loop, it drains any leftovers.
+// toPrev, authPrev, or vfailed[i-1]). After the main loop, it drains any
+// leftovers.
 func (x *v2ExecCtx) runValidationLoop(valDone chan struct{}) {
 	defer close(valDone)
 
@@ -707,6 +781,8 @@ func (x *v2ExecCtx) buildResult(startTime time.Time, settleStart, settleEnd *tim
 		ValWaitDur:      x.valWaitDur,
 		ValCheckDur:     x.valCheckDur,
 		ValReexDur:      x.valReexDur,
+		AuthStallCount:  int(x.authStallCount.Load()),
+		AuthStallDur:    time.Duration(x.authStallNanos.Load()),
 		ValidationPanic: x.validationPanic,
 	}
 }

--- a/core/blockstm/v2_executor.go
+++ b/core/blockstm/v2_executor.go
@@ -120,9 +120,15 @@ func ExecuteV2BlockSTM(
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	// Derive a cancellable ctx so the validation goroutine can release workers
+	// parked on completionCh waits (e.g. the authPrev barrier) if it panics —
+	// the incoming ctx is typically long-lived and never cancelled on panic.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	x := newV2ExecCtx(tasks, env, coinbase, numWorkers, conflictAddrs)
 	x.ctx = ctx
+	x.cancel = cancel
 	startTime := time.Now()
 
 	taskCh, wg := x.startWorkers()
@@ -146,7 +152,8 @@ func ExecuteV2BlockSTM(
 // Pulled out of the long function so each phase reads as a focused
 // method against a stable receiver instead of a closure soup.
 type v2ExecCtx struct {
-	ctx          context.Context // for cancellation; checked at dispatch and validation boundaries
+	ctx          context.Context    // for cancellation; checked at dispatch and validation boundaries
+	cancel       context.CancelFunc // cancels ctx so workers parked on completionCh waits unblock on a validation panic
 	tasks        []V2Task
 	env          V2Env
 	coinbase     common.Address
@@ -726,6 +733,12 @@ func (x *v2ExecCtx) runValidationLoop(valDone chan struct{}) {
 	defer func() {
 		if r := recover(); r != nil {
 			x.validationPanic = r
+			// Unfinalized tasks never close their completionCh, so workers
+			// parked on the authPrev/finalization waits would hang. Cancel ctx
+			// to release them and let the caller fall back to serial.
+			if x.cancel != nil {
+				x.cancel()
+			}
 			log.Error("V2 validation panic — falling back to serial",
 				"err", r, "stack", string(debug.Stack()))
 		}

--- a/core/blockstm/v2_executor_test.go
+++ b/core/blockstm/v2_executor_test.go
@@ -261,6 +261,37 @@ func TestV2ValidationPanicIsRecovered(t *testing.T) {
 	}
 }
 
+// TestV2SharedAuthorityValidationPanicNoDeadlock: a Validate() panic on an
+// earlier tx must not wedge a later tx parked on the authPrev barrier. The
+// earlier tx never finalizes (so its completionCh never closes), so the
+// recover path must cancel ctx to release the parked worker; otherwise
+// ExecuteV2BlockSTM hangs on wg.Wait instead of surfacing ValidationPanic for
+// the serial fallback. Hangs without the cancel-on-panic fix.
+func TestV2SharedAuthorityValidationPanicNoDeadlock(t *testing.T) {
+	authority := common.HexToAddress("0xA")
+	env := &panickingV2Env{s: &panickingV2State{}}
+	// Both txs share the authority, so authPrev[1] = 0 and tx1 waits on tx0's
+	// finalization — which never comes because tx0's Validate() panics.
+	tasks := []V2Task{
+		&nonceMockTask{idx: 0, sender: common.HexToAddress("0x1"), auths: []common.Address{authority}},
+		&nonceMockTask{idx: 1, sender: common.HexToAddress("0x2"), auths: []common.Address{authority}},
+	}
+
+	done := make(chan *V2ExecutionResult, 1)
+	go func() {
+		done <- ExecuteV2BlockSTM(context.Background(), tasks, env, common.Address{}, 2, nil, func(int, V2TxState) {})
+	}()
+
+	select {
+	case result := <-done:
+		if result == nil || result.ValidationPanic == nil {
+			t.Fatalf("expected ValidationPanic to be set, got %+v", result)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ExecuteV2BlockSTM deadlocked: Validate() panic on a shared-authority predecessor left the later tx parked on the authPrev barrier")
+	}
+}
+
 // nonceMockTask lets tests override Sender/Authorities per task.
 type nonceMockTask struct {
 	idx    int

--- a/core/blockstm/v2_executor_test.go
+++ b/core/blockstm/v2_executor_test.go
@@ -306,7 +306,7 @@ func TestComputeSenderNonces_ExcludesAuthorities(t *testing.T) {
 			&nonceMockTask{idx: 1, sender: addrA},
 		}
 		env := &nonceMockEnv{nonces: map[common.Address]uint64{addrA: 100}}
-		out := computeSenderNonces(tasks, env)
+		out := computeSenderNonces(tasks, env, computeTaskAuthorities(tasks))
 		if got := out[0][addrA]; got != 100 {
 			t.Errorf("tx0 SenderNonces[A] = %d, want 100", got)
 		}
@@ -326,7 +326,7 @@ func TestComputeSenderNonces_ExcludesAuthorities(t *testing.T) {
 			&nonceMockTask{idx: 2, sender: addrA},
 		}
 		env := &nonceMockEnv{nonces: map[common.Address]uint64{addrA: 0, addrB: 0}}
-		out := computeSenderNonces(tasks, env)
+		out := computeSenderNonces(tasks, env, computeTaskAuthorities(tasks))
 		// B is not an authority: still gets nil because chain length is 1.
 		if out[0] != nil {
 			t.Errorf("tx0 SenderNonces = %v, want nil (single-tx sender)", out[0])
@@ -351,7 +351,7 @@ func TestComputeSenderNonces_ExcludesAuthorities(t *testing.T) {
 			&nonceMockTask{idx: 2, sender: addrC, auths: []common.Address{addrA}},
 		}
 		env := &nonceMockEnv{nonces: map[common.Address]uint64{addrA: 50, addrC: 0}}
-		out := computeSenderNonces(tasks, env)
+		out := computeSenderNonces(tasks, env, computeTaskAuthorities(tasks))
 		if out[0] != nil || out[1] != nil {
 			t.Errorf("A is auth in tx[2]; want nil for tx[0] and tx[1], got %v / %v", out[0], out[1])
 		}
@@ -366,7 +366,7 @@ func TestComputeSenderNonces_ExcludesAuthorities(t *testing.T) {
 			&nonceMockTask{idx: 2, sender: addrA},
 		}
 		env := &nonceMockEnv{nonces: map[common.Address]uint64{addrA: 7}}
-		out := computeSenderNonces(tasks, env)
+		out := computeSenderNonces(tasks, env, computeTaskAuthorities(tasks))
 		if got := out[1][addrA]; got != 7 {
 			t.Errorf("tx1 SenderNonces[A] = %d, want 7", got)
 		}
@@ -374,4 +374,130 @@ func TestComputeSenderNonces_ExcludesAuthorities(t *testing.T) {
 			t.Errorf("tx2 SenderNonces[A] = %d, want 8", got)
 		}
 	})
+}
+
+func TestComputeAuthorityPrev(t *testing.T) {
+	addrA := common.HexToAddress("0xA")
+	addrB := common.HexToAddress("0xB")
+	addrC := common.HexToAddress("0xC")
+
+	tasks := []V2Task{
+		&nonceMockTask{idx: 0, sender: addrA, auths: []common.Address{addrA}},
+		&nonceMockTask{idx: 1, sender: addrB, auths: []common.Address{addrB}},
+		&nonceMockTask{idx: 2, sender: addrC, auths: []common.Address{addrA}},
+		&nonceMockTask{idx: 3, sender: addrC, auths: []common.Address{addrB, addrA}},
+		&nonceMockTask{idx: 4, sender: addrC},
+	}
+
+	got := computeAuthorityPrev(computeTaskAuthorities(tasks))
+	want := []int{-1, -1, 0, 2, -1}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("authPrev[%d] = %d, want %d; full=%v", i, got[i], want[i], got)
+		}
+	}
+}
+
+type authorityWaitState struct {
+	validateStarted chan struct{}
+	validateRelease chan struct{}
+	validateOnce    sync.Once
+}
+
+func (s *authorityWaitState) Validate() bool {
+	if s.validateStarted != nil {
+		s.validateOnce.Do(func() { close(s.validateStarted) })
+	}
+	if s.validateRelease != nil {
+		<-s.validateRelease
+	}
+	return true
+}
+func (s *authorityWaitState) ValidateCategory() string                { return "" }
+func (s *authorityWaitState) MarkEstimate()                           {}
+func (s *authorityWaitState) CleanupEstimate([]Key, []common.Address) {}
+func (s *authorityWaitState) GetWriteKeys() []Key                     { return nil }
+func (s *authorityWaitState) GetBalAddrs() []common.Address           { return nil }
+func (s *authorityWaitState) FlushToMVStore()                         {}
+func (s *authorityWaitState) SetDeferMVWrites(bool)                   {}
+
+type authorityWaitEnv struct {
+	states      []V2TxState
+	execStarted []chan struct{}
+	startOnce   []sync.Once
+}
+
+func (e *authorityWaitEnv) BaseNonce(common.Address) uint64 { return 0 }
+func (e *authorityWaitEnv) Execute(task V2Task, workerID int, incarnation int,
+	senderNonces map[common.Address]uint64, coinbase common.Address,
+	waitForTx func(int), waitForFinal func(int), deferWrites bool) V2TxState {
+	idx := task.Index()
+	e.startOnce[idx].Do(func() { close(e.execStarted[idx]) })
+	return e.states[idx]
+}
+func (e *authorityWaitEnv) Recycle(V2TxState) {}
+
+func TestV2SharedAuthorityWaitsForFinalization(t *testing.T) {
+	authority := common.HexToAddress("0xA")
+	validateStarted := make(chan struct{})
+	validateRelease := make(chan struct{})
+	execStarted := []chan struct{}{make(chan struct{}), make(chan struct{})}
+
+	env := &authorityWaitEnv{
+		states: []V2TxState{
+			&authorityWaitState{
+				validateStarted: validateStarted,
+				validateRelease: validateRelease,
+			},
+			&authorityWaitState{},
+		},
+		execStarted: execStarted,
+		startOnce:   []sync.Once{{}, {}},
+	}
+	tasks := []V2Task{
+		&nonceMockTask{idx: 0, sender: common.HexToAddress("0x1"), auths: []common.Address{authority}},
+		&nonceMockTask{idx: 1, sender: common.HexToAddress("0x2"), auths: []common.Address{authority}},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ExecuteV2BlockSTM(context.Background(), tasks, env, common.Address{}, 2, nil, func(int, V2TxState) {})
+		close(done)
+	}()
+	defer func() {
+		select {
+		case <-validateRelease:
+		default:
+			close(validateRelease)
+		}
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("ExecuteV2BlockSTM did not return")
+		}
+	}()
+
+	select {
+	case <-execStarted[0]:
+	case <-time.After(time.Second):
+		t.Fatal("tx0 did not start")
+	}
+	select {
+	case <-validateStarted:
+	case <-time.After(time.Second):
+		t.Fatal("tx0 validation did not start")
+	}
+
+	select {
+	case <-execStarted[1]:
+		t.Fatal("tx1 started before tx0 finalized")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(validateRelease)
+	select {
+	case <-execStarted[1]:
+	case <-time.After(time.Second):
+		t.Fatal("tx1 did not start after tx0 finalized")
+	}
 }

--- a/core/parallel_state_processor.go
+++ b/core/parallel_state_processor.go
@@ -1310,5 +1310,7 @@ func logV2BlockStats(block *types.Block, tasks []V2Task, result *V2ExecutionResu
 		"val_wait", common.PrettyDuration(result.ValWaitDur),
 		"val_check", common.PrettyDuration(result.ValCheckDur),
 		"val_reexec", common.PrettyDuration(result.ValReexDur),
+		"auth_stalls", result.AuthStallCount,
+		"auth_stall_dur", common.PrettyDuration(result.AuthStallDur),
 		"settle", common.PrettyDuration(result.SettleDur))
 }

--- a/core/state/parallel_statedb_authority_test.go
+++ b/core/state/parallel_statedb_authority_test.go
@@ -1,0 +1,99 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/blockstm"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/triedb"
+)
+
+// These tests pin the read-validation contract for EIP-7702 authority
+// accounts — accounts that an earlier SetCodeTx mutates (nonce + code) even
+// though they are neither that tx's sender nor its call target. The failure
+// mode they guard against was observed on mainnet (block 87714892): a later
+// SetCodeTx sharing the same authority ran its authorization nonce/code check
+// against the pre-block authority state and its authorization silently failed,
+// diverging gas from the canonical block.
+//
+// The question these answer at the ParallelStateDB layer: once the earlier
+// tx's authority write is committed to the store, does the later tx's
+// Validate() reject the stale read so the executor re-runs it? If these pass,
+// validation is sound and any escaping bad block lives above this layer (the
+// executor / real EIP-7702 apply path); if they fail, the version/value
+// validation has a hole for writes to non-sender / non-target accounts.
+
+func newAuthorityBase(t *testing.T, authority common.Address, nonce uint64, code []byte) *SafeBase {
+	t.Helper()
+	memdb := rawdb.NewMemoryDatabase()
+	tdb := triedb.NewDatabase(memdb, triedb.HashDefaults)
+	sdb, err := New(types.EmptyRootHash, NewDatabase(tdb, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Base state must be populated before SafeBase snapshots the StateDB.
+	sdb.SetNonce(authority, nonce, tracing.NonceChangeUnspecified)
+	if len(code) != 0 {
+		sdb.SetCode(authority, code, tracing.CodeChangeUnspecified)
+	}
+	return NewSafeBase(sdb, 2)
+}
+
+func TestPDB_AuthorityNonceStaleRead_LaterWriterInvalidates(t *testing.T) {
+	authority := common.HexToAddress("0x92E2167c379664462C48F10f76a7A5ea26795cE7")
+	const baseNonce = 5931
+	const writerIdx = 31
+	const readerIdx = 32
+	const finalNonce = 5933
+
+	base := newAuthorityBase(t, authority, baseNonce, nil)
+	store := blockstm.NewMVStore()
+	bals := blockstm.NewMVBalanceStore()
+
+	reader := NewParallelStateDB(readerIdx, base, store, bals)
+	reader.EnableReadTracking()
+
+	// Later tx checks the authorization nonce before the earlier same-authority
+	// tx has published its bump: it observes the stale base nonce and records it.
+	if got := reader.GetNonce(authority); got != baseNonce {
+		t.Fatalf("pre-write read: got %d, want %d", got, baseNonce)
+	}
+
+	// Earlier same-authority tx publishes the bumped nonce.
+	store.WriteInc(blockstm.NewSubpathKey(authority, NoncePath), writerIdx, 0, uint64(finalNonce))
+
+	if reader.Validate() {
+		t.Fatal("Validate=true after the earlier same-authority tx published the authority nonce bump — " +
+			"the later tx would settle a failed authorization while the canonical block applied it")
+	}
+}
+
+func TestPDB_AuthorityCodeStaleRead_LaterWriterInvalidates(t *testing.T) {
+	authority := common.HexToAddress("0x92E2167c379664462C48F10f76a7A5ea26795cE7")
+	target := common.HexToAddress("0x55a0ab9e6182f274a9288469af41feb4438c24a7")
+	const writerIdx = 31
+	const readerIdx = 32
+
+	// Base authority is a plain EOA (no delegation yet).
+	base := newAuthorityBase(t, authority, 5931, nil)
+	store := blockstm.NewMVStore()
+	bals := blockstm.NewMVBalanceStore()
+
+	reader := NewParallelStateDB(readerIdx, base, store, bals)
+	reader.EnableReadTracking()
+
+	if got := reader.GetCode(authority); len(got) != 0 {
+		t.Fatalf("pre-write code read: got %x, want empty", got)
+	}
+
+	// Earlier tx installs the EIP-7702 delegation on the authority.
+	store.WriteInc(blockstm.NewSubpathKey(authority, CodePath), writerIdx, 0, types.AddressToDelegation(target))
+
+	if reader.Validate() {
+		t.Fatal("Validate=true after the earlier same-authority tx installed the delegation code — " +
+			"the later tx read empty code (no delegation) and its execution diverges from canonical")
+	}
+}


### PR DESCRIPTION
## Summary

V2 parallel execution (BlockSTM v2) is missing a dependency edge between transactions that share an **EIP-7702 authority**. Applying an authorization reads and then mutates the *authority account's* nonce and code — but that account is typically neither the transaction's sender nor its call target. The existing scheduling hints (`toPrev` same-`to` chains, same-sender nonce chains) therefore never order two transactions that share an authority.

As a result, a later same-authority transaction can **finalize before the earlier one's authority write lands in the MVStore**, baking a stale base read into the block and diverging gas. The observable symptom is an `invalid gas used` / "bad block" that re-executes correctly on retry (the write has landed by the time it re-runs).

This PR adds the missing ordering edge:

- `computeAuthorityPrev` chains each transaction to the most recent earlier transaction sharing one of its authorities.
- `execute()` waits on that predecessor's **completion (finalization)** — not merely its first speculative flush — before running, so the authorization nonce/code check runs against committed authority state. Finalization is monotonic in transaction order, so the wait is deadlock-free.
- Authorities are recovered once per task (`computeTaskAuthorities`) and the slice is shared between the sender-nonce precompute and the new ordering, so the per-authorization `ecrecover` isn't paid twice per block.
- `auth_stalls` / `auth_stall_dur` are surfaced in the V2 block stats so the serialization cost of same-authority bursts is observable.

The dependency gap is **latent in V2 regardless of import mode**. It was observed in production under pipelined import (`pipelineMode=flatdiff`), whose finalization timing widens the race window — but the fix closes the gap unconditionally rather than depending on import mode.

### Why this is correct, not just a symptom mask

The accompanying `ParallelStateDB` tests show the **validation predicate was already sound** — once the earlier authority write is committed to the MVStore, a later transaction's recorded stale read is correctly rejected by `Validate()`. So the defect is purely **execution ordering** (a later tx finalizing before the earlier tx's write is visible), which is exactly what the new `authPrev` barrier fixes.

## Executed tests

Beyond the standard CI gates:

- `TestV2SharedAuthorityWaitsForFinalization` (new) — pins the ordering barrier. **Verified it fails without the fix** (`tx1 started before tx0 finalized`) and passes with it.
- `TestComputeAuthorityPrev` (new) — pins the same-authority chaining logic.
- `TestPDB_AuthorityNonceStaleRead_LaterWriterInvalidates` / `TestPDB_AuthorityCodeStaleRead_LaterWriterInvalidates` (new) — pin that `Validate()` rejects the stale authority nonce/code read once the earlier write is committed, localizing the defect to ordering rather than the validation predicate.
- Full `go test ./core/blockstm/` suite green (~40s), `go vet ./core/blockstm/` clean, `gofmt` clean.

Field context: the originating branch ran parallel-EVM **on** with pipelined-import-src **off** for 3 days and observed zero bad blocks; with pipelined-src on, the bad blocks reproduced and each self-healed via direct-mode retry. Both "pipelined off" and this `authPrev` fix independently eliminate the bad blocks — they break different links in the same chain (pipelined timing is the trigger, the missing BlockSTM dependency is the cause).

## Rollout notes

- **Consensus-affecting:** yes — changes V2 parallel execution scheduling so same-authority EIP-7702 transactions produce the canonical gas/state. It removes a source of non-deterministic bad blocks; output for any block without shared-authority EIP-7702 transactions is unchanged.
- **Backwards-compatible:** yes — no config, genesis, wire, or storage changes. Pure executor ordering plus added observability fields.
- **Coordinated upgrade:** not required. Nodes without the fix self-heal each bad block via direct-mode re-execution, but carry the latent divergence risk; this makes V2 deterministic for the shared-authority case.
- **Performance:** the barrier only blocks transactions that *share* an EIP-7702 authority (rare); `auth_stalls` / `auth_stall_dur` block stats quantify any serialization cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
