### PR TITLE
eth/filters: honor context cancellation in bor block-log range scan

### DIFF
--- a/eth/filters/bor_filter.go
+++ b/eth/filters/bor_filter.go
@@ -128,6 +128,16 @@ func (f *BorBlockLogsFilter) unindexedLogs(ctx context.Context, end uint64) ([]*
 	sprintLength := f.borConfig.CalculateSprint(uint64(f.begin))
 
 	for ; f.begin <= int64(end); f.begin = f.begin + int64(sprintLength) {
+		// Honor context cancellation (client disconnect or deadline) so a large
+		// range scan stops promptly instead of holding an RPC worker busy with
+		// work whose result the caller will never read. Mirrors the check in
+		// upstream go-ethereum eth/filters/filter.go's unindexedLogs.
+		select {
+		case <-ctx.Done():
+			return logs, ctx.Err()
+		default:
+		}
+
 		header, err := f.backend.HeaderByNumber(ctx, rpc.BlockNumber(f.begin))
 		if header == nil || err != nil {
 			return logs, err

--- a/eth/filters/bor_filter_test.go
+++ b/eth/filters/bor_filter_test.go
@@ -1,13 +1,18 @@
 package filters
 
 import (
+	"context"
+	"errors"
 	"math/big"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	types "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"go.uber.org/mock/gomock"
 )
@@ -151,6 +156,102 @@ func TestBorFilters(t *testing.T) {
 	logs, _ = filter.Logs(t.Context())
 	if len(logs) != 0 {
 		t.Error("expected 0 log, got", len(logs))
+	}
+}
+
+// TestBorFilterHonorsContextCancellation asserts that a range scan stops as soon
+// as the request context is cancelled (e.g. the RPC client disconnected, or a
+// deadline fired) instead of scanning the whole range and keeping an RPC worker
+// busy with work whose result nobody will read. This mirrors the cancellation
+// check upstream go-ethereum performs in eth/filters/filter.go's unindexedLogs.
+func TestBorFilterHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := NewMockDatabase(ctrl)
+	backend := NewMockBackend(ctrl)
+
+	testBorConfig := params.TestChainConfig.Bor
+
+	// Count only the per-block reads inside the scan loop. The single pre-loop
+	// head lookup uses rpc.LatestBlockNumber (negative); loop reads use the
+	// concrete, non-negative block number.
+	var loopBlockReads int32
+	backend.EXPECT().ChainDb().Return(db).AnyTimes()
+	backend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, number rpc.BlockNumber) (*types.Header, error) {
+			if number >= 0 {
+				atomic.AddInt32(&loopBlockReads, 1)
+			}
+			return newTestHeader(1), nil
+		}).AnyTimes()
+	backend.EXPECT().GetBorBlockReceipt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	// Cancel up-front: a scan that honors cancellation must bail out before
+	// doing any per-block work.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Range large enough that an unguarded loop would iterate hundreds of times.
+	filter := NewBorBlockLogsRangeFilter(backend, testBorConfig, 0, 4000, []common.Address{addr}, nil)
+
+	logs, err := filter.Logs(ctx)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got err=%v (loop ran %d block reads, ignoring cancellation)",
+			err, atomic.LoadInt32(&loopBlockReads))
+	}
+	if got := atomic.LoadInt32(&loopBlockReads); got != 0 {
+		t.Fatalf("expected 0 in-loop block reads after honoring cancellation, got %d", got)
+	}
+	if len(logs) != 0 {
+		t.Fatalf("expected no logs on a cancelled scan, got %d", len(logs))
+	}
+}
+
+// TestBorFilterHonorsContextDeadline asserts the scan also stops once the
+// context deadline has passed. Because the loop now observes the context, any
+// deadline attached upstream (an operator-configured RPC timeout, or a deadline
+// the caller sets) bounds the scan -- previously the loop ran to completion
+// regardless of the deadline.
+func TestBorFilterHonorsContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := NewMockDatabase(ctrl)
+	backend := NewMockBackend(ctrl)
+
+	testBorConfig := params.TestChainConfig.Bor
+
+	var loopBlockReads int32
+	backend.EXPECT().ChainDb().Return(db).AnyTimes()
+	backend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, number rpc.BlockNumber) (*types.Header, error) {
+			if number >= 0 {
+				atomic.AddInt32(&loopBlockReads, 1)
+			}
+			return newTestHeader(1), nil
+		}).AnyTimes()
+	backend.EXPECT().GetBorBlockReceipt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	// Deadline already in the past: the scan must stop before any per-block work.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	defer cancel()
+
+	filter := NewBorBlockLogsRangeFilter(backend, testBorConfig, 0, 4000, []common.Address{addr}, nil)
+
+	_, err := filter.Logs(ctx)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got err=%v (loop ran %d block reads, ignoring the deadline)",
+			err, atomic.LoadInt32(&loopBlockReads))
+	}
+	if got := atomic.LoadInt32(&loopBlockReads); got != 0 {
+		t.Fatalf("expected 0 in-loop block reads after honoring the deadline, got %d", got)
 	}
 }
 

--- a/eth/filters/bor_filter_test.go
+++ b/eth/filters/bor_filter_test.go
@@ -159,6 +159,38 @@ func TestBorFilters(t *testing.T) {
 	}
 }
 
+// newCancellationTestFilter builds a bor range filter wired to a mock backend
+// that counts per-block header reads inside the scan loop, returning the filter
+// and a pointer to that counter. A test can then assert the loop bailed out
+// early (counter == 0) instead of scanning the whole range. Only the per-block
+// reads are counted: the single pre-loop head lookup uses rpc.LatestBlockNumber
+// (negative), while loop reads use the concrete, non-negative block number.
+func newCancellationTestFilter(t *testing.T) (*BorBlockLogsFilter, *int32) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	db := NewMockDatabase(ctrl)
+	backend := NewMockBackend(ctrl)
+
+	loopBlockReads := new(int32)
+	backend.EXPECT().ChainDb().Return(db).AnyTimes()
+	backend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, number rpc.BlockNumber) (*types.Header, error) {
+			if number >= 0 {
+				atomic.AddInt32(loopBlockReads, 1)
+			}
+			return newTestHeader(1), nil
+		}).AnyTimes()
+	backend.EXPECT().GetBorBlockReceipt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	// Range large enough that an unguarded loop would iterate hundreds of times.
+	filter := NewBorBlockLogsRangeFilter(backend, params.TestChainConfig.Bor, 0, 4000, []common.Address{addr}, nil)
+
+	return filter, loopBlockReads
+}
+
 // TestBorFilterHonorsContextCancellation asserts that a range scan stops as soon
 // as the request context is cancelled (e.g. the RPC client disconnected, or a
 // deadline fired) instead of scanning the whole range and keeping an RPC worker
@@ -167,43 +199,20 @@ func TestBorFilters(t *testing.T) {
 func TestBorFilterHonorsContextCancellation(t *testing.T) {
 	t.Parallel()
 
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	db := NewMockDatabase(ctrl)
-	backend := NewMockBackend(ctrl)
-
-	testBorConfig := params.TestChainConfig.Bor
-
-	// Count only the per-block reads inside the scan loop. The single pre-loop
-	// head lookup uses rpc.LatestBlockNumber (negative); loop reads use the
-	// concrete, non-negative block number.
-	var loopBlockReads int32
-	backend.EXPECT().ChainDb().Return(db).AnyTimes()
-	backend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, number rpc.BlockNumber) (*types.Header, error) {
-			if number >= 0 {
-				atomic.AddInt32(&loopBlockReads, 1)
-			}
-			return newTestHeader(1), nil
-		}).AnyTimes()
-	backend.EXPECT().GetBorBlockReceipt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	filter, loopBlockReads := newCancellationTestFilter(t)
 
 	// Cancel up-front: a scan that honors cancellation must bail out before
 	// doing any per-block work.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	// Range large enough that an unguarded loop would iterate hundreds of times.
-	filter := NewBorBlockLogsRangeFilter(backend, testBorConfig, 0, 4000, []common.Address{addr}, nil)
-
 	logs, err := filter.Logs(ctx)
 
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got err=%v (loop ran %d block reads, ignoring cancellation)",
-			err, atomic.LoadInt32(&loopBlockReads))
+			err, atomic.LoadInt32(loopBlockReads))
 	}
-	if got := atomic.LoadInt32(&loopBlockReads); got != 0 {
+	if got := atomic.LoadInt32(loopBlockReads); got != 0 {
 		t.Fatalf("expected 0 in-loop block reads after honoring cancellation, got %d", got)
 	}
 	if len(logs) != 0 {
@@ -219,38 +228,19 @@ func TestBorFilterHonorsContextCancellation(t *testing.T) {
 func TestBorFilterHonorsContextDeadline(t *testing.T) {
 	t.Parallel()
 
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	db := NewMockDatabase(ctrl)
-	backend := NewMockBackend(ctrl)
-
-	testBorConfig := params.TestChainConfig.Bor
-
-	var loopBlockReads int32
-	backend.EXPECT().ChainDb().Return(db).AnyTimes()
-	backend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, number rpc.BlockNumber) (*types.Header, error) {
-			if number >= 0 {
-				atomic.AddInt32(&loopBlockReads, 1)
-			}
-			return newTestHeader(1), nil
-		}).AnyTimes()
-	backend.EXPECT().GetBorBlockReceipt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	filter, loopBlockReads := newCancellationTestFilter(t)
 
 	// Deadline already in the past: the scan must stop before any per-block work.
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
 	defer cancel()
 
-	filter := NewBorBlockLogsRangeFilter(backend, testBorConfig, 0, 4000, []common.Address{addr}, nil)
-
 	_, err := filter.Logs(ctx)
 
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context.DeadlineExceeded, got err=%v (loop ran %d block reads, ignoring the deadline)",
-			err, atomic.LoadInt32(&loopBlockReads))
+			err, atomic.LoadInt32(loopBlockReads))
 	}
-	if got := atomic.LoadInt32(&loopBlockReads); got != 0 {
+	if got := atomic.LoadInt32(loopBlockReads); got != 0 {
 		t.Fatalf("expected 0 in-loop block reads after honoring the deadline, got %d", got)
 	}
 }


### PR DESCRIPTION
## What

`BorBlockLogsFilter.unindexedLogs` scans a block range one sprint at a time but
never checked the request context, so a request whose context was cancelled —
the client disconnected, or a deadline fired — kept scanning the full range and
held its RPC worker until the range was exhausted.

Upstream go-ethereum performs this check at the top of its `unindexedLogs` loop
(`eth/filters/filter.go`); the bor block-log filter omitted it.

## Change

Restore parity with a `select { case <-ctx.Done(): ... }` guard at the top of
the loop, so a range scan stops promptly once the caller is gone. With the
context now observed, any deadline attached upstream (e.g. an operator-configured
RPC timeout) also bounds the scan.

## Why

Without the check, a long range query keeps consuming a worker after its result
can no longer be delivered, reducing the RPC server's effective capacity under
cancelled or abandoned requests. The fix is small and matches the canonical
go-ethereum loop.

## Changes

- `eth/filters/bor_filter.go`: add the context-cancellation check to the
  `unindexedLogs` scan loop.
- `eth/filters/bor_filter_test.go`: add `TestBorFilterHonorsContextCancellation`
  and `TestBorFilterHonorsContextDeadline`.

## Testing

- `go test ./eth/filters/` — all pass (28).
- The new tests fail on the prior code (the loop ran 1001 block reads on an
  already-cancelled context and returned a nil error) and pass with the fix.