### PR TITLE
core/state, core: fix BlockSTM v2 vs serial divergences behind recent bad blocks

### DIFF
--- a/core/state/parallel_read_equivalence_test.go
+++ b/core/state/parallel_read_equivalence_test.go
@@ -1,0 +1,187 @@
+package state
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/blockstm"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/triedb"
+)
+
+// equivMutator is the subset of write APIs the table exercises — both
+// *StateDB and *ParallelStateDB implement it, so each mutation runs
+// verbatim on both engines.
+type equivMutator interface {
+	SetNonce(common.Address, uint64, tracing.NonceChangeReason)
+	AddBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) uint256.Int
+	SetCode(common.Address, []byte, tracing.CodeChangeReason) []byte
+	SetState(common.Address, common.Hash, common.Hash) common.Hash
+	SelfDestruct(common.Address) uint256.Int
+}
+
+// TestParallelReadEquivalence is a meta-test over the read API: for every
+// account-mutation class a prior in-block tx can perform, it asserts that
+// every ParallelStateDB read agrees with serial StateDB after the same
+// mutation. The three V2 divergences fixed on this branch were all "one
+// read API disagrees with serial for one account shape" — Exist ignoring
+// a prior-tx nonce bump being the canonical case. A per-API/per-shape
+// table makes that whole failure class regress loudly instead of shipping
+// as a bad block.
+//
+// Each case applies its mutation as tx 0 on both engines:
+//   - serial: a StateDB at the base root, mutated then Finalise(true)
+//   - V2:     a writer ParallelStateDB (idx 0) mutated then FlushToMVStore,
+//     observed by a reader ParallelStateDB (idx 1)
+//
+// then compares Exist / Empty / GetNonce / GetBalance / GetCode /
+// GetCodeHash / GetCodeSize / GetState across the two. addr is exercised
+// both when absent from the base state and when pre-funded in it.
+func TestParallelReadEquivalence(t *testing.T) {
+	addr := common.HexToAddress("0x00000000000000000000000000000000000000e0")
+	slot := common.HexToHash("0x01")
+	contractCode := []byte{0x60, 0x00, 0x60, 0x00, 0xf3}
+
+	type mutation struct {
+		name  string
+		apply func(equivMutator)
+	}
+	mutations := []mutation{
+		{"none", func(db equivMutator) {}},
+		{"nonce-only", func(db equivMutator) {
+			db.SetNonce(addr, 5, tracing.NonceChangeEoACall)
+		}},
+		{"balance-only", func(db equivMutator) {
+			db.AddBalance(addr, uint256.NewInt(1000), tracing.BalanceChangeTransfer)
+		}},
+		// Realistic deployment via SetNonce(1)+SetCode — the balance-
+		// preserving shape (serial getOrNewStateObject; V2 SetCode marks
+		// the account created internally). Explicit CreateAccount is
+		// intentionally not in the table: the EVM only calls it on a
+		// truly-new address (a pre-funded target goes through the
+		// balance-preserving CreateContract), and createObject's own
+		// docstring warns that overwriting an existing account "might
+		// lead to a consensus bug" — exercising it in isolation tests an
+		// unreachable primitive, not parity. Likewise bare SetState: an
+		// account left empty after Finalise is EIP-158-deleted serially
+		// while its MVStore write survives, a divergence SSTORE can't
+		// reach because it only runs in an account that already has code.
+		{"deploy-contract", func(db equivMutator) {
+			db.SetNonce(addr, 1, tracing.NonceChangeContractCreator)
+			db.SetCode(addr, contractCode, tracing.CodeChangeUnspecified)
+		}},
+		{"deploy-with-storage", func(db equivMutator) {
+			db.SetNonce(addr, 1, tracing.NonceChangeContractCreator)
+			db.SetCode(addr, contractCode, tracing.CodeChangeUnspecified)
+			db.SetState(addr, slot, common.HexToHash("0x2a"))
+		}},
+		{"nonce+balance", func(db equivMutator) {
+			db.SetNonce(addr, 3, tracing.NonceChangeEoACall)
+			db.AddBalance(addr, uint256.NewInt(7), tracing.BalanceChangeTransfer)
+		}},
+		{"destruct-after-fund", func(db equivMutator) {
+			db.AddBalance(addr, uint256.NewInt(99), tracing.BalanceChangeTransfer)
+			db.SelfDestruct(addr)
+		}},
+	}
+
+	for _, basePrefunded := range []bool{false, true} {
+		for _, m := range mutations {
+			name := m.name
+			if basePrefunded {
+				name += "/base-prefunded"
+			} else {
+				name += "/base-absent"
+			}
+			t.Run(name, func(t *testing.T) {
+				root, db := buildEquivBase(t, addr, basePrefunded)
+
+				serial, err := New(root, db)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.apply(serial)
+				serial.Finalise(true)
+
+				parBase, err := New(root, db)
+				if err != nil {
+					t.Fatal(err)
+				}
+				sb := NewSafeBase(parBase, 2)
+				store := blockstm.NewMVStore()
+				bals := blockstm.NewMVBalanceStore()
+
+				writer := NewParallelStateDB(0, sb, store, bals)
+				writer.EnableReadTracking()
+				m.apply(writer)
+				writer.FlushToMVStore()
+
+				reader := NewParallelStateDB(1, sb, store, bals)
+				reader.EnableReadTracking()
+
+				assertReadEquivalence(t, serial, reader, addr, slot)
+			})
+		}
+	}
+}
+
+// assertReadEquivalence compares every read API between a serial StateDB
+// and a V2 ParallelStateDB reader for addr (and one storage slot).
+func assertReadEquivalence(t *testing.T, serial *StateDB, par *ParallelStateDB, addr common.Address, slot common.Hash) {
+	t.Helper()
+	if got, want := par.Exist(addr), serial.Exist(addr); got != want {
+		t.Errorf("Exist: parallel=%v serial=%v", got, want)
+	}
+	if got, want := par.Empty(addr), serial.Empty(addr); got != want {
+		t.Errorf("Empty: parallel=%v serial=%v", got, want)
+	}
+	if got, want := par.GetNonce(addr), serial.GetNonce(addr); got != want {
+		t.Errorf("GetNonce: parallel=%d serial=%d", got, want)
+	}
+	if got, want := par.GetBalance(addr), serial.GetBalance(addr); got.Cmp(want) != 0 {
+		t.Errorf("GetBalance: parallel=%s serial=%s", got, want)
+	}
+	if got, want := par.GetCode(addr), serial.GetCode(addr); !bytes.Equal(got, want) {
+		t.Errorf("GetCode: parallel=%x serial=%x", got, want)
+	}
+	if got, want := par.GetCodeHash(addr), serial.GetCodeHash(addr); got != want {
+		t.Errorf("GetCodeHash: parallel=%s serial=%s", got, want)
+	}
+	if got, want := par.GetCodeSize(addr), serial.GetCodeSize(addr); got != want {
+		t.Errorf("GetCodeSize: parallel=%d serial=%d", got, want)
+	}
+	if got, want := par.GetState(addr, slot), serial.GetState(addr, slot); got != want {
+		t.Errorf("GetState: parallel=%s serial=%s", got, want)
+	}
+}
+
+// buildEquivBase returns a committed base state (and its database) where
+// addr either does not exist or is pre-funded with a balance + nonce, so
+// each mutation can be exercised against both starting points.
+func buildEquivBase(t *testing.T, addr common.Address, prefunded bool) (common.Hash, Database) {
+	t.Helper()
+	memdb := rawdb.NewMemoryDatabase()
+	tdb := triedb.NewDatabase(memdb, triedb.HashDefaults)
+	db := NewDatabase(tdb, nil)
+	pre, err := New(types.EmptyRootHash, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prefunded {
+		pre.AddBalance(addr, uint256.NewInt(500), tracing.BalanceChangeTransfer)
+		pre.SetNonce(addr, 1, tracing.NonceChangeEoACall)
+	}
+	root, err := pre.Commit(0, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tdb.Commit(root, false); err != nil {
+		t.Fatal(err)
+	}
+	return root, db
+}

--- a/core/state/parallel_read_invariants_test.go
+++ b/core/state/parallel_read_invariants_test.go
@@ -1,0 +1,157 @@
+package state
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/blockstm"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// This file pins the two structural invariants that keep V2 reads safe
+// under concurrency. Every intra-tx read must be EITHER:
+//
+//	(1) snapshot-stable — repeated reads of the same key within one tx
+//	    incarnation return one value even if a concurrent writer lands
+//	    between them, so derived artifacts that escape re-execution (the
+//	    shared jumpdest cache, keyed by codehash) can't be poisoned; or
+//	(2) validation-visible — the read is recorded so that if the value it
+//	    observed is later contradicted by a prior tx's write, the tx fails
+//	    validation and re-executes.
+//
+// The three V2 divergences fixed on this branch each violated one of
+// these: the 7702 code double-read was neither stable nor self-consistent
+// (invariant 1), and Exist's missing nonce check read state it never
+// recorded (invariant 2). A read that satisfies neither is a latent
+// consensus bug, so both are asserted generically here.
+
+func delegationDesignator(target common.Address) []byte {
+	return append([]byte{0xef, 0x01, 0x00}, target.Bytes()...)
+}
+
+// TestParallelCodeReadSnapshotConsistency is invariant (1) for CodePath:
+// within one tx, GetCode and GetCodeHash must observe one consistent value
+// even when a concurrent writer rewrites the address's delegation between
+// the calls. This is the exact EVM sequence behind the fix — resolveCode
+// reads the code, resolveCodeHash reads it again — and the failure it
+// prevents is a Contract whose Code and CodeHash come from different
+// delegation targets, poisoning the shared jumpdest cache.
+func TestParallelCodeReadSnapshotConsistency(t *testing.T) {
+	pdb, store, _ := newTestPDB(t, 5)
+	pdb.EnableReadTracking()
+
+	addr := common.HexToAddress("0x00000000000000000000000000000000000000e0")
+	d1 := delegationDesignator(common.HexToAddress("0x7001"))
+	d2 := delegationDesignator(common.HexToAddress("0x7002"))
+	codeKey := blockstm.NewSubpathKey(addr, CodePath)
+
+	// A prior tx delegated addr -> target1.
+	store.WriteInc(codeKey, 0, 0, d1)
+
+	code1 := pdb.GetCode(addr) // resolveCode's read
+
+	// A concurrent re-exec of the prior tx redirects the delegation,
+	// landing between the EVM's two resolution reads.
+	store.WriteInc(codeKey, 0, 1, d2)
+
+	hash := pdb.GetCodeHash(addr) // resolveCodeHash's read
+	code2 := pdb.GetCode(addr)
+
+	if !bytes.Equal(code1, code2) {
+		t.Errorf("GetCode not snapshot-stable: first=%x second=%x", code1, code2)
+	}
+	if want := crypto.Keccak256Hash(code1); hash != want {
+		t.Errorf("GetCodeHash disagrees with GetCode within one tx: hash=%s keccak(code)=%s\n"+
+			"a Contract built from this (Code, CodeHash) pair points at two different "+
+			"delegation targets and poisons the shared jumpdest cache", hash.Hex(), want.Hex())
+	}
+}
+
+// TestParallelReadRecordingCompleteness is invariant (2): for every read
+// API, after the read observes a value, a prior tx writing a different
+// value on the same path must make the tx fail validation. A read that
+// leaves no record is invisible to the conflict detector, so a stale
+// observation is silently accepted — exactly how Exist's missing nonce
+// read shipped EIP-7702 over-charges as bad blocks rather than triggering
+// a re-execution.
+func TestParallelReadRecordingCompleteness(t *testing.T) {
+	addr := common.HexToAddress("0x00000000000000000000000000000000000000e0")
+	slot := common.HexToHash("0x01")
+
+	cases := []struct {
+		name string
+		read func(*ParallelStateDB)
+		// write applies a prior-tx (idx 2) write that contradicts what the
+		// read observed on an empty base.
+		write func(*blockstm.MVStore, *blockstm.MVBalanceStore)
+	}{
+		{
+			name: "Exist", // the fix #2 safety-net gap
+			read: func(p *ParallelStateDB) { p.Exist(addr) },
+			write: func(s *blockstm.MVStore, _ *blockstm.MVBalanceStore) {
+				s.WriteInc(blockstm.NewSubpathKey(addr, NoncePath), 2, 0, uint64(7))
+			},
+		},
+		{
+			name: "Empty",
+			read: func(p *ParallelStateDB) { p.Empty(addr) },
+			write: func(s *blockstm.MVStore, _ *blockstm.MVBalanceStore) {
+				s.WriteInc(blockstm.NewSubpathKey(addr, NoncePath), 2, 0, uint64(7))
+			},
+		},
+		{
+			name: "GetNonce",
+			read: func(p *ParallelStateDB) { p.GetNonce(addr) },
+			write: func(s *blockstm.MVStore, _ *blockstm.MVBalanceStore) {
+				s.WriteInc(blockstm.NewSubpathKey(addr, NoncePath), 2, 0, uint64(7))
+			},
+		},
+		{
+			name: "GetCode",
+			read: func(p *ParallelStateDB) { p.GetCode(addr) },
+			write: func(s *blockstm.MVStore, _ *blockstm.MVBalanceStore) {
+				s.WriteInc(blockstm.NewSubpathKey(addr, CodePath), 2, 0, []byte{0x60, 0x00})
+			},
+		},
+		{
+			name: "GetCodeHash",
+			read: func(p *ParallelStateDB) { p.GetCodeHash(addr) },
+			write: func(s *blockstm.MVStore, _ *blockstm.MVBalanceStore) {
+				s.WriteInc(blockstm.NewSubpathKey(addr, CodePath), 2, 0, []byte{0x60, 0x00})
+			},
+		},
+		{
+			name: "GetState",
+			read: func(p *ParallelStateDB) { p.GetState(addr, slot) },
+			write: func(s *blockstm.MVStore, _ *blockstm.MVBalanceStore) {
+				s.WriteInc(blockstm.NewStateKey(addr, slot), 2, 0, common.HexToHash("0x2a"))
+			},
+		},
+		{
+			name: "GetBalance",
+			read: func(p *ParallelStateDB) { p.GetBalance(addr) },
+			write: func(_ *blockstm.MVStore, b *blockstm.MVBalanceStore) {
+				b.WriteDelta(addr, 2, uint256.NewInt(13), uint256.NewInt(0))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pdb, store, bals := newTestPDB(t, 5)
+			pdb.EnableReadTracking()
+
+			tc.read(pdb)
+			tc.write(store, bals)
+
+			if res := pdb.ValidateDetailed(); res.Valid {
+				t.Fatalf("%s left no validation-visible record: a prior-tx write that "+
+					"changed the observed value did not invalidate the tx, so a stale read "+
+					"would be silently accepted", tc.name)
+			}
+		})
+	}
+}

--- a/core/state/parallel_statedb.go
+++ b/core/state/parallel_statedb.go
@@ -610,20 +610,35 @@ func (s *ParallelStateDB) Exist(addr common.Address) bool {
 	if suicideIdx >= 0 {
 		// Most recent action was destruction. The account is gone unless
 		// a later tx implicitly recreated it via AddBalance (value
-		// transfer doesn't touch CreatePath, only MVBalanceStore).
-		// GetBalance records its own read so validation catches drift.
+		// transfer doesn't touch CreatePath, only MVBalanceStore) or by
+		// bumping its nonce (e.g. a 7702 delegation clear). GetBalance /
+		// GetNonce record their own reads so validation catches drift.
 		if !s.GetBalance(addr).IsZero() {
+			return true
+		}
+		if s.GetNonce(addr) > 0 {
 			return true
 		}
 		return false
 	}
-	// No prior creation or destruction. Fall through to base + balance
-	// check (handles base-state accounts and addresses created implicitly
-	// by a prior tx's value transfer).
+	// No prior creation or destruction. Fall through to base + balance +
+	// nonce check (handles base-state accounts and addresses made to exist
+	// by a prior tx's value transfer or nonce bump).
 	if s.base.Exist(addr) {
 		return true
 	}
 	if !s.GetBalance(addr).IsZero() {
+		return true
+	}
+	// Serial StateDB.Exist is getStateObject()!=nil, and an account with
+	// nonce>0 is not empty — so it exists. ParallelStateDB historically
+	// omitted this nonce check: an account made to exist purely by a prior
+	// in-block nonce bump (a sender increment, or a 7702 delegation clear —
+	// SetNonce writes NoncePath but NOT CreatePath) was reported absent.
+	// That flipped EIP-7702 applyAuthorization's Exist-gated 12500 refund and
+	// the new-account CALL surcharge, over-charging gas and splitting from
+	// serial. GetNonce records the read so validation now catches drift.
+	if s.GetNonce(addr) > 0 {
 		return true
 	}
 	return false

--- a/core/state/parallel_statedb.go
+++ b/core/state/parallel_statedb.go
@@ -146,6 +146,15 @@ type ParallelStateDB struct {
 	// Per-tx cache for GetCommittedState — ensures SSTORE original is stable
 	committedCache map[stateKey]common.Hash
 
+	// Per-tx cache for CodePath reads — ensures repeated GetCode/GetCodeHash of
+	// the same address within one tx observe ONE consistent value. The EVM
+	// resolves a 7702-delegated account via two separate GetCode(addr) reads
+	// (resolveCode + resolveCodeHash); without snapshot isolation a concurrent
+	// writer between them can make them follow different delegation targets,
+	// building a Contract whose Code and CodeHash disagree (poisoning the shared
+	// jumpdest cache). Mirrors balCache/committedCache/destructedCache.
+	codeReadCache map[common.Address]codeKeyRead
+
 	// Recorded transfers for log generation during settlement
 	Transfers []TransferRecord
 
@@ -248,6 +257,7 @@ func (s *ParallelStateDB) Reset(txIndex int, base *SafeBase, store *blockstm.MVS
 	s.destructedCache = nil
 	s.destructedSeen = nil
 	s.committedCache = nil
+	s.codeReadCache = nil
 	s.Transfers = s.Transfers[:0]
 	s.FeeData = nil
 	s.Coinbase = common.Address{}
@@ -292,6 +302,33 @@ func (s *ParallelStateDB) readStoreWait(key blockstm.Key) (interface{}, int, int
 		}
 		return nil, -1, 0, false
 	}
+}
+
+// codeKeyRead is a cached CodePath readStoreWait result (see codeReadCache).
+type codeKeyRead struct {
+	val       interface{}
+	writerIdx int
+	writerInc int
+	found     bool
+}
+
+// readCodeKey reads addr's CodePath via readStoreWait, cached per-tx so that the
+// EVM's two 7702-resolution reads (resolveCode + resolveCodeHash, each a
+// GetCode(addr)) observe ONE consistent value. Without this, a concurrent writer
+// landing between the two reads can redirect them to different delegation
+// targets, yielding a Contract whose Code and CodeHash disagree.
+func (s *ParallelStateDB) readCodeKey(addr common.Address, codeKey blockstm.Key) (interface{}, int, int, bool) {
+	if s.codeReadCache != nil {
+		if c, ok := s.codeReadCache[addr]; ok {
+			return c.val, c.writerIdx, c.writerInc, c.found
+		}
+	}
+	val, writerIdx, writerInc, found := s.readStoreWait(codeKey)
+	if s.codeReadCache == nil {
+		s.codeReadCache = make(map[common.Address]codeKeyRead, 2)
+	}
+	s.codeReadCache[addr] = codeKeyRead{val: val, writerIdx: writerIdx, writerInc: writerInc, found: found}
+	return val, writerIdx, writerInc, found
 }
 
 // handleEstimate decides what readStoreWait should do when it observes
@@ -721,7 +758,7 @@ func (s *ParallelStateDB) GetCode(addr common.Address) []byte {
 	}
 	suicideIdx := s.priorDestructedAt(addr)
 	codeKey := blockstm.NewSubpathKey(addr, CodePath)
-	if val, writerIdx, writerInc, found := s.readStoreWait(codeKey); found {
+	if val, writerIdx, writerInc, found := s.readCodeKey(addr, codeKey); found {
 		s.recordStoreRead(codeKey, writerIdx, writerInc, val)
 		if writerIdx > suicideIdx {
 			return val.([]byte)
@@ -757,7 +794,7 @@ func (s *ParallelStateDB) GetCodeHash(addr common.Address) common.Hash {
 	// path as GetCode and record the read so validation can catch a stale
 	// value when the writer is later invalidated.
 	codeKey := blockstm.NewSubpathKey(addr, CodePath)
-	if val, writerIdx, writerInc, found := s.readStoreWait(codeKey); found {
+	if val, writerIdx, writerInc, found := s.readCodeKey(addr, codeKey); found {
 		s.recordStoreRead(codeKey, writerIdx, writerInc, val)
 		// Honor the code write only if it happened after the destruction
 		// (otherwise the destruction wiped it).

--- a/core/state/parallel_statedb.go
+++ b/core/state/parallel_statedb.go
@@ -610,8 +610,9 @@ func (s *ParallelStateDB) Exist(addr common.Address) bool {
 	if suicideIdx >= 0 {
 		// Most recent action was destruction. The account is gone unless
 		// a later tx implicitly recreated it via AddBalance (value
-		// transfer doesn't touch CreatePath, only MVBalanceStore) or by
-		// bumping its nonce (e.g. a 7702 delegation clear). GetBalance /
+		// transfer doesn't touch CreatePath, only MVBalanceStore) or via a
+		// bare nonce bump (SetNonce writes NoncePath, not CreatePath, so it
+		// lands here rather than the createIdx branch above). GetBalance /
 		// GetNonce record their own reads so validation catches drift.
 		if !s.GetBalance(addr).IsZero() {
 			return true
@@ -633,11 +634,13 @@ func (s *ParallelStateDB) Exist(addr common.Address) bool {
 	// Serial StateDB.Exist is getStateObject()!=nil, and an account with
 	// nonce>0 is not empty — so it exists. ParallelStateDB historically
 	// omitted this nonce check: an account made to exist purely by a prior
-	// in-block nonce bump (a sender increment, or a 7702 delegation clear —
-	// SetNonce writes NoncePath but NOT CreatePath) was reported absent.
-	// That flipped EIP-7702 applyAuthorization's Exist-gated 12500 refund and
-	// the new-account CALL surcharge, over-charging gas and splitting from
-	// serial. GetNonce records the read so validation now catches drift.
+	// in-block sender nonce increment (SetNonce writes NoncePath but NOT
+	// CreatePath) was reported absent. That flipped EIP-7702
+	// applyAuthorization's Exist-gated 12500 refund and the new-account CALL
+	// surcharge, over-charging gas and splitting from serial. (A 7702
+	// delegation clear is not this case: it also writes CreatePath because
+	// SetCode calls CreateAccount, so it returns at the createIdx branch
+	// above.) GetNonce records the read so validation now catches drift.
 	if s.GetNonce(addr) > 0 {
 		return true
 	}

--- a/core/state/parallel_statedb_badblock_cover_test.go
+++ b/core/state/parallel_statedb_badblock_cover_test.go
@@ -1,0 +1,89 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+)
+
+// Coverage for two parallel-vs-serial branches added by the bad-block fix. The
+// cross-package V2 parity tests exercise them, but those live in package core
+// and don't count toward core/state coverage; both guard a consensus
+// divergence, so they're pinned here directly.
+
+// TestPDB_Exist_DestructedThenNonceBump hits the destructed-branch nonce check:
+// an account self-destructed by tx0 then given a bare nonce bump by tx1
+// (NoncePath only, landing after the suicide) has zero balance but nonce>0, so
+// it exists — matching serial StateDB.Exist. The balance fallback can't see
+// this shape; only the nonce check does.
+func TestPDB_Exist_DestructedThenNonceBump(t *testing.T) {
+	pdb0, store, bals := newTestPDB(t, 0)
+	addr := common.HexToAddress("0xab57")
+
+	// tx0: fund, then self-destruct — SuicidePath at tx0, balance back to 0.
+	pdb0.AddBalance(addr, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
+	pdb0.SetDeferMVWrites(true)
+	pdb0.EnableReadTracking()
+	pdb0.SelfDestruct(addr)
+	pdb0.FlushToMVStore()
+
+	// tx1: bare nonce bump at writerIdx 1, after the tx0 suicide and with no
+	// CreatePath write — the only shape that reaches the nonce fallback.
+	pdb1 := NewParallelStateDB(1, pdb0.base, store, bals)
+	pdb1.EnableReadTracking()
+	pdb1.SetNonce(addr, 9, tracing.NonceChangeUnspecified)
+	pdb1.FlushToMVStore()
+
+	// tx2: the read under test.
+	pdb2 := NewParallelStateDB(2, pdb0.base, store, bals)
+	pdb2.EnableReadTracking()
+
+	if got := pdb2.GetBalance(addr); !got.IsZero() {
+		t.Fatalf("precondition: balance must be 0 to isolate the nonce branch, got %s", got)
+	}
+	if got := pdb2.GetNonce(addr); got != 9 {
+		t.Fatalf("precondition: post-destruct nonce must survive as 9, got %d", got)
+	}
+	if !pdb2.Exist(addr) {
+		t.Fatal("Exist: destructed account with a later nonce bump must exist (serial parity)")
+	}
+}
+
+// TestPDB_SettleBalanceOpsAndLogs_TransferPositionMismatch hits the
+// position-match guard in tryEmitTransferAt: a leading non-transfer op at index
+// 0 pushes the recorded transfer's Sub/Add pair to indices 1/2, so the first
+// call sees opIdx != BalanceOpsIdx and skips instead of pairing by shape.
+func TestPDB_SettleBalanceOpsAndLogs_TransferPositionMismatch(t *testing.T) {
+	pdb, _, _ := newTestPDB(t, 0)
+	final := settleFinalDB(t)
+
+	other := common.HexToAddress("0x9")
+	sender := common.HexToAddress("0x1")
+	recipient := common.HexToAddress("0x2")
+	amt := *uint256.NewInt(10)
+
+	final.AddBalance(sender, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
+	final.AddBalance(other, uint256.NewInt(100), tracing.BalanceChangeUnspecified)
+
+	pdb.BalanceOps = []BalanceOp{
+		{Addr: other, Amount: *uint256.NewInt(20), IsAdd: false},
+		{Addr: sender, Amount: amt, IsAdd: false},
+		{Addr: recipient, Amount: amt, IsAdd: true},
+	}
+	pdb.Transfers = []TransferRecord{{Sender: sender, Recipient: recipient, Amount: amt, BalanceOpsIdx: 1}}
+
+	pdb.settleBalanceOpsAndLogs(final)
+
+	if got := final.GetBalance(other).Uint64(); got != 80 {
+		t.Fatalf("other (leading non-transfer op): got %d, want 80", got)
+	}
+	if got := final.GetBalance(sender).Uint64(); got != 90 {
+		t.Fatalf("sender: got %d, want 90", got)
+	}
+	if got := final.GetBalance(recipient).Uint64(); got != 10 {
+		t.Fatalf("recipient: got %d, want 10", got)
+	}
+}

--- a/core/state/parallel_statedb_settle.go
+++ b/core/state/parallel_statedb_settle.go
@@ -84,17 +84,28 @@ func (s *ParallelStateDB) settleBalanceOpsAndLogs(final *StateDB) {
 	}
 }
 
-// tryEmitTransferAt detects whether the next pair of balance ops at opIdx
-// matches a recorded Transfer (Sub from sender + Add to recipient with the
-// matching amount). If so it applies the transfer, emits any preceding
-// execution logs + the transfer log, advances *transferIdx and *logIdx,
-// and returns true. Returns false otherwise.
+// tryEmitTransferAt detects whether the pair of balance ops at opIdx is the
+// next recorded Transfer's Sub/Add. If so it applies the transfer, emits any
+// preceding execution logs + the transfer log, advances *transferIdx and
+// *logIdx, and returns true. Returns false otherwise.
 func (s *ParallelStateDB) tryEmitTransferAt(final *StateDB, opIdx int, transferIdx, logIdx *int) bool {
 	if *transferIdx >= len(s.Transfers) {
 		return false
 	}
-	op := &s.BalanceOps[opIdx]
 	tr := &s.Transfers[*transferIdx]
+	// Match by recorded position, not by op shape: RecordTransfer runs
+	// immediately before the transfer's SubBalance/AddBalance, so the
+	// transfer's ops live at exactly [BalanceOpsIdx, BalanceOpsIdx+1]
+	// (RevertToSnapshot truncates BalanceOps and Transfers in lockstep, so
+	// surviving indices never shift). Shape matching alone mispairs with
+	// look-alike Sub/Add pairs — e.g. an EIP-6780 selfdestruct payout with
+	// the same sender, recipient and amount as a later recorded transfer —
+	// emitting the transfer log at the wrong replay point with wrong
+	// input/output balances.
+	if opIdx != tr.BalanceOpsIdx {
+		return false
+	}
+	op := &s.BalanceOps[opIdx]
 	if op.IsAdd || op.Addr != tr.Sender || !op.Amount.Eq(&tr.Amount) {
 		return false
 	}

--- a/core/v2_7702_coderead_test.go
+++ b/core/v2_7702_coderead_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/blockstm"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/triedb"
+)
+
+// TestV2_DelegateCodeReadConsistency reproduces the root of bor PR #2264 at the
+// state layer: the EVM resolves a 7702-delegated account's code and hash via two
+// separate GetCode(addr) reads (resolveCode + resolveCodeHash). Under blockstm v2
+// there is no snapshot isolation, so a concurrent writer landing between the two
+// reads makes them follow DIFFERENT delegation targets → the Contract gets a
+// (Code, CodeHash) pair from different targets → poisons the shared jumpdest cache
+// (panic "index out of range" in validJumpdest, or gas mismatch on reverts).
+//
+// The state-layer fix (alternative to changing the EVM): a per-tx code read cache,
+// so repeated GetCode(addr) within one tx/incarnation return a consistent value —
+// mirroring the existing balCache/committedCache/destructedCache. With the cache
+// the two reads agree; without it they diverge and this test fails.
+func TestV2_DelegateCodeReadConsistency(t *testing.T) {
+	addrE := common.HexToAddress("0x000000000000000000000000000000000000e0a7") // delegated EOA
+	target1 := common.HexToAddress("0x0000000000000000000000000000000000007001")
+	target2 := common.HexToAddress("0x0000000000000000000000000000000000007002")
+	designator := func(tgt common.Address) []byte {
+		return append([]byte{0xef, 0x01, 0x00}, tgt.Bytes()...)
+	}
+	d1, d2 := designator(target1), designator(target2)
+
+	memdb := rawdb.NewMemoryDatabase()
+	tdb := triedb.NewDatabase(memdb, triedb.HashDefaults)
+	base, err := state.New(types.EmptyRootHash, state.NewDatabase(tdb, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sb := state.NewSafeBase(base, 0)
+	store := blockstm.NewMVStore()
+	bals := blockstm.NewMVBalanceStore()
+	codeKey := blockstm.NewSubpathKey(addrE, state.CodePath)
+
+	// A prior tx (idx 0) delegated E -> target1.
+	store.WriteInc(codeKey, 0, 0, d1)
+
+	r := state.NewParallelStateDB(5, sb, store, bals)
+	r.EnableReadTracking()
+
+	// EVM's resolveCode: first GetCode(E) reads the delegation designator.
+	codeRead := r.GetCode(addrE)
+
+	// A concurrent writer (tx 0 re-executing) rewrites E's delegation -> target2,
+	// landing between the EVM's two resolution reads.
+	store.WriteInc(codeKey, 0, 1, d2)
+
+	// EVM's resolveCodeHash: second GetCode(E) reads the designator again.
+	hashRead := r.GetCode(addrE)
+
+	t.Logf("GetCode#1(resolveCode)=%x  GetCode#2(resolveCodeHash)=%x", codeRead, hashRead)
+	if !bytes.Equal(codeRead, hashRead) {
+		t.Fatalf("MISMATCH: two GetCode(E) reads within one tx returned different delegation "+
+			"designators (%x vs %x). resolveCode and resolveCodeHash would build a Contract whose "+
+			"Code and CodeHash point at different targets, poisoning the shared jumpdest cache. "+
+			"Fix: a per-tx code read cache so repeated GetCode(addr) is snapshot-consistent.", codeRead, hashRead)
+	}
+}

--- a/core/v2_blockstm_test.go
+++ b/core/v2_blockstm_test.go
@@ -2,16 +2,21 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/holiman/uint256"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core/blockstm"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -266,4 +271,156 @@ func TestV2GasDeterminism(t *testing.T) {
 			t.Errorf("run %d: gas %d != expected %d (non-deterministic!)", run, res.GasUsed, expectedGas)
 		}
 	}
+}
+
+// A transaction involving a selfdestruct and a transfer makes BlockSTM V2 execution differ from
+// serial execution. Both state roots are identical, but the receipt hash of the BlockSTM V2 differs.
+// The receipt hash differs because a wrong log is emitted in the BlockSTM V2 case. This is Bor specific
+// transfer (LogTransfer event) emitted for native value transfers.
+
+// Note that the bloom matches, because
+// serial      -> LogTransfer: token=0x0000000000000000000000000000000000001010 from=0x000000000000000000000000000000000000aaaa to=0x000000000000000000000000000000000000BbBB amount=10 input1=10 input2=10 output1=0 output2=20
+// BlockSTM V2 -> LogTransfer: token=0x0000000000000000000000000000000000001010 from=0x000000000000000000000000000000000000aaaa to=0x000000000000000000000000000000000000BbBB amount=10 input1=10 input2=0 output1=0 output2=10
+
+// Run:
+// go test ./core/ -run TestV2_SelfDestructTransferLog_MispairsWithSerial -v
+func TestV2_SelfDestructTransferLog_MispairsWithSerial(t *testing.T) {
+	memdb := rawdb.NewMemoryDatabase()
+	tdb := triedb.NewDatabase(memdb, triedb.HashDefaults)
+	gen, _ := state.New(common.Hash{}, state.NewDatabase(tdb, nil))
+	cfg := *params.MergedTestChainConfig
+
+	// x Smart Contract. Simple code with two paths. Selft destruct to Y or call z contract. This contract is the entry point.
+	//   if (msg.sender == Z) { selfdestruct(payable(Y)); }
+	//   else { Z.call{value: 0}(""); payable(Y).transfer(A); }
+	x := common.HexToAddress("0x000000000000000000000000000000000000aaaa")
+	xCode := common.FromHex("3373000000000000000000000000000000000000cccc146056575f5f5f5f5f73000000000000000000000000000000000000cccc5af1505f5f5f5f600a73000000000000000000000000000000000000bbbb5af150005b73000000000000000000000000000000000000bbbbff")
+
+	// y is just an EOA. Hardcoded above.
+	// 0x000000000000000000000000000000000000bbbb
+
+	// z Smart Contract. Calls X and selfdestructs itself.
+	//   X.call{value: 0}(""); selfdestruct(payable(X));
+	z := common.HexToAddress("0x000000000000000000000000000000000000cccc")
+	zCode := common.FromHex("5f5f5f5f5f73000000000000000000000000000000000000aaaa5af15073000000000000000000000000000000000000aaaaff")
+
+	weiToTransfer := uint64(10)
+	gen.SetCode(x, xCode, tracing.CodeChangeUnspecified)
+	gen.AddBalance(x, uint256.NewInt(weiToTransfer), tracing.BalanceChangeUnspecified)
+	gen.SetCode(z, zCode, tracing.CodeChangeUnspecified)
+	gen.AddBalance(z, uint256.NewInt(weiToTransfer), tracing.BalanceChangeUnspecified)
+
+	key, _ := crypto.GenerateKey()
+	sender := crypto.PubkeyToAddress(key.PublicKey)
+	gen.AddBalance(sender, uint256.NewInt(1e18), tracing.BalanceChangeUnspecified)
+
+	root, _ := gen.Commit(0, false, false)
+	tdb.Commit(root, false)
+
+	signer := types.NewLondonSigner(cfg.ChainID)
+
+	// Note x contract is the entry point
+	tx, _ := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID:   cfg.ChainID,
+		Nonce:     0,
+		GasTipCap: big.NewInt(0),
+		GasFeeCap: big.NewInt(7),
+		Gas:       1_000_000,
+		To:        &x,
+		Value:     big.NewInt(0),
+	}), signer, key)
+	msg, _ := TransactionToMessage(tx, signer, big.NewInt(7))
+
+	blockCtx := vm.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    Transfer,
+		GetHash:     func(uint64) common.Hash { return common.Hash{} },
+		Coinbase:    common.HexToAddress("0x00000000000000000000000000000000c0ffee00"),
+		GasLimit:    30_000_000,
+		BlockNumber: big.NewInt(1),
+		Time:        1,
+		BaseFee:     big.NewInt(7),
+		Random:      &common.Hash{},
+	}
+
+	// Serial Execution
+	serialDB, _ := state.New(root, state.NewDatabase(tdb, nil))
+	serialDB.SetTxContext(tx.Hash(), 0)
+	serialEVM := vm.NewEVM(blockCtx, serialDB, &cfg, vm.Config{})
+	usedGas := uint64(0)
+	serialReceipt, err := ApplyTransactionWithEVM(msg, new(GasPool).AddGas(blockCtx.GasLimit),
+		serialDB, blockCtx.BlockNumber, common.Hash{}, blockCtx.Time, tx, &usedGas, serialEVM)
+	if err != nil {
+		t.Fatalf("serial ApplyTransactionWithEVM: %v", err)
+	}
+
+	// BlockSTM V2 Execution
+	v2DB, _ := state.New(root, state.NewDatabase(tdb, nil))
+	v2DB.SetTxContext(tx.Hash(), 0)
+	readBase := v2DB.Copy()
+	readBase.EnableConcurrentReads()
+	res := ExecuteV2BlockSTM(context.Background(), []V2Task{{Index: 0, Tx: tx, Msg: msg}},
+		readBase, blockstm.NewMVStore(), blockstm.NewMVBalanceStore(),
+		blockCtx, common.Hash{}, vm.Config{}, &cfg, blockCtx.GasLimit, 1, v2DB, nil)
+	v2DB.Finalise(true)
+
+	serialLog := decodeTransferLog(t, serialReceipt)
+	v2Log := decodeTransferLog(t, res.Receipts[0])
+
+	t.Logf("serial LogTransfer: %s", serialLog)
+	t.Logf("v2     LogTransfer: %s", v2Log)
+
+	if serialLog.data() != v2Log.data() {
+		t.Errorf("V2 BlockSTM receipt diverges from serial for the same transaction")
+	}
+}
+
+// Bor's native LogTransfer event
+const logTransferABI = `[{"anonymous":false,"name":"LogTransfer","type":"event","inputs":[
+  {"indexed":true, "name":"token",  "type":"address"},
+  {"indexed":true, "name":"from",   "type":"address"},
+  {"indexed":true, "name":"to",     "type":"address"},
+  {"indexed":false,"name":"amount", "type":"uint256"},
+  {"indexed":false,"name":"input1", "type":"uint256"},
+  {"indexed":false,"name":"input2", "type":"uint256"},
+  {"indexed":false,"name":"output1","type":"uint256"},
+  {"indexed":false,"name":"output2","type":"uint256"}]}]`
+
+// transferLog is a decoded LogTransfer. Official Polygon Bor native transfers.
+type transferLog struct {
+	Token, From, To                          common.Address
+	Amount, Input1, Input2, Output1, Output2 *big.Int
+}
+
+func (l transferLog) String() string {
+	return fmt.Sprintf("token=%s from=%s to=%s amount=%d input1=%d input2=%d output1=%d output2=%d",
+		l.Token.Hex(), l.From.Hex(), l.To.Hex(), l.Amount, l.Input1, l.Input2, l.Output1, l.Output2)
+}
+
+// data returns the 5 non-indexed words for a simple (==) comparison.
+func (l transferLog) data() [5]uint64 {
+	return [5]uint64{l.Amount.Uint64(), l.Input1.Uint64(), l.Input2.Uint64(), l.Output1.Uint64(), l.Output2.Uint64()}
+}
+
+// decodeTransferLog finds the Bor LogTransfer in a receipt and ABI-decodes it
+// (indexed topics + data) into named fields via bind.UnpackLog -- no manual
+// byte slicing.
+func decodeTransferLog(t *testing.T, r *types.Receipt) transferLog {
+	t.Helper()
+	parsed, err := abi.JSON(strings.NewReader(logTransferABI))
+	if err != nil {
+		t.Fatalf("parse LogTransfer ABI: %v", err)
+	}
+	bc := bind.NewBoundContract(feeAddress, parsed, nil, nil, nil)
+	for _, l := range r.Logs {
+		if l.Address == feeAddress && len(l.Topics) > 0 && l.Topics[0] == transferLogSig {
+			var e transferLog
+			if err := bc.UnpackLog(&e, "LogTransfer", *l); err != nil {
+				t.Fatalf("UnpackLog: %v", err)
+			}
+			return e
+		}
+	}
+	t.Fatalf("no Bor LogTransfer (0x%x at %s) found in receipt %s", transferLogSig, feeAddress, r.TxHash)
+	return transferLog{}
 }

--- a/core/v2_exist_nonce_test.go
+++ b/core/v2_exist_nonce_test.go
@@ -1,0 +1,87 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/blockstm"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/triedb"
+)
+
+// TestV2_ExistMissesPriorTxNonce is the deterministic root cause of the
+// block-77703134 / 77794337 bad blocks (both EIP-7702, both V2 over-charge,
+// both engine_validation=0).
+//
+// Serial StateDB.Exist(addr) == (getStateObject != nil); an account with
+// nonce>0 exists. ParallelStateDB.Exist checks own-create, CreatePath, suicide,
+// balance, and base — but NEVER the nonce. SetNonce writes only NoncePath (no
+// CreateAccount). So an account made to exist by a PRIOR in-block tx's nonce
+// bump (a sender increment, or a 7702 delegation clear) is seen as existing by
+// serial but non-existent by V2.
+//
+// Consequence: applyAuthorization gates a 12500-gas refund on
+// st.state.Exist(authority); V2 wrongly skips it -> over-charge -> bad block.
+// Invisible to validation because Exist never reads/records the nonce.
+func TestV2_ExistMissesPriorTxNonce(t *testing.T) {
+	e := common.HexToAddress("0x00000000000000000000000000000000000000e0")
+
+	memdb := rawdb.NewMemoryDatabase()
+	tdb := triedb.NewDatabase(memdb, triedb.HashDefaults)
+	db := state.NewDatabase(tdb, nil)
+	// base: E does NOT exist pre-block.
+	bsdb, err := state.New(types.EmptyRootHash, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := bsdb.Commit(0, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tdb.Commit(root, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// --- serial: a prior tx bumps E's nonce (no balance, no code) ---
+	serial, err := state.New(root, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial.SetNonce(e, 5, tracing.NonceChangeEoACall)
+	serial.Finalise(true)
+	serialExist := serial.Exist(e)
+
+	// --- V2: prior tx (idx 0) bumps E's nonce via the MVStore ---
+	parBase, err := state.New(root, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sb := state.NewSafeBase(parBase, 2)
+	store := blockstm.NewMVStore()
+	bals := blockstm.NewMVBalanceStore()
+
+	writer := state.NewParallelStateDB(0, sb, store, bals)
+	writer.EnableReadTracking()
+	writer.SetNonce(e, 5, tracing.NonceChangeEoACall)
+	writer.FlushToMVStore() // publish NoncePath to MVStore (no CreatePath written)
+
+	reader := state.NewParallelStateDB(1, sb, store, bals)
+	reader.EnableReadTracking()
+	v2Nonce := reader.GetNonce(e) // proves the nonce IS present and readable
+	v2Exist := reader.Exist(e)
+
+	t.Logf("E via prior-tx nonce-only: serial.Exist=%v  v2.GetNonce=%d  v2.Exist=%v",
+		serialExist, v2Nonce, v2Exist)
+
+	if v2Nonce != 5 {
+		t.Fatalf("sanity: expected V2 GetNonce(E)=5 (prior-tx nonce visible), got %d", v2Nonce)
+	}
+	if v2Exist != serialExist {
+		t.Fatalf("ROOT CAUSE REPRODUCED: ParallelStateDB.Exist=%v but serial StateDB.Exist=%v "+
+			"for an account existing via prior-tx nonce-only (nonce=%d). Exist ignores the nonce, "+
+			"so EIP-7702 applyAuthorization's Exist-gated 12500 refund diverges.", v2Exist, serialExist, v2Nonce)
+	}
+}

--- a/core/v2_serial_parity_fuzz_test.go
+++ b/core/v2_serial_parity_fuzz_test.go
@@ -1,29 +1,29 @@
 package core
 
 import (
+	"bytes"
 	"context"
-	"crypto/ecdsa"
-	"crypto/sha256"
 	"math/big"
+	"slices"
 	"testing"
-
-	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/blockstm"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/triedb"
 )
 
 // This file builds the executor-level differential against serial: the
-// fuzzer drives both (a) the full V2 BlockSTM executor and (b) a
-// straight-line serial application of the same txs, then asserts the
-// resulting state roots are byte-identical.
+// fuzzer drives both (a) the full V2 BlockSTM executor and (b) the
+// production serial path (ApplyTransactionWithEVM) over the same txs,
+// then asserts every consensus output matches: state root, receipts
+// root, and per-tx status / cumulative gas / bloom / logs. Comparing
+// roots alone is not enough — the settlement log mispairing fixed on
+// this branch left state roots identical and corrupted only receipts.
 //
 // The motivation: TestV2Differential exercises only ParallelStateDB +
 // SettleTo, never going through ExecuteV2BlockSTM. v2_executor_diff
@@ -33,286 +33,64 @@ import (
 // real EVM, real signed txs, real executor, fast enough for CI.
 //
 // Inputs are decoded into a sequence of valid signed transactions
-// over a fixed set of pre-funded sender keys. Each tx is one of:
+// over a fixed set of pre-funded sender keys (see
+// v2_serial_parity_gen_test.go for the generator). Each tx is one of:
 //   transfer to a sender    — exercises balance delta read/write
 //   transfer to a fresh adr — exercises EIP-161 touch / new-account
 //   create contract         — exercises CodePath writes + EXTCODEHASH
 //   call last contract      — exercises EXTCODEHASH + storage rw +
 //                             cross-tx vfail/re-exec under conflict
+//   call selfdestruct pair  — exercises EIP-6780 payouts whose balance
+//                             ops shape-match recorded transfers
+//   7702 authorization      — exercises delegation set/clear, nonce-only
+//                             account existence, delegated code reads
 //
-// Between txs the V2 path runs through SettleTo on a finalDB; the
-// serial path runs ApplyMessage + Finalise(true). Both finish with
-// IntermediateRoot. Mismatch → fuzz failure (saved to testdata/fuzz/).
+// Between txs the V2 path settles through SettleTo on a finalDB; the
+// serial path runs ApplyTransactionWithEVM + Finalise(true). Mismatch
+// in any consensus output → fuzz failure (saved to testdata/fuzz/).
 
-// numFuzzSenders is fixed so the encoder can stably interpret "sender
-// index" as one byte. Five senders is enough to exercise per-sender
-// nonce chaining and cross-sender independence without exploding the
-// per-iteration cost of fuzzing.
-const numFuzzSenders = 5
+// fuzzChainConfig enables every supported fork (incl. Prague/EIP-7702)
+// so the vocabulary above is all live. Bor is nil here, so bor fee
+// transfer logs are skipped identically on both paths; the 0x1010
+// LogTransfer for value transfers is emitted unconditionally by
+// core.Transfer and is part of the compared receipts.
+var fuzzChainConfig = params.MergedTestChainConfig
 
-// fuzzGasLimit caps every tx so a malformed contract can't burn the
-// fuzzer's wall-clock. 200k is enough for any contract scenario the
-// generator produces; transfers consume 21k.
-const fuzzGasLimit = 200_000
-
-// fuzzMaxTxs caps txs per scenario so a long fuzz input doesn't blow
-// out the per-iteration runtime — keeps each fuzz step fast.
-const fuzzMaxTxs = 25
-
-// fuzzKeys are deterministic per-run keys derived from a constant seed
-// so failing fuzz inputs reproduce identically across runs.
-var fuzzKeys = mustGenFuzzKeys(numFuzzSenders)
-
-func mustGenFuzzKeys(n int) []*ecdsa.PrivateKey {
-	out := make([]*ecdsa.PrivateKey, n)
-	for i := 0; i < n; i++ {
-		// Stable, deterministic key derivation from index — never use
-		// these in production; they're test-only for byte-identical
-		// repro across machines.
-		seed := sha256.Sum256([]byte{0x42, byte(i)})
-		k, err := crypto.ToECDSA(seed[:])
-		if err != nil {
-			panic(err)
-		}
-		out[i] = k
-	}
-	return out
-}
-
-// fuzzCoinbase is the block coinbase. It's deliberately separate from
-// any sender so the fee-burn / fee-tip path involves balance changes
-// to a non-sender address, exercising V2's settle-time fee plumbing.
-var fuzzCoinbase = common.HexToAddress("0xCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCB")
-
-// initialBalance per sender — generous enough that a 25-tx scenario
-// can't bankrupt anyone via gas + value.
-var initialBalance = new(uint256.Int).Mul(uint256.NewInt(100), uint256.NewInt(1e18))
-
-// fuzzTxKind enumerates the tx shapes the generator produces.
-type fuzzTxKind uint8
-
-const (
-	kindTransferToSender fuzzTxKind = iota
-	kindTransferToFresh
-	kindContractCreate
-	kindContractCall
-)
-
-// fuzzTx is one tx in a decoded scenario.
-type fuzzTx struct {
-	kind         fuzzTxKind
-	senderIdx    int    // index into fuzzKeys
-	recipientIdx int    // for kindTransferToSender
-	freshNonce   byte   // for kindTransferToFresh — derived from input bytes for determinism
-	valueGwei    uint16 // small value so balances don't run out
-	createKind   uint8  // for kindContractCreate — selects which canned bytecode
-}
-
-// canned contract bytecodes used by kindContractCreate. Each one is
-// short and self-contained so the fuzzer can deploy any of them cheaply.
-var fuzzCreateSnippets = [][]byte{
-	// 0: empty constructor → returns nothing → contract has no code.
-	{0x60, 0x00, 0x60, 0x00, 0xf3}, // PUSH1 0 PUSH1 0 RETURN
-	// 1: SSTORE slot 0 = 1, then return empty code.
-	{0x60, 0x01, 0x60, 0x00, 0x55, 0x60, 0x00, 0x60, 0x00, 0xf3},
-	// 2: returns runtime code that does SSTORE slot 1 += 1 and STOP.
-	// Constructor: copy the runtime code to memory, return it.
-	// Runtime code: 60 01 60 01 54 01 60 01 55 00
-	//               PUSH1 1 PUSH1 1 SLOAD ADD PUSH1 1 SSTORE STOP  (10 bytes)
-	{
-		0x60, 0x0a, // PUSH1 10 (length)
-		0x60, 0x0c, // PUSH1 12 (offset = past constructor)
-		0x60, 0x00, // PUSH1 0  (dest in memory)
-		0x39,       // CODECOPY
-		0x60, 0x0a, // PUSH1 10 (length)
-		0x60, 0x00, // PUSH1 0
-		0xf3, // RETURN
-		// runtime code starts here:
-		0x60, 0x01, 0x60, 0x01, 0x54, 0x01, 0x60, 0x01, 0x55, 0x00,
-	},
-}
-
-// decodeScenario consumes the fuzzer's bytes and produces a sequence
-// of valid txs. Validity (nonce ordering, balance) is the decoder's
-// responsibility — failing txs are fine (both paths must reject the
-// same way) but txs that exhaust a sender's balance bias the test.
-func decodeScenario(data []byte) []fuzzTx {
-	if len(data) < 5 {
-		return nil
-	}
-	var out []fuzzTx
-	i := 0
-	for i+4 < len(data) && len(out) < fuzzMaxTxs {
-		// Layout: [kind(1) | sender(1) | aux(1) | valueLo(1) | valueHi(1)]
-		kind := fuzzTxKind(data[i] % 4)
-		senderIdx := int(data[i+1]) % numFuzzSenders
-		aux := data[i+2]
-		valueGwei := uint16(data[i+3]) | (uint16(data[i+4]) << 8)
-		// Cap value in gwei so cumulative spend per sender stays well
-		// under initialBalance.
-		valueGwei %= 4096
-
-		tx := fuzzTx{
-			kind:      kind,
-			senderIdx: senderIdx,
-			valueGwei: valueGwei,
-		}
-		switch kind {
-		case kindTransferToSender:
-			tx.recipientIdx = int(aux) % numFuzzSenders
-		case kindTransferToFresh:
-			tx.freshNonce = aux
-		case kindContractCreate:
-			tx.createKind = aux % uint8(len(fuzzCreateSnippets))
-		case kindContractCall:
-			// nothing extra; we'll resolve the target at apply time
-		}
-		out = append(out, tx)
-		i += 5
-	}
-	return out
-}
-
-// scenarioState tracks per-sender nonces and the most-recently-created
-// contract address so kindContractCall has a target.
-type scenarioState struct {
-	nonces      [numFuzzSenders]uint64
-	lastCreated common.Address
-	hasContract bool
-}
-
-// freshAddr derives a deterministic address from a single byte —
-// reused across both serial and V2 runs so they target the same
-// recipient.
-func freshAddr(seed byte) common.Address {
-	var a common.Address
-	a[19] = seed
-	a[18] = 0xa1
-	return a
-}
-
-// signedTxs builds the signed transactions from the decoded scenario,
-// using the per-sender nonce tracker. Returns parallel slices: the
-// signed txs and their pre-recovered Messages.
-func signedTxs(t testing.TB, decoded []fuzzTx, signer types.Signer, baseFee *big.Int) ([]*types.Transaction, []*Message) {
-	t.Helper()
-	state := scenarioState{}
-	txs := make([]*types.Transaction, 0, len(decoded))
-	msgs := make([]*Message, 0, len(decoded))
-
-	for _, d := range decoded {
-		nonce := state.nonces[d.senderIdx]
-		state.nonces[d.senderIdx]++
-
-		var to *common.Address
-		var data []byte
-		gas := uint64(21000)
-		switch d.kind {
-		case kindTransferToSender:
-			a := crypto.PubkeyToAddress(fuzzKeys[d.recipientIdx].PublicKey)
-			to = &a
-		case kindTransferToFresh:
-			a := freshAddr(d.freshNonce)
-			to = &a
-		case kindContractCreate:
-			data = fuzzCreateSnippets[d.createKind]
-			gas = fuzzGasLimit
-		case kindContractCall:
-			if !state.hasContract {
-				// No contract deployed yet — fall back to a fresh transfer.
-				a := freshAddr(d.freshNonce)
-				to = &a
-			} else {
-				a := state.lastCreated
-				to = &a
-				gas = fuzzGasLimit
-			}
-		}
-
-		// Compute value in wei from gwei; 0 is a legal value too.
-		value := new(big.Int).Mul(big.NewInt(int64(d.valueGwei)), big.NewInt(1e9))
-		tx, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
-			ChainID:   params.TestChainConfig.ChainID,
-			Nonce:     nonce,
-			GasTipCap: big.NewInt(1),
-			GasFeeCap: big.NewInt(1e9),
-			Gas:       gas,
-			To:        to,
-			Value:     value,
-			Data:      data,
-		}), signer, fuzzKeys[d.senderIdx])
-		if err != nil {
-			t.Fatal(err)
-		}
-		// Track the contract address that this tx WOULD create — both
-		// paths derive it the same way (CREATE = keccak(rlp(sender, nonce))).
-		if d.kind == kindContractCreate {
-			state.lastCreated = crypto.CreateAddress(crypto.PubkeyToAddress(fuzzKeys[d.senderIdx].PublicKey), nonce)
-			state.hasContract = true
-		}
-		msg, err := TransactionToMessage(tx, signer, baseFee)
-		if err != nil {
-			t.Fatal(err)
-		}
-		txs = append(txs, tx)
-		msgs = append(msgs, msg)
-	}
-	return txs, msgs
-}
-
-// buildBaseStateRoot creates an in-memory pre-state with every sender
-// pre-funded, commits, and returns (db, root) so both serial and V2
-// paths can re-open at the same root.
-func buildBaseStateRoot(t testing.TB) (*triedb.Database, common.Hash) {
-	t.Helper()
-	memdb := rawdb.NewMemoryDatabase()
-	tdb := triedb.NewDatabase(memdb, triedb.HashDefaults)
-	sdb, err := state.New(common.Hash{}, state.NewDatabase(tdb, nil))
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, k := range fuzzKeys {
-		addr := crypto.PubkeyToAddress(k.PublicKey)
-		sdb.AddBalance(addr, initialBalance, 0)
-	}
-	root, err := sdb.Commit(0, false, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := tdb.Commit(root, false); err != nil {
-		t.Fatal(err)
-	}
-	return tdb, root
-}
-
-// runSerial applies txs sequentially via ApplyMessage on a fresh
-// StateDB at root. Between txs Finalise(true) so EIP-158 empty-account
-// deletion lines up with V2's settle path. Returns the post-IntermediateRoot.
-func runSerial(t testing.TB, tdb *triedb.Database, root common.Hash, txs []*types.Transaction, msgs []*Message, blockCtx vm.BlockContext) common.Hash {
+// runSerial applies txs sequentially via ApplyTransactionWithEVM (the
+// production serial path — it finalises per tx and emits receipts) on
+// a fresh StateDB at root. Returns the post-IntermediateRoot and the
+// per-tx receipts.
+func runSerial(t testing.TB, tdb *triedb.Database, root common.Hash, txs []*types.Transaction, msgs []*Message, blockCtx vm.BlockContext) (common.Hash, types.Receipts) {
 	t.Helper()
 	sdb, err := state.New(root, state.NewDatabase(tdb, nil))
 	if err != nil {
 		t.Fatal(err)
 	}
+	gp := new(GasPool).AddGas(blockCtx.GasLimit)
+	var usedGas uint64
+	receipts := make(types.Receipts, 0, len(txs))
 	for i, tx := range txs {
 		sdb.SetTxContext(tx.Hash(), i)
-		evm := vm.NewEVM(blockCtx, sdb, params.TestChainConfig, vm.Config{})
-		evm.SetTxContext(NewEVMTxContext(msgs[i]))
-		// Failures are expected and accepted (e.g., out-of-gas) — V2
-		// must reject them the same way. Either way the state changes
-		// the message produced before failure must be reflected in
-		// the journal+Finalise so the trie matches V2's settle path.
-		_, _ = ApplyMessage(evm, msgs[i], new(GasPool).AddGas(blockCtx.GasLimit))
-		sdb.Finalise(true)
+		evm := vm.NewEVM(blockCtx, sdb, fuzzChainConfig, vm.Config{})
+		// The generator only emits consensus-valid txs (tracked nonces,
+		// bounded values against huge balances), so an apply error is a
+		// generator bug, not an accepted outcome. EVM-level failures
+		// (revert, OOG) still produce a status-failed receipt.
+		receipt, err := ApplyTransactionWithEVM(msgs[i], gp, sdb, blockCtx.BlockNumber, common.Hash{}, blockCtx.Time, tx, &usedGas, evm)
+		if err != nil {
+			t.Fatalf("serial apply tx %d: %v", i, err)
+		}
+		receipts = append(receipts, receipt)
 	}
-	return sdb.IntermediateRoot(true)
+	return sdb.IntermediateRoot(true), receipts
 }
 
 // runV2 runs txs through ExecuteV2BlockSTM with `workers` parallel
-// workers, then returns the IntermediateRoot of finalDB. base and
-// finalDB are independent StateDB instances at the same root (V2
-// requires this — workers read from base, settlement writes to finalDB).
-func runV2(t testing.TB, tdb *triedb.Database, root common.Hash, txs []*types.Transaction, msgs []*Message, blockCtx vm.BlockContext, workers int) common.Hash {
+// workers, then returns the IntermediateRoot of finalDB and the
+// settlement-built receipts. base and finalDB are independent StateDB
+// instances at the same root (V2 requires this — workers read from
+// base, settlement writes to finalDB).
+func runV2(t testing.TB, tdb *triedb.Database, root common.Hash, txs []*types.Transaction, msgs []*Message, blockCtx vm.BlockContext, workers int) (common.Hash, types.Receipts) {
 	t.Helper()
 	base, err := state.New(root, state.NewDatabase(tdb, nil))
 	if err != nil {
@@ -330,21 +108,74 @@ func runV2(t testing.TB, tdb *triedb.Database, root common.Hash, txs []*types.Tr
 
 	store := blockstm.NewMVStore()
 	bals := blockstm.NewMVBalanceStore()
-	_ = ExecuteV2BlockSTM(context.Background(), tasks, base, store, bals, blockCtx, common.Hash{}, vm.Config{},
-		params.TestChainConfig, blockCtx.GasLimit, workers, finalDB, nil)
+	res := ExecuteV2BlockSTM(context.Background(), tasks, base, store, bals, blockCtx, common.Hash{}, vm.Config{},
+		fuzzChainConfig, blockCtx.GasLimit, workers, finalDB, nil)
+	if res.PanickedIdx >= 0 {
+		t.Fatalf("V2 executor: tx %d panicked", res.PanickedIdx)
+	}
+	if res.ExecErrIdx >= 0 {
+		t.Fatalf("V2 executor: tx %d consensus error: %v", res.ExecErrIdx, res.ExecErr)
+	}
 
-	return finalDB.IntermediateRoot(true)
+	return finalDB.IntermediateRoot(true), res.Receipts
+}
+
+// assertReceiptParity compares every consensus field of the two receipt
+// sets, then the receipts trie root itself — exactly the header field a
+// validator recomputes. Per-field errors first so a divergence
+// pinpoints the tx and field instead of just two root hashes.
+func assertReceiptParity(t testing.TB, serial, v2 types.Receipts, workers int, decoded []fuzzTx) {
+	t.Helper()
+	if len(serial) != len(v2) {
+		t.Fatalf("receipt count mismatch: serial=%d v2=%d (workers=%d)", len(serial), len(v2), workers)
+	}
+	for i := range serial {
+		s, p := serial[i], v2[i]
+		if s.Status != p.Status {
+			t.Errorf("tx %d: status serial=%d v2=%d", i, s.Status, p.Status)
+		}
+		if s.CumulativeGasUsed != p.CumulativeGasUsed {
+			t.Errorf("tx %d: cumulative gas serial=%d v2=%d (tx gas serial=%d v2=%d)",
+				i, s.CumulativeGasUsed, p.CumulativeGasUsed, s.GasUsed, p.GasUsed)
+		}
+		if s.Bloom != p.Bloom {
+			t.Errorf("tx %d: bloom mismatch", i)
+		}
+		if len(s.Logs) != len(p.Logs) {
+			t.Errorf("tx %d: log count serial=%d v2=%d", i, len(s.Logs), len(p.Logs))
+			continue
+		}
+		for j := range s.Logs {
+			sl, pl := s.Logs[j], p.Logs[j]
+			if sl.Address != pl.Address || !slices.Equal(sl.Topics, pl.Topics) || !bytes.Equal(sl.Data, pl.Data) {
+				t.Errorf("tx %d log %d:\n  serial = addr=%s topics=%v data=%x\n  v2     = addr=%s topics=%v data=%x",
+					i, j, sl.Address, sl.Topics, sl.Data, pl.Address, pl.Topics, pl.Data)
+			}
+		}
+	}
+	sRoot := types.DeriveSha(serial, trie.NewStackTrie(nil))
+	pRoot := types.DeriveSha(v2, trie.NewStackTrie(nil))
+	if sRoot != pRoot {
+		t.Fatalf(`receipts-root divergence between serial and V2 executor:
+  serial = %s
+  v2     = %s
+  workers= %d
+First decoded txs:
+  %v`,
+			sRoot.Hex(), pRoot.Hex(), workers, decoded[:min(len(decoded), 4)])
+	}
 }
 
 // runScenarioAndAssertParity is the workhorse. It generates txs from
-// the decoded scenario, runs both paths, and t.Fatals on root mismatch.
+// the decoded scenario, runs both paths, and fails on any consensus
+// output mismatch.
 func runScenarioAndAssertParity(t testing.TB, decoded []fuzzTx, workers int) {
 	if len(decoded) == 0 {
 		return
 	}
 	tdb, root := buildBaseStateRoot(t)
 
-	signer := types.NewLondonSigner(params.TestChainConfig.ChainID)
+	signer := types.LatestSigner(fuzzChainConfig)
 	baseFee := big.NewInt(1)
 	blockCtx := vm.BlockContext{
 		CanTransfer: CanTransfer,
@@ -355,6 +186,7 @@ func runScenarioAndAssertParity(t testing.TB, decoded []fuzzTx, workers int) {
 		BlockNumber: big.NewInt(1),
 		Time:        1,
 		BaseFee:     baseFee,
+		Random:      &common.Hash{}, // post-merge rules (PREVRANDAO)
 	}
 
 	txs, msgs := signedTxs(t, decoded, signer, baseFee)
@@ -362,8 +194,8 @@ func runScenarioAndAssertParity(t testing.TB, decoded []fuzzTx, workers int) {
 		return
 	}
 
-	serialRoot := runSerial(t, tdb, root, txs, msgs, blockCtx)
-	v2Root := runV2(t, tdb, root, txs, msgs, blockCtx, workers)
+	serialRoot, serialReceipts := runSerial(t, tdb, root, txs, msgs, blockCtx)
+	v2Root, v2Receipts := runV2(t, tdb, root, txs, msgs, blockCtx, workers)
 
 	if serialRoot != v2Root {
 		t.Fatalf(`state-root divergence between serial and V2 executor:
@@ -376,11 +208,12 @@ First decoded txs:
 Re-run a single iteration with: go test -run FuzzV2ExecutorVsSerial/<corpus-id>`,
 			serialRoot.Hex(), v2Root.Hex(), workers, len(txs), decoded[:min(len(decoded), 4)])
 	}
+	assertReceiptParity(t, serialReceipts, v2Receipts, workers, decoded)
 }
 
 // FuzzV2ExecutorVsSerial drives the V2 BlockSTM executor and the serial
 // state path with random tx sequences and asserts byte-identical
-// state roots after each run. Failing inputs are persisted to
+// consensus outputs after each run. Failing inputs are persisted to
 // testdata/fuzz/FuzzV2ExecutorVsSerial/ for replay.
 //
 // Run with `go test -fuzz=FuzzV2ExecutorVsSerial ./core/`.
@@ -411,11 +244,37 @@ func FuzzV2ExecutorVsSerial(f *testing.F) {
 		},
 		// Transfer to fresh address (EIP-161 path).
 		{byte(kindTransferToFresh), 0, 0xab, 5, 0},
+		// Zero-value call into the predeployed selfdestruct pair: the
+		// EIP-6780 payout (X→Y, 10 wei) shape-matches the tx's later
+		// recorded transfer (X→Y, 10 wei) — the settlement mispairing
+		// shape from PR #2268. State roots match; only receipts diverge.
+		{byte(kindCallSelfDestructPair), 0, 0, 0, 0},
+		// Repeated delegation-clears for the same authority (Exist via
+		// CreatePath + nonce churn on the refund gate).
+		{
+			byte(kind7702Auth), 0, 0, 0, 0,
+			byte(kind7702Auth), 1, 0, 0, 0,
+		},
+		// Fund → self-drain-to-zero → authorize: the authority is a
+		// nonce-only account when its authorization is validated, so the
+		// 12500 refund hinges on Exist seeing the nonce — the EIP-7702
+		// over-charge shape from the mainnet bad blocks.
+		{byte(kindNonceOnlyAccount), 0, 0, 0, 0},
+		// Delegate two authorities to the selfdestruct-pair entry (their
+		// calls run X's bounce-and-payout code as the authority), then
+		// clear one — 7702 churn mixed with EIP-6780 payouts.
+		{
+			byte(kind7702Auth), 0, 0x80, 0, 0,
+			byte(kind7702Auth), 1, 0x81, 0, 0,
+			byte(kind7702Auth), 2, 1, 0, 0,
+		},
 		// Mixed: every kind in one scenario.
 		{
 			byte(kindContractCreate), 0, 2, 0, 0,
 			byte(kindTransferToSender), 1, 2, 7, 0,
 			byte(kindContractCall), 2, 0, 0, 0,
+			byte(kindCallSelfDestructPair), 3, 0, 0, 0,
+			byte(kind7702Auth), 4, 0x80, 0, 0,
 			byte(kindTransferToFresh), 3, 0xff, 1, 0,
 			byte(kindTransferToSender), 4, 0, 3, 0,
 		},
@@ -441,34 +300,64 @@ func FuzzV2ExecutorVsSerial(f *testing.F) {
 // `-fuzz`. Each subtest runs with a small worker count grid.
 func TestV2ExecutorVsSerial_SeedCorpus(t *testing.T) {
 	cases := map[string][]fuzzTx{
-		"OneTransfer": {{kindTransferToSender, 0, 1, 0, 100, 0}},
+		"OneTransfer": {{kind: kindTransferToSender, senderIdx: 0, recipientIdx: 1, valueGwei: 100}},
 		"SenderChain": {
-			{kindTransferToSender, 0, 1, 0, 50, 0},
-			{kindTransferToSender, 0, 2, 0, 50, 0},
-			{kindTransferToSender, 0, 3, 0, 50, 0},
+			{kind: kindTransferToSender, senderIdx: 0, recipientIdx: 1, valueGwei: 50},
+			{kind: kindTransferToSender, senderIdx: 0, recipientIdx: 2, valueGwei: 50},
+			{kind: kindTransferToSender, senderIdx: 0, recipientIdx: 3, valueGwei: 50},
 		},
 		"IndependentSenders": {
-			{kindTransferToSender, 0, 1, 0, 10, 0},
-			{kindTransferToSender, 1, 2, 0, 10, 0},
-			{kindTransferToSender, 2, 3, 0, 10, 0},
-			{kindTransferToSender, 3, 4, 0, 10, 0},
-			{kindTransferToSender, 4, 0, 0, 10, 0},
+			{kind: kindTransferToSender, senderIdx: 0, recipientIdx: 1, valueGwei: 10},
+			{kind: kindTransferToSender, senderIdx: 1, recipientIdx: 2, valueGwei: 10},
+			{kind: kindTransferToSender, senderIdx: 2, recipientIdx: 3, valueGwei: 10},
+			{kind: kindTransferToSender, senderIdx: 3, recipientIdx: 4, valueGwei: 10},
+			{kind: kindTransferToSender, senderIdx: 4, recipientIdx: 0, valueGwei: 10},
 		},
 		"CreateThenCall": {
-			{kindContractCreate, 0, 0, 0, 0, 1},
-			{kindContractCall, 1, 0, 0, 0, 0},
-			{kindContractCall, 2, 0, 0, 0, 0},
+			{kind: kindContractCreate, senderIdx: 0, createKind: 1},
+			{kind: kindContractCall, senderIdx: 1},
+			{kind: kindContractCall, senderIdx: 2},
 		},
 		"FreshAddrTransfer": {
-			{kindTransferToFresh, 0, 0, 0xab, 5, 0},
-			{kindTransferToFresh, 1, 0, 0xcd, 7, 0},
+			{kind: kindTransferToFresh, senderIdx: 0, freshNonce: 0xab, valueGwei: 5},
+			{kind: kindTransferToFresh, senderIdx: 1, freshNonce: 0xcd, valueGwei: 7},
+		},
+		// The PR #2268 settlement mispairing shape — state roots equal,
+		// receipts diverge without the BalanceOpsIdx pairing fix.
+		"SelfDestructTransferPair": {
+			{kind: kindCallSelfDestructPair, senderIdx: 0},
+		},
+		"SelfDestructPairWithValue": {
+			{kind: kindCallSelfDestructPair, senderIdx: 0, valueGwei: 3},
+			{kind: kindCallSelfDestructPair, senderIdx: 1},
+		},
+		"Auth7702RepeatedClears": {
+			{kind: kind7702Auth, senderIdx: 0, authSel: 0},
+			{kind: kind7702Auth, senderIdx: 1, authSel: 0},
+		},
+		// The Exist nonce fix's shape: fund the authority, let it drain
+		// itself to exactly zero (account = nonce-only), then validate an
+		// authorization for it — the 12500 refund hinges on Exist seeing
+		// the nonce.
+		"NonceOnlyAuthorityRefund": {
+			{kind: kindNonceOnlyAccount, senderIdx: 0, authSel: 0},
+		},
+		"NonceOnlyAuthorityDelegate": {
+			{kind: kindNonceOnlyAccount, senderIdx: 1, authSel: 0x81},
+		},
+		"Auth7702DelegateCallClear": {
+			{kind: kind7702Auth, senderIdx: 0, authSel: 0x80},
+			{kind: kind7702Auth, senderIdx: 1, authSel: 0x81},
+			{kind: kind7702Auth, senderIdx: 2, authSel: 1},
 		},
 		"MixedKinds": {
-			{kindContractCreate, 0, 0, 0, 0, 2},
-			{kindTransferToSender, 1, 2, 0, 7, 0},
-			{kindContractCall, 2, 0, 0, 0, 0},
-			{kindTransferToFresh, 3, 0, 0xff, 1, 0},
-			{kindTransferToSender, 4, 0, 0, 3, 0},
+			{kind: kindContractCreate, senderIdx: 0, createKind: 2},
+			{kind: kindTransferToSender, senderIdx: 1, recipientIdx: 2, valueGwei: 7},
+			{kind: kindContractCall, senderIdx: 2},
+			{kind: kindCallSelfDestructPair, senderIdx: 3},
+			{kind: kind7702Auth, senderIdx: 4, authSel: 0x80},
+			{kind: kindTransferToFresh, senderIdx: 3, freshNonce: 0xff, valueGwei: 1},
+			{kind: kindTransferToSender, senderIdx: 4, recipientIdx: 0, valueGwei: 3},
 		},
 	}
 	workerGrid := []int{1, 4, 8}

--- a/core/v2_serial_parity_gen_test.go
+++ b/core/v2_serial_parity_gen_test.go
@@ -1,0 +1,475 @@
+package core
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/triedb"
+)
+
+// This file holds the scenario generator for the serial-vs-V2 parity
+// fuzzer (see v2_serial_parity_fuzz_test.go): tx vocabulary, key
+// derivation, scenario decoding, signing, and the pre-state builder.
+//
+// The vocabulary must track the fork schedule: when a fork adds a tx
+// type or changes account-mutating behavior, add a kind here in the
+// same PR. The three V2 divergences fixed on this branch (settlement
+// log mispairing, Exist missing nonce-only accounts, code-read
+// snapshot inconsistency) all lived in surface the old vocabulary —
+// transfers, creates, storage calls — could not reach: selfdestruct
+// payouts and EIP-7702 authorizations.
+
+// numFuzzSenders is fixed so the encoder can stably interpret "sender
+// index" as one byte. Five senders is enough to exercise per-sender
+// nonce chaining and cross-sender independence without exploding the
+// per-iteration cost of fuzzing.
+const numFuzzSenders = 5
+
+// numFuzzAuthorities is the pool of EIP-7702 authority keys. They are
+// disjoint from the sender keys and never send transactions, so their
+// account nonce moves only via applied authorizations — which keeps
+// scenarioState's authority-nonce tracking exact and, crucially, lets
+// a delegation-clear produce a nonce-only account (nonce>0, zero
+// balance, no code): the account class ParallelStateDB.Exist used to
+// misreport.
+const numFuzzAuthorities = 2
+
+// fuzzGasLimit caps every tx so a malformed contract can't burn the
+// fuzzer's wall-clock. 200k is enough for any contract scenario the
+// generator produces; transfers consume 21k.
+const fuzzGasLimit = 200_000
+
+// fuzzMaxTxs caps txs per scenario so a long fuzz input doesn't blow
+// out the per-iteration runtime — keeps each fuzz step fast.
+const fuzzMaxTxs = 25
+
+// fuzzKeys / fuzzAuthKeys are deterministic per-run keys derived from
+// constant seeds so failing fuzz inputs reproduce identically across runs.
+var (
+	fuzzKeys     = mustGenFuzzKeys(numFuzzSenders, 0x42)
+	fuzzAuthKeys = mustGenFuzzKeys(numFuzzAuthorities, 0x43)
+)
+
+func mustGenFuzzKeys(n int, tag byte) []*ecdsa.PrivateKey {
+	out := make([]*ecdsa.PrivateKey, n)
+	for i := 0; i < n; i++ {
+		// Stable, deterministic key derivation from index — never use
+		// these in production; they're test-only for byte-identical
+		// repro across machines.
+		seed := sha256.Sum256([]byte{tag, byte(i)})
+		k, err := crypto.ToECDSA(seed[:])
+		if err != nil {
+			panic(err)
+		}
+		out[i] = k
+	}
+	return out
+}
+
+// fuzzCoinbase is the block coinbase. It's deliberately separate from
+// any sender so the fee-burn / fee-tip path involves balance changes
+// to a non-sender address, exercising V2's settle-time fee plumbing.
+var fuzzCoinbase = common.HexToAddress("0xCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCB")
+
+// initialBalance per sender — generous enough that a 25-tx scenario
+// can't bankrupt anyone via gas + value.
+var initialBalance = new(uint256.Int).Mul(uint256.NewInt(100), uint256.NewInt(1e18))
+
+// The EIP-6780 selfdestruct pair from PR #2268, predeployed at fixed
+// addresses (genesis-style) so generator txs can target them. Entry X
+// holds 10 wei; called by anyone but Z it bounces through helper Z,
+// which re-enters X (msg.sender == Z → selfdestruct to payout EOA Y)
+// and then selfdestructs back to X; X's outer frame finally transfers
+// 10 wei to Y. With a zero-value entry call, the selfdestruct payout
+// ops (X→Y, 10) shape-match the later recorded transfer (X→Y, 10) —
+// the settlement mispairing class that produced V2 receipts diverging
+// from serial while state roots stayed identical.
+var (
+	sdPairEntry  = common.HexToAddress("0x000000000000000000000000000000000000aaaa") // X
+	sdPairHelper = common.HexToAddress("0x000000000000000000000000000000000000cccc") // Z
+	sdPairPayout = common.HexToAddress("0x000000000000000000000000000000000000bbbb") // Y (EOA)
+
+	// if (msg.sender == Z) { selfdestruct(payable(Y)); }
+	// else { Z.call{value: 0}(""); payable(Y).transfer(10); }
+	sdPairEntryCode = common.FromHex("3373000000000000000000000000000000000000cccc146056575f5f5f5f5f73000000000000000000000000000000000000cccc5af1505f5f5f5f600a73000000000000000000000000000000000000bbbb5af150005b73000000000000000000000000000000000000bbbbff")
+	// X.call{value: 0}(""); selfdestruct(payable(X));
+	sdPairHelperCode = common.FromHex("5f5f5f5f5f73000000000000000000000000000000000000aaaa5af15073000000000000000000000000000000000000aaaaff")
+)
+
+// sweeper selfdestructs to the address in calldata[0:20], forwarding its
+// whole balance (including the call value). An EIP-6780 payout credits
+// the beneficiary directly in the opcode handler — unlike a plain value
+// CALL, which explicitly creates a non-existent recipient (evm.Call →
+// CreateAccount → CreatePath). Funding through the sweeper is therefore
+// the way to give a fresh account balance without making it visible to
+// existence checks that only consult CreatePath/balance/base.
+var (
+	sweeperAddr = common.HexToAddress("0x000000000000000000000000000000000000dddd")
+	// PUSH0 CALLDATALOAD PUSH1 96 SHR SELFDESTRUCT
+	sweeperCode = common.FromHex("5f3560601cff")
+)
+
+// fuzzTxKind enumerates the tx shapes the generator produces.
+type fuzzTxKind uint8
+
+const (
+	kindTransferToSender fuzzTxKind = iota
+	kindTransferToFresh
+	kindContractCreate
+	kindContractCall
+	kindCallSelfDestructPair
+	kind7702Auth
+	kindNonceOnlyAccount
+)
+
+// fuzzTx is one tx in a decoded scenario.
+type fuzzTx struct {
+	kind         fuzzTxKind
+	senderIdx    int    // index into fuzzKeys
+	recipientIdx int    // for kindTransferToSender
+	freshNonce   byte   // for kindTransferToFresh — derived from input bytes for determinism
+	valueGwei    uint16 // small value so balances don't run out
+	createKind   uint8  // for kindContractCreate — selects which canned bytecode
+	authSel      uint8  // for kind7702Auth/kindNonceOnlyAccount — low bits pick the authority, 0x80 delegates to X (else clears)
+}
+
+// canned contract bytecodes used by kindContractCreate. Each one is
+// short and self-contained so the fuzzer can deploy any of them cheaply.
+var fuzzCreateSnippets = [][]byte{
+	// 0: empty constructor → returns nothing → contract has no code.
+	{0x60, 0x00, 0x60, 0x00, 0xf3}, // PUSH1 0 PUSH1 0 RETURN
+	// 1: SSTORE slot 0 = 1, then return empty code.
+	{0x60, 0x01, 0x60, 0x00, 0x55, 0x60, 0x00, 0x60, 0x00, 0xf3},
+	// 2: returns runtime code that does SSTORE slot 1 += 1 and STOP.
+	// Constructor: copy the runtime code to memory, return it.
+	// Runtime code: 60 01 60 01 54 01 60 01 55 00
+	//               PUSH1 1 PUSH1 1 SLOAD ADD PUSH1 1 SSTORE STOP  (10 bytes)
+	{
+		0x60, 0x0a, // PUSH1 10 (length)
+		0x60, 0x0c, // PUSH1 12 (offset = past constructor)
+		0x60, 0x00, // PUSH1 0  (dest in memory)
+		0x39,       // CODECOPY
+		0x60, 0x0a, // PUSH1 10 (length)
+		0x60, 0x00, // PUSH1 0
+		0xf3, // RETURN
+		// runtime code starts here:
+		0x60, 0x01, 0x60, 0x01, 0x54, 0x01, 0x60, 0x01, 0x55, 0x00,
+	},
+}
+
+// decodeScenario consumes the fuzzer's bytes and produces a sequence
+// of valid txs. Validity (nonce ordering, balance) is the decoder's
+// responsibility — failing txs are fine (both paths must reject the
+// same way) but txs that exhaust a sender's balance bias the test.
+func decodeScenario(data []byte) []fuzzTx {
+	if len(data) < 5 {
+		return nil
+	}
+	var out []fuzzTx
+	i := 0
+	for i+4 < len(data) && len(out) < fuzzMaxTxs {
+		// Layout: [kind(1) | sender(1) | aux(1) | valueLo(1) | valueHi(1)]
+		kind := fuzzTxKind(data[i] % 7)
+		senderIdx := int(data[i+1]) % numFuzzSenders
+		aux := data[i+2]
+		valueGwei := uint16(data[i+3]) | (uint16(data[i+4]) << 8)
+		// Cap value in gwei so cumulative spend per sender stays well
+		// under initialBalance.
+		valueGwei %= 4096
+
+		tx := fuzzTx{
+			kind:      kind,
+			senderIdx: senderIdx,
+			valueGwei: valueGwei,
+		}
+		switch kind {
+		case kindTransferToSender:
+			tx.recipientIdx = int(aux) % numFuzzSenders
+		case kindTransferToFresh:
+			tx.freshNonce = aux
+		case kindContractCreate:
+			tx.createKind = aux % uint8(len(fuzzCreateSnippets))
+		case kindContractCall:
+			// nothing extra; we'll resolve the target at apply time
+		case kindCallSelfDestructPair:
+			// value (0 is legal and is the mispairing shape) goes to X
+		case kind7702Auth, kindNonceOnlyAccount:
+			tx.authSel = aux
+		}
+		out = append(out, tx)
+		i += 5
+	}
+	return out
+}
+
+// scenarioState tracks per-sender and per-authority nonces plus the
+// most-recently-created contract address so kindContractCall has a target.
+type scenarioState struct {
+	nonces      [numFuzzSenders]uint64
+	authNonces  [numFuzzAuthorities]uint64
+	lastCreated common.Address
+	hasContract bool
+}
+
+// freshAddr derives a deterministic address from a single byte —
+// reused across both serial and V2 runs so they target the same
+// recipient.
+func freshAddr(seed byte) common.Address {
+	var a common.Address
+	a[19] = seed
+	a[18] = 0xa1
+	return a
+}
+
+// signedTxs builds the signed transactions from the decoded scenario,
+// using the per-sender nonce tracker. Returns parallel slices: the
+// signed txs and their pre-recovered Messages.
+func signedTxs(t testing.TB, decoded []fuzzTx, signer types.Signer, baseFee *big.Int) ([]*types.Transaction, []*Message) {
+	t.Helper()
+	st := scenarioState{}
+	txs := make([]*types.Transaction, 0, len(decoded))
+	msgs := make([]*Message, 0, len(decoded))
+
+	for _, d := range decoded {
+		if d.kind == kindNonceOnlyAccount {
+			txs, msgs = appendNonceOnlyAccountTxs(t, txs, msgs, &st, d, signer, baseFee)
+			continue
+		}
+		nonce := st.nonces[d.senderIdx]
+		st.nonces[d.senderIdx]++
+
+		var to *common.Address
+		var data []byte
+		var authList []types.SetCodeAuthorization
+		gas := uint64(21000)
+		switch d.kind {
+		case kindTransferToSender:
+			a := crypto.PubkeyToAddress(fuzzKeys[d.recipientIdx].PublicKey)
+			to = &a
+		case kindTransferToFresh:
+			a := freshAddr(d.freshNonce)
+			to = &a
+		case kindContractCreate:
+			data = fuzzCreateSnippets[d.createKind]
+			gas = fuzzGasLimit
+		case kindContractCall:
+			if !st.hasContract {
+				// No contract deployed yet — fall back to a fresh transfer.
+				a := freshAddr(d.freshNonce)
+				to = &a
+			} else {
+				a := st.lastCreated
+				to = &a
+				gas = fuzzGasLimit
+			}
+		case kindCallSelfDestructPair:
+			a := sdPairEntry
+			to = &a
+			gas = fuzzGasLimit
+		case kind7702Auth:
+			authIdx := int(d.authSel) % numFuzzAuthorities
+			target := common.Address{} // zero address clears the delegation
+			if d.authSel&0x80 != 0 {
+				target = sdPairEntry
+			}
+			auth, err := types.SignSetCode(fuzzAuthKeys[authIdx], types.SetCodeAuthorization{
+				ChainID: *uint256.MustFromBig(signer.ChainID()),
+				Address: target,
+				Nonce:   st.authNonces[authIdx],
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			st.authNonces[authIdx]++
+			authList = []types.SetCodeAuthorization{auth}
+			a := crypto.PubkeyToAddress(fuzzAuthKeys[authIdx].PublicKey)
+			to = &a
+			gas = fuzzGasLimit
+		}
+
+		// Compute value in wei from gwei; 0 is a legal value too.
+		value := new(big.Int).Mul(big.NewInt(int64(d.valueGwei)), big.NewInt(1e9))
+		var inner types.TxData
+		if d.kind == kind7702Auth {
+			// To is the authority itself, so post-application calls run its
+			// (possibly delegated) code. Value stays zero so a cleared
+			// authority remains a nonce-only account — the class
+			// ParallelStateDB.Exist must report identically to serial.
+			inner = &types.SetCodeTx{
+				ChainID:   uint256.MustFromBig(signer.ChainID()),
+				Nonce:     nonce,
+				GasTipCap: uint256.NewInt(1),
+				GasFeeCap: uint256.NewInt(1e9),
+				Gas:       gas,
+				To:        *to,
+				Value:     uint256.NewInt(0),
+				AuthList:  authList,
+			}
+		} else {
+			inner = &types.DynamicFeeTx{
+				ChainID:   signer.ChainID(),
+				Nonce:     nonce,
+				GasTipCap: big.NewInt(1),
+				GasFeeCap: big.NewInt(1e9),
+				Gas:       gas,
+				To:        to,
+				Value:     value,
+				Data:      data,
+			}
+		}
+		tx, err := types.SignTx(types.NewTx(inner), signer, fuzzKeys[d.senderIdx])
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Track the contract address that this tx WOULD create — both
+		// paths derive it the same way (CREATE = keccak(rlp(sender, nonce))).
+		if d.kind == kindContractCreate {
+			st.lastCreated = crypto.CreateAddress(crypto.PubkeyToAddress(fuzzKeys[d.senderIdx].PublicKey), nonce)
+			st.hasContract = true
+		}
+		msg, err := TransactionToMessage(tx, signer, baseFee)
+		if err != nil {
+			t.Fatal(err)
+		}
+		txs = append(txs, tx)
+		msgs = append(msgs, msg)
+	}
+	return txs, msgs
+}
+
+// appendNonceOnlyAccountTxs emits the three-tx sequence that leaves an
+// authority as a nonce-only account (nonce>0, zero balance, no code, no
+// in-block create) at the moment its authorization is validated:
+//
+//  1. a sender funds the authority with exactly drain-gas + 1 wei VIA THE
+//     SWEEPER's selfdestruct payout — a plain value CALL would create the
+//     recipient (evm.Call → CreateAccount), defeating the shape
+//  2. the authority spends its entire balance in a plain transfer — its
+//     account now exists only via the sender nonce increment
+//  3. a sender carries a SetCodeTx authorization signed by the authority;
+//     applyAuthorization gates a 12500-gas refund on Exist(authority)
+//
+// This is the EIP-7702 over-charge shape from the mainnet bad blocks the
+// Exist nonce fix closed: serial sees the account (nonce>0), a V2 that
+// derives existence from balance/create/base alone does not. Note that
+// neither a delegation clear (SetCode(nil) marks the account created) nor
+// a plain transfer (evm.Call creates the recipient) can produce this
+// account class — which is why the plain kind7702Auth scenarios can't
+// reach it and the selfdestruct-funded drain here is load-bearing.
+func appendNonceOnlyAccountTxs(t testing.TB, txs []*types.Transaction, msgs []*Message, st *scenarioState, d fuzzTx, signer types.Signer, baseFee *big.Int) ([]*types.Transaction, []*Message) {
+	t.Helper()
+	authIdx := int(d.authSel) % numFuzzAuthorities
+	authority := fuzzAuthKeys[authIdx]
+	authorityAddr := crypto.PubkeyToAddress(authority.PublicKey)
+	an := st.authNonces[authIdx]
+
+	// Drain economics: fee cap = base fee + 1 tip, gas exactly 21000,
+	// 1 wei of value onward — the upfront gas purchase plus value consumes
+	// the funded amount to the last wei and the refund is zero.
+	drainPrice := new(big.Int).Add(baseFee, big.NewInt(1))
+	fund := new(big.Int).Mul(big.NewInt(21000), drainPrice)
+	fund.Add(fund, big.NewInt(1))
+
+	build := func(inner types.TxData, key *ecdsa.PrivateKey) {
+		tx, err := types.SignTx(types.NewTx(inner), signer, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg, err := TransactionToMessage(tx, signer, baseFee)
+		if err != nil {
+			t.Fatal(err)
+		}
+		txs = append(txs, tx)
+		msgs = append(msgs, msg)
+	}
+
+	sweeper := sweeperAddr
+	build(&types.DynamicFeeTx{
+		ChainID:   signer.ChainID(),
+		Nonce:     st.nonces[d.senderIdx],
+		GasTipCap: big.NewInt(1),
+		GasFeeCap: big.NewInt(1e9),
+		Gas:       fuzzGasLimit,
+		To:        &sweeper,
+		Value:     fund,
+		Data:      authorityAddr.Bytes(),
+	}, fuzzKeys[d.senderIdx])
+	st.nonces[d.senderIdx]++
+
+	payout := freshAddr(0xee)
+	build(&types.DynamicFeeTx{
+		ChainID:   signer.ChainID(),
+		Nonce:     an,
+		GasTipCap: big.NewInt(1),
+		GasFeeCap: drainPrice,
+		Gas:       21000,
+		To:        &payout,
+		Value:     big.NewInt(1),
+	}, authority)
+
+	target := common.Address{}
+	if d.authSel&0x80 != 0 {
+		target = sdPairEntry
+	}
+	auth, err := types.SignSetCode(authority, types.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(signer.ChainID()),
+		Address: target,
+		Nonce:   an + 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	build(&types.SetCodeTx{
+		ChainID:   uint256.MustFromBig(signer.ChainID()),
+		Nonce:     st.nonces[d.senderIdx],
+		GasTipCap: uint256.NewInt(1),
+		GasFeeCap: uint256.NewInt(1e9),
+		Gas:       fuzzGasLimit,
+		To:        authorityAddr,
+		Value:     uint256.NewInt(0),
+		AuthList:  []types.SetCodeAuthorization{auth},
+	}, fuzzKeys[d.senderIdx])
+	st.nonces[d.senderIdx]++
+	st.authNonces[authIdx] = an + 2
+	return txs, msgs
+}
+
+// buildBaseStateRoot creates an in-memory pre-state with every sender
+// pre-funded and the selfdestruct pair predeployed, commits, and
+// returns (db, root) so both serial and V2 paths can re-open at the
+// same root.
+func buildBaseStateRoot(t testing.TB) (*triedb.Database, common.Hash) {
+	t.Helper()
+	memdb := rawdb.NewMemoryDatabase()
+	tdb := triedb.NewDatabase(memdb, triedb.HashDefaults)
+	sdb, err := state.New(common.Hash{}, state.NewDatabase(tdb, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range fuzzKeys {
+		addr := crypto.PubkeyToAddress(k.PublicKey)
+		sdb.AddBalance(addr, initialBalance, 0)
+	}
+	sdb.SetCode(sdPairEntry, sdPairEntryCode, 0)
+	sdb.AddBalance(sdPairEntry, uint256.NewInt(10), 0)
+	sdb.SetCode(sdPairHelper, sdPairHelperCode, 0)
+	sdb.AddBalance(sdPairHelper, uint256.NewInt(10), 0)
+	sdb.SetCode(sweeperAddr, sweeperCode, 0)
+	root, err := sdb.Commit(0, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tdb.Commit(root, false); err != nil {
+		t.Fatal(err)
+	}
+	return tdb, root
+}

--- a/core/v2_serial_parity_gen_test.go
+++ b/core/v2_serial_parity_gen_test.go
@@ -96,8 +96,8 @@ var initialBalance = new(uint256.Int).Mul(uint256.NewInt(100), uint256.NewInt(1e
 var (
 	sdPairEntry  = common.HexToAddress("0x000000000000000000000000000000000000aaaa") // X
 	sdPairHelper = common.HexToAddress("0x000000000000000000000000000000000000cccc") // Z
-	sdPairPayout = common.HexToAddress("0x000000000000000000000000000000000000bbbb") // Y (EOA)
 
+	// Payout EOA Y (low bytes bbbb) lives only inside sdPairEntryCode below; no Go binding.
 	// if (msg.sender == Z) { selfdestruct(payable(Y)); }
 	// else { Z.call{value: 0}(""); payable(Y).transfer(10); }
 	sdPairEntryCode = common.FromHex("3373000000000000000000000000000000000000cccc146056575f5f5f5f5f73000000000000000000000000000000000000cccc5af1505f5f5f5f600a73000000000000000000000000000000000000bbbb5af150005b73000000000000000000000000000000000000bbbbff")


### PR DESCRIPTION
## Summary

Three independent BlockSTM v2 (parallel EVM) vs serial-execution divergences, each
capable of producing a bad block, fixed at the `core/state` layer. All three surfaced
around EIP-7702 / Prague execution and the parallel path's read/settlement handling.
Serial `StateDB` and `core/vm` are untouched, so non-parallel nodes are unaffected.

1. **CodePath read snapshot-consistency** (`0b53ad4`) — the EVM resolves a 7702-delegated
   account's code and code hash via two separate `GetCode(addr)` calls (`resolveCode` +
   `resolveCodeHash`). `ParallelStateDB` re-read the MVStore on each call, so a concurrent
   writer landing between them could redirect the two reads to different delegation
   targets, building a `Contract` whose `Code` and `CodeHash` disagree and poisoning the
   shared cross-block jumpdest cache. Observed on mainnet as `index out of range` panics
   in `validJumpdest` and `invalid gas used` bad blocks (a poisoned entry sent a sub-call
   off the rails, ~63/64 of tx gas burned via Multicall3 `aggregate3`). Fix: per-tx
   CodePath read cache mirroring `balCache` / `committedCache` / `destructedCache`; the
   cached read is still recorded for validation, so genuine staleness re-executes. Same
   root cause as #2264, addressed at the state layer instead of the EVM resolution path.

2. **`Exist` ignores prior-tx nonce bumps** (`f42d299`) — serial `StateDB.Exist` is
   `getStateObject() != nil`, and a nonce>0 account is not empty, so it exists.
   `ParallelStateDB.SetNonce` writes `NoncePath` but not `CreatePath`, and `Exist` never
   consulted the nonce — so an account made to exist purely by a prior in-block nonce bump
   (sender increment, or a 7702 delegation clear) was reported absent. That flipped
   `applyAuthorization`'s `Exist`-gated 12500-gas existing-account refund and the
   new-account CALL surcharge, over-charging gas relative to serial. Fix: return true when
   `GetNonce(addr) > 0` in both fall-through branches; `GetNonce` records the read so
   validation catches drift, and the check cannot over-report.

3. **Settlement transfer-log mispairing** (`530781b`) — `tryEmitTransferAt` matched
   recorded transfers against balance ops by *shape* (Sub from sender + Add to recipient,
   equal amount), so a look-alike pair from an EIP-6780 selfdestruct payout with the same
   sender / recipient / amount as a later recorded transfer stole that transfer's log
   emission point. The `LogTransfer` then carried pre/post balances from the wrong replay
   position — state roots still matched, only the receipts root diverged. Fix: match on
   `TransferRecord.BalanceOpsIdx` (the transfer's ops live at exactly
   `[BalanceOpsIdx, BalanceOpsIdx+1]`, and `RevertToSnapshot` truncates `BalanceOps` /
   `Transfers` in lockstep so surviving indices never shift). Fixes the divergence
   reported in #2268.

## Executed tests

Test coverage added/extended alongside the fixes (all under `core` / `core/state`, fast
and EVM-free or fuzz-based — no devnet required):

- `core/v2_blockstm_test.go` — cherry-picked repro from #2268 (alrevuelta); red before the
  transfer-log fix, green after.
- `core/v2_serial_parity_fuzz_test.go` + `core/v2_serial_parity_gen_test.go` — the
  serial-vs-V2 differential now runs the production serial path (`ApplyTransactionWithEVM`)
  and compares full consensus output (per-tx status, cumulative gas, bloom, logs, receipts
  root) alongside the state root, not just the post-block state root. Generator vocabulary
  extended to reach the divergence surfaces: `MergedTestChainConfig` (Prague / 7702 live),
  predeployed EIP-6780 selfdestruct pair, 7702-authorization and nonce-only-account tx
  kinds; seed corpus covers worker counts 1 / 4 / 8.
- `core/state/parallel_read_equivalence_test.go` — every read API (`Exist` / `Empty` /
  `GetNonce` / `GetBalance` / `GetCode` / `GetCodeHash` / `GetCodeSize` / `GetState`) must
  agree between `StateDB` and `ParallelStateDB` across prior-tx mutation shapes.
- `core/state/parallel_read_invariants_test.go` — the two structural invariants every
  intra-tx read must satisfy (snapshot-stable within an incarnation, or validation-visible).
- `core/v2_7702_coderead_test.go`, `core/v2_exist_nonce_test.go` — targeted regression
  tests for fixes 1 and 2.

Per the commit notes, reverting any of the three fixes turns the matching test red. CI
verification (`go test ./core/...` + fuzz seeds green) is still pending — confirm before
marking ready, and consider a Kurtosis e2e / parallel-EVM devnet soak given the consensus
surface.

## Rollout notes

- **Consensus-affecting.** Aligns the parallel EVM (BlockSTM v2) execution path's state +
  receipt output with serial execution; relevant only on nodes running parallel execution.
  No hardfork, no activation height, no genesis change — purely a correctness fix to an
  existing code path.
- Backwards-compatible: serial `StateDB` and `core/vm` are untouched, so non-parallel
  nodes are unaffected and already-produced blocks are unchanged.
- Given the mainnet bad-block history, recommend the standard release soak ladder
  (devnet → internal testnet → external testnet → internal mainnet) before broad rollout,
  with parallel execution explicitly enabled on the soak nodes.

Related PRs: #2264 (CodePath root cause, EVM-path approach), #2268 (transfer-log repro, by
alrevuelta).
