### PR TITLE
core/vm: resolve EIP-7702 code and hash in a single read; guard jumpdest cache

### DIFF
--- a/core/vm/analysis_legacy.go
+++ b/core/vm/analysis_legacy.go
@@ -61,12 +61,16 @@ func (bits *BitVec) codeSegment(pos uint64) bool {
 	return (((*bits)[pos/8] >> (pos % 8)) & 1) == 0
 }
 
+// codeBitmapLen returns the BitVec length codeBitmap allocates for code of the
+// given byte length. The bitmap is 4 bytes longer than necessary so a trailing
+// PUSH32 can set bits past the end of the actual code without overflowing.
+func codeBitmapLen(codeLen int) int {
+	return codeLen/8 + 1 + 4
+}
+
 // codeBitmap collects data locations in code.
 func codeBitmap(code []byte) BitVec {
-	// The bitmap is 4 bytes longer than necessary, in case the code
-	// ends with a PUSH32, the algorithm will set bits on the
-	// bitvector outside the bounds of the actual code.
-	bits := make(BitVec, len(code)/8+1+4)
+	bits := make(BitVec, codeBitmapLen(len(code)))
 	return codeBitmapInternal(code, bits)
 }
 

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -90,7 +90,17 @@ func (c *Contract) isCode(udest uint64) bool {
 	if c.CodeHash != (common.Hash{}) {
 		// Does parent context have the analysis?
 		analysis, exist := c.jumpDests.Load(c.CodeHash)
-		if !exist {
+		// The cache is keyed by code hash and trusts it to identify the code,
+		// then indexes the cached bitvec with no bounds check. Under BlockSTM
+		// parallel execution a (Code, CodeHash) pair can momentarily be
+		// inconsistent, leaving a cached analysis too short for the current Code;
+		// codeSegment would then index out of range and panic, which on this
+		// shared, persistent, cross-block cache is a node-crash surface.
+		// resolveCodeAndHash removes the known source of such mismatches — this
+		// guard is defense in depth: recompute from the actual Code rather than
+		// trusting a too-short cached entry. Serial go-ethereum cannot reach an
+		// inconsistent pair, so this stays a Bor-specific safeguard.
+		if !exist || len(analysis) < codeBitmapLen(len(c.Code)) {
 			// Do the analysis and save in parent context
 			// We do not need to store it in c.analysis
 			analysis = codeBitmap(c.Code)

--- a/core/vm/contract_resolve_test.go
+++ b/core/vm/contract_resolve_test.go
@@ -1,0 +1,115 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// A code-hash-keyed jumpdest cache entry can momentarily describe a shorter
+// code than the Contract actually carries (an inconsistent (Code, CodeHash)
+// pair from parallel EIP-7702 resolution). isCode must recompute from the
+// actual code instead of indexing the cached bitvec out of range.
+func TestIsCodeRecomputesShortCachedAnalysis(t *testing.T) {
+	t.Parallel()
+
+	hash := common.HexToHash("0xdeadbeef")
+	cache := newMapJumpDests()
+	// Poison the cache: store an analysis sized for an 8-byte code under hash.
+	cache.Store(hash, codeBitmap(make([]byte, 8)))
+
+	// The contract carries the same hash but a much longer code, with a
+	// JUMPDEST at a position whose byte index is far past the cached bitvec.
+	const dest = 771
+	longCode := make([]byte, 800)
+	longCode[dest] = byte(JUMPDEST)
+
+	c := &Contract{jumpDests: cache, Code: longCode, CodeHash: hash}
+
+	if !c.validJumpdest(uint256.NewInt(dest)) {
+		t.Fatalf("expected %d to be a valid jumpdest after recompute", dest)
+	}
+
+	// The poisoned entry should have been replaced with one sized for the code.
+	if got, _ := cache.Load(hash); len(got) < codeBitmapLen(len(longCode)) {
+		t.Fatalf("cache entry not repaired: len=%d, want >= %d", len(got), codeBitmapLen(len(longCode)))
+	}
+}
+
+// resolveCodeAndHash must follow an EIP-7702 delegation once and return the
+// code and hash of the same resolved target, so a Contract's Code and CodeHash
+// always agree.
+func TestResolveCodeAndHashFollowsDelegation(t *testing.T) {
+	t.Parallel()
+
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+
+	target := common.Address{0xaa}
+	targetCode := []byte{byte(PUSH1), 0x01, byte(JUMPDEST), byte(STOP)}
+	statedb.CreateAccount(target)
+	statedb.SetCode(target, targetCode, tracing.CodeChangeGenesis)
+
+	auth := common.Address{0xbb}
+	statedb.CreateAccount(auth)
+	statedb.SetCode(auth, types.AddressToDelegation(target), tracing.CodeChangeGenesis)
+
+	evm := NewEVM(BlockContext{BlockNumber: big.NewInt(0)}, statedb, params.MergedTestChainConfig, Config{})
+
+	code, hash := evm.resolveCodeAndHash(auth)
+	if !bytes.Equal(code, targetCode) {
+		t.Fatalf("code mismatch: got %x, want %x", code, targetCode)
+	}
+	if want := crypto.Keccak256Hash(targetCode); hash != want {
+		t.Fatalf("hash %x does not match the resolved code (keccak %x)", hash, want)
+	}
+	if want := statedb.GetCodeHash(target); hash != want {
+		t.Fatalf("hash %x != target code hash %x", hash, want)
+	}
+}
+
+// A plain (non-delegated) account resolves to its own code and hash.
+func TestResolveCodeAndHashPlainAccount(t *testing.T) {
+	t.Parallel()
+
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+
+	addr := common.Address{0xcc}
+	code := []byte{byte(PUSH1), 0x02, byte(STOP)}
+	statedb.CreateAccount(addr)
+	statedb.SetCode(addr, code, tracing.CodeChangeGenesis)
+
+	evm := NewEVM(BlockContext{BlockNumber: big.NewInt(0)}, statedb, params.MergedTestChainConfig, Config{})
+
+	gotCode, gotHash := evm.resolveCodeAndHash(addr)
+	if !bytes.Equal(gotCode, code) {
+		t.Fatalf("code mismatch: got %x, want %x", gotCode, code)
+	}
+	if want := statedb.GetCodeHash(addr); gotHash != want {
+		t.Fatalf("hash %x != account code hash %x", gotHash, want)
+	}
+}

--- a/core/vm/contract_resolve_test.go
+++ b/core/vm/contract_resolve_test.go
@@ -92,6 +92,30 @@ func TestResolveCodeAndHashFollowsDelegation(t *testing.T) {
 	}
 }
 
+// Empty code (a plain EOA, or a delegation to an empty target) resolves to a
+// zero hash — the hash is unused for empty code, so the read is skipped.
+func TestResolveCodeAndHashEmptyCode(t *testing.T) {
+	t.Parallel()
+
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	evm := NewEVM(BlockContext{BlockNumber: big.NewInt(0)}, statedb, params.MergedTestChainConfig, Config{})
+
+	// EOA with no code.
+	eoa := common.Address{0xee}
+	if code, hash := evm.resolveCodeAndHash(eoa); len(code) != 0 || hash != (common.Hash{}) {
+		t.Fatalf("EOA: got code=%x hash=%x, want empty code and zero hash", code, hash)
+	}
+
+	// Delegation pointing at an empty target.
+	auth := common.Address{0xdd}
+	empty := common.Address{0x11}
+	statedb.CreateAccount(auth)
+	statedb.SetCode(auth, types.AddressToDelegation(empty), tracing.CodeChangeGenesis)
+	if code, hash := evm.resolveCodeAndHash(auth); len(code) != 0 || hash != (common.Hash{}) {
+		t.Fatalf("delegation→empty: got code=%x hash=%x, want empty code and zero hash", code, hash)
+	}
+}
+
 // A plain (non-delegated) account resolves to its own code and hash.
 func TestResolveCodeAndHashPlainAccount(t *testing.T) {
 	t.Parallel()

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -740,14 +740,23 @@ func (evm *EVM) Create2(caller common.Address, code []byte, gas uint64, endowmen
 // operation, so it cannot bind them into a single coherent read.
 func (evm *EVM) resolveCodeAndHash(addr common.Address) ([]byte, common.Hash) {
 	code := evm.StateDB.GetCode(addr)
+	target := addr
 	// EIP-7702
 	if evm.chainRules.IsPrague {
-		if target, ok := types.ParseDelegation(code); ok {
+		if t, ok := types.ParseDelegation(code); ok {
 			// Note we only follow one level of delegation.
-			return evm.StateDB.GetCode(target), evm.StateDB.GetCodeHash(target)
+			target = t
+			code = evm.StateDB.GetCode(target)
 		}
 	}
-	return code, evm.StateDB.GetCodeHash(addr)
+	// Skip the code-hash read for empty code: the hash is unused (Call returns
+	// early, and the interpreter short-circuits empty code before any JUMPDEST
+	// lookup), so reading it would only add a redundant read of a key already
+	// read above — notably on the hot path of calling EOAs.
+	if len(code) == 0 {
+		return code, common.Hash{}
+	}
+	return code, evm.StateDB.GetCodeHash(target)
 }
 
 // ChainConfig returns the environment's chain configuration

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -364,14 +364,14 @@ func (evm *EVM) Call(caller common.Address, addr common.Address, input []byte, g
 		ret, gas, err = evm.runPrecompile(p, addr, input, gas)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
-		code := evm.resolveCode(addr)
+		code, codeHash := evm.resolveCodeAndHash(addr)
 		if len(code) == 0 {
 			ret, err = nil, nil // gas is unchanged
 		} else {
 			// The contract is a scoped environment for this execution context only.
 			contract := NewContract(caller, addr, value, gas, evm.jumpDests)
 			contract.IsSystemCall = isSystemCall(caller)
-			contract.SetCallCode(evm.resolveCodeHash(addr), code)
+			contract.SetCallCode(codeHash, code)
 			ret, err = evm.Run(contract, input, false)
 			gas = contract.Gas
 		}
@@ -433,7 +433,8 @@ func (evm *EVM) CallCode(caller common.Address, addr common.Address, input []byt
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
 		contract := NewContract(caller, caller, value, gas, evm.jumpDests)
-		contract.SetCallCode(evm.resolveCodeHash(addr), evm.resolveCode(addr))
+		code, codeHash := evm.resolveCodeAndHash(addr)
+		contract.SetCallCode(codeHash, code)
 		ret, err = evm.Run(contract, input, false)
 		gas = contract.Gas
 	}
@@ -480,7 +481,8 @@ func (evm *EVM) DelegateCall(originCaller common.Address, caller common.Address,
 		//
 		// Note: The value refers to the original value from the parent call.
 		contract := NewContract(originCaller, caller, value, gas, evm.jumpDests)
-		contract.SetCallCode(evm.resolveCodeHash(addr), evm.resolveCode(addr))
+		code, codeHash := evm.resolveCodeAndHash(addr)
+		contract.SetCallCode(codeHash, code)
 		ret, err = evm.Run(contract, input, false)
 		gas = contract.Gas
 	}
@@ -534,7 +536,8 @@ func (evm *EVM) StaticCall(caller common.Address, addr common.Address, input []b
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
 		contract := NewContract(caller, addr, new(uint256.Int), gas, evm.jumpDests)
-		contract.SetCallCode(evm.resolveCodeHash(addr), evm.resolveCode(addr))
+		code, codeHash := evm.resolveCodeAndHash(addr)
+		contract.SetCallCode(codeHash, code)
 
 		// When an error was returned by the EVM or when setting the creation code
 		// above we revert to the snapshot and consume any gas remaining. Additionally
@@ -720,35 +723,31 @@ func (evm *EVM) Create2(caller common.Address, code []byte, gas uint64, endowmen
 	return evm.create(caller, code, gas, endowment, contractAddr, CREATE2)
 }
 
-// resolveCode returns the code associated with the provided account. After
-// Prague, it can also resolve code pointed to by a delegation designator.
-func (evm *EVM) resolveCode(addr common.Address) []byte {
+// resolveCodeAndHash returns the code and matching code hash for the provided
+// account, following a single level of EIP-7702 delegation after Prague. The
+// delegation designator is read exactly once so the returned code and hash
+// always describe the same resolved target. The earlier split into separate
+// resolveCode and resolveCodeHash helpers read the designator twice; BlockSTM
+// gives no snapshot isolation between two reads of the same key within one
+// incarnation, so a concurrent writer landing between them could make the two
+// reads follow different delegation targets, yielding a Contract whose Code and
+// CodeHash disagree and poisoning the persistent CodeHash-keyed jumpdest cache
+// (a later caller running the longer code then indexes a too-short bitvec and
+// crashes). Serial go-ethereum reads the designator twice harmlessly, so this
+// single-read resolution lives in the EVM — the only layer that knows the two
+// reads form one logical 7702 resolution. The state layer cannot fix it: it has
+// no notion that addr's designator and the target's code/hash are one atomic
+// operation, so it cannot bind them into a single coherent read.
+func (evm *EVM) resolveCodeAndHash(addr common.Address) ([]byte, common.Hash) {
 	code := evm.StateDB.GetCode(addr)
 	// EIP-7702
-	if !evm.chainRules.IsPrague {
-		return code
-	}
-	if target, ok := types.ParseDelegation(code); ok {
-		// Note we only follow one level of delegation.
-		return evm.StateDB.GetCode(target)
-	}
-	return code
-}
-
-// resolveCodeHash returns the code hash associated with the provided address.
-// After Prague, it can also resolve code hash of the account pointed to by a
-// delegation designator. Although this is not accessible in the EVM it is used
-// internally to associate jumpdest analysis to code.
-func (evm *EVM) resolveCodeHash(addr common.Address) common.Hash {
-	// EIP-7702
 	if evm.chainRules.IsPrague {
-		code := evm.StateDB.GetCode(addr)
 		if target, ok := types.ParseDelegation(code); ok {
 			// Note we only follow one level of delegation.
-			return evm.StateDB.GetCodeHash(target)
+			return evm.StateDB.GetCode(target), evm.StateDB.GetCodeHash(target)
 		}
 	}
-	return evm.StateDB.GetCodeHash(addr)
+	return code, evm.StateDB.GetCodeHash(addr)
 }
 
 // ChainConfig returns the environment's chain configuration


### PR DESCRIPTION
## Summary

V2 parallel execution (BlockSTM v2) can build a `Contract` whose `Code` and `CodeHash` describe **different** EIP-7702 delegation targets, which then poisons the shared jumpdest-analysis cache and crashes a later caller.

`EVM.Call` (and `CallCode` / `DelegateCall` / `StaticCall`) resolved a delegated account's code and code hash through two independent helpers — `resolveCode` and `resolveCodeHash` — **each of which read the delegation designator with its own `GetCode(addr)` call**. BlockSTM gives no snapshot isolation between two reads of the same key within one incarnation, so a concurrent writer landing between the two reads could make them follow different delegation targets. The result is a `Contract` whose `Code` is one impl and whose `CodeHash` is another impl's.

The jumpdest analysis cache (`Contract.isCode`) is keyed **only by `CodeHash`**, is **shared, persistent, and cross-block**, and `codeSegment` indexes the cached bitvec **with no bounds check**. So a mismatched `(Code, CodeHash)` pair stores/serves a too-short bitvec under a hash; a later caller running the longer code passes `validJumpdest`'s `dest < len(Code)` check but indexes the short bitvec out of range.

Two observed manifestations of the same defect on a mainnet devnode under `pipelineMode=flatdiff`:

- **Panic:** `runtime error: index out of range [771] with length 282` during `validJumpdest` of a JUMP into a 7702-delegated account (block 88,097,566).
- **Gas mismatch:** the same `(Code, CodeHash)` mismatch where the bad destination is in-bounds-but-not-a-JUMPDEST → clean `ErrInvalidJump` → the tx reverts consuming its full gas limit → `invalid gas used` (block 87,960,386).

In every case the block was rejected and **self-healed via the serial direct-mode retry**, which resolves code+hash consistently — so no wrong state was ever committed. This is a **liveness / robustness defect, not consensus corruption**. Distinct from the shared-authority ordering bug fixed in #2255.

## The fix — and why these layers

Two changes, both in `core/vm`:

**Root fix — `evm.go`:** replace `resolveCode` + `resolveCodeHash` with a single `resolveCodeAndHash` that reads the delegation designator **once** and derives both code and hash from the same resolved target.

This must live in the EVM. It is the only layer that knows the designator read and the target's code/hash read form **one logical 7702 resolution**. `ParallelStateDB` has no notion that `addr`'s designator and the target's code/hash are one atomic operation, so it cannot bind them into a single coherent read — a state-layer fix is not possible here. Serial go-ethereum reads the designator twice harmlessly (two reads of one key are identical with no concurrency), so upstream will never carry this change; the divergence is justified specifically by Bor's parallel execution making the double-read unsafe.

**Defense in depth — `contract.go` / `analysis_legacy.go`:** the cache indexes the cached bitvec with no bounds check, so **any** `(Code, CodeHash)` inconsistency — from any source, now or future — is a node-crash surface. `isCode` now recomputes `codeBitmap(c.Code)` (and repairs the cache entry) when a cache-loaded analysis is too short for the current `Code`, instead of indexing out of range. A new `codeBitmapLen` helper keeps the length check in sync with `codeBitmap`'s allocation.

This is a **crash guard, not a correctness guarantee** — it turns a would-be OOB panic into a correct recompute. The root fix removes the known mismatch source; the guard protects the consensus-critical, externally-reachable crash path against any residual mismatch. Serial go-ethereum cannot reach an inconsistent pair, so this too is a Bor-specific safeguard.

### Considered but deferred

A state-layer `ParallelStateDB.GetCodeAndHash` for the residual where a delegation **target's** code is written in the *same* block (then `GetCode(target)` and `GetCodeHash(target)` are two separate reads that could diverge). The observed bug never hits it — the impl contracts are immutable pre-block (base) reads, where `GetCode(target)` and `GetCodeHash(target)` already agree — and the previous code had the identical residual, so this is **not a regression**. The V2 bad-block diagnostic remains enabled on the devnode to capture that case with a full read-set dump + stack if it ever occurs, so we'd design the state-layer fix against real data rather than speculatively.

## Executed tests

Beyond the standard CI gates:

- `TestIsCodeRecomputesShortCachedAnalysis` (new) — poisons the shared cache with a short bitvec under a hash, then runs a `Contract` carrying that hash but a longer code with a JUMPDEST at offset 771 (the observed OOB index); asserts `validJumpdest` does **not** panic, returns the correct result, and that the poisoned cache entry is repaired. Pins the defense-in-depth guard.
- `TestResolveCodeAndHashFollowsDelegation` (new) — asserts a single-level 7702 delegation resolves code and hash to the **same** target (`hash == keccak(code) == GetCodeHash(target)`). Pins the root fix's consistency property.
- `TestResolveCodeAndHashPlainAccount` (new) — non-delegated account resolves to its own code/hash.
- Full `go test ./core/vm/` green except two failures that are **pre-existing on `develop`** and unrelated (`TestAbortDuringJump`, `TestInterruptDuringExecution` — EVM switch-dispatch/interrupt tests, reproduced on a clean tree). `go build ./...`, `go vet ./core/vm/`, `gofmt` clean.

Field context: deployed to a mainnet devnode (parallel EVM + pipelined-import-src on) on 2026-06-08. Baseline before the fix was ~2 bad blocks / 20h, all under `pipelineMode=flatdiff`; post-deploy monitoring shows no `BAD BLOCK` / `invalid gas used` / `execution panic` / `index out of range` (the proactive near-gas-limit read-set dumps that the diagnostic also emits are expected noise on healthy blocks, not rejections).

## Rollout notes

- **Consensus-affecting:** the fix makes V2 parallel execution produce the canonical, serial-equivalent result for calls into EIP-7702-delegated accounts; it removes a source of non-deterministic bad blocks. Jumpdest analysis is execution-internal — when correct it does not change state output, so V2 matches serial/Erigon. Output for any block without a call into a 7702-delegated account is unchanged. **No fork gate** — this is a latent V2 correctness bug, not a hardfork-gated behavior change.
- **Backwards-compatible:** yes — no config, genesis, wire, or storage changes. Pure execution-path correctness.
- **Coordinated upgrade:** not required. Nodes without the fix self-heal each occurrence via direct-mode re-execution but carry the latent crash/divergence risk; this makes the 7702 call path deterministic and crash-safe under parallel execution.
- **Cross-client parity:** execution-internal, no consensus-output change, so no Erigon change is required.
- **Upstream divergence:** two deliberate divergences from go-ethereum (`resolveCodeAndHash` and the jumpdest-cache guard), both justified by Bor's parallel EVM making patterns reachable that serial geth never can. Called out here for the next go-ethereum sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
