### PR TITLE
txpool/legacypool: fix fillPool TOCTOU and remove debug prints

### DIFF
--- a/core/txpool/legacypool/legacypool2_test.go
+++ b/core/txpool/legacypool/legacypool2_test.go
@@ -66,8 +66,15 @@ func fillPool(t testing.TB, pool *LegacyPool) {
 	}
 	// Import the batch and verify the pool is full and executable.
 	pool.addRemotesSync(executableTxs)
-	pending, queued := pool.Stats()
+
+	// Read pending, queued, and all.Slots() under pool.mu.RLock so the three
+	// values are consistent: no concurrent mutation can interleave between the
+	// two calls because all paths that modify pool.all require pool.mu.Lock.
+	pool.mu.RLock()
+	pending, queued := pool.stats()
 	slots := pool.all.Slots()
+	pool.mu.RUnlock()
+
 	// sanity-check that the test prerequisites are ok (pending full)
 	if have, want := slots, target; have != want {
 		t.Fatalf("have %d, want %d", have, want)

--- a/core/txpool/legacypool/list_test.go
+++ b/core/txpool/legacypool/list_test.go
@@ -17,7 +17,6 @@
 package legacypool
 
 import (
-	"fmt"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -145,14 +144,14 @@ func TestFilterTxConditionalKnownAccounts(t *testing.T) {
 	state.AddBalance(common.Address{19: 1}, uint256.NewInt(1000), tracing.BalanceChangeTransfer)
 
 	trie, _ := state.StorageTrie(common.Address{19: 1})
-	fmt.Println("before", trie)
+	_ = trie
 
 	state.SetState(common.Address{19: 1}, common.Hash{}, common.Hash{30: 1})
 
 	state.Finalise(true)
 
 	trie, _ = state.StorageTrie(common.Address{19: 1})
-	fmt.Println("after", trie.Hash())
+	_ = trie
 
 	tx2.PutOptions(&options)
 	list.Add(tx2, DefaultConfig.PriceBump)
@@ -169,7 +168,7 @@ func TestFilterTxConditionalKnownAccounts(t *testing.T) {
 	state.Finalise(true)
 
 	trie, _ = state.StorageTrie(common.Address{19: 1})
-	fmt.Println("after2", trie.Hash())
+	_ = trie
 
 	// tx2 should be the single transaction filtered out
 	drops = list.FilterTxConditional(state, header)


### PR DESCRIPTION
## Summary

- **Flaky test fix**: `fillPool` in `legacypool2_test.go` read `pool.Stats()` and `pool.all.Slots()` in two separate critical sections (`pool.mu.RLock` and `t.lock.RLock`). A concurrent pool mutation between the two reads could produce an inconsistent snapshot, causing `TestLockOrdering_ReplacePendingNoDeadlock` to fail with `have 199, want 200`.
- **Fix**: hold `pool.mu.RLock` across both reads in `fillPool`, using the unexported `pool.stats()` (valid since the test is in the same package). All paths that mutate `pool.all` require `pool.mu.Lock`, so the two reads are now atomic with respect to pool mutations.
- **Debug print removal**: three leftover `fmt.Println` calls in `list_test.go` (`TestFilterTxConditionalKnownAccounts`) polluted CI output; replaced with blank identifier assignments and removed the unused `"fmt"` import.

## Test plan

- [ ] `go test ./core/txpool/legacypool/... -count=50 -run TestLockOrdering_ReplacePendingNoDeadlock` — no failures expected
- [ ] `go test ./core/txpool/legacypool/... -count=1` — full package passes