### PR TITLE
Fix nightly race test flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
 
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
-        run: sudo apt update && sudo apt install build-essential
+        run: |
+          sudo find /etc/apt/sources.list.d -maxdepth 1 -type f \( -name 'azure-cli*' -o -name 'microsoft-prod*' \) -delete
+          sudo apt-get update
+          sudo apt-get install -y build-essential
 
       - uses: actions/cache@v4
         with:
@@ -68,7 +71,10 @@ jobs:
 
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
-        run: sudo apt update && sudo apt install build-essential
+        run: |
+          sudo find /etc/apt/sources.list.d -maxdepth 1 -type f \( -name 'azure-cli*' -o -name 'microsoft-prod*' \) -delete
+          sudo apt-get update
+          sudo apt-get install -y build-essential
 
       - name: Golang-ci install
         if: runner.os == 'Linux'
@@ -96,7 +102,10 @@ jobs:
 
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
-        run: sudo apt update && sudo apt install build-essential
+        run: |
+          sudo find /etc/apt/sources.list.d -maxdepth 1 -type f \( -name 'azure-cli*' -o -name 'microsoft-prod*' \) -delete
+          sudo apt-get update
+          sudo apt-get install -y build-essential
 
       - uses: actions/cache@v4
         with:
@@ -133,7 +142,10 @@ jobs:
 
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
-        run: sudo apt update && sudo apt install build-essential
+        run: |
+          sudo find /etc/apt/sources.list.d -maxdepth 1 -type f \( -name 'azure-cli*' -o -name 'microsoft-prod*' \) -delete
+          sudo apt-get update
+          sudo apt-get install -y build-essential
 
       - uses: actions/cache@v4
         with:

--- a/core/txpool/legacypool/legacypool2_test.go
+++ b/core/txpool/legacypool/legacypool2_test.go
@@ -52,23 +52,26 @@ func count(t *testing.T, pool *LegacyPool) (pending int, queued int) {
 
 func fillPool(t testing.TB, pool *LegacyPool) {
 	t.Helper()
-	// Create a number of test accounts, fund them and make transactions
+	// Create enough executable transactions to exactly fill the configured pool
+	// capacity. Each account stays within AccountSlots so pending truncation
+	// does not need to penalize oversized accounts during setup.
 	executableTxs := types.Transactions{}
-	nonExecutableTxs := types.Transactions{}
-	for i := 0; i < 384; i++ {
+	target := int(pool.config.GlobalSlots + pool.config.GlobalQueue)
+	for i := 0; len(executableTxs) < target; i++ {
 		key, _ := crypto.GenerateKey()
 		pool.currentState.AddBalance(crypto.PubkeyToAddress(key.PublicKey), uint256.NewInt(10000000000), tracing.BalanceChangeUnspecified)
-		// Add executable ones
-		for j := 0; j < int(pool.config.AccountSlots); j++ {
+		for j := 0; j < int(pool.config.AccountSlots) && len(executableTxs) < target; j++ {
 			executableTxs = append(executableTxs, pricedTransaction(uint64(j), 100000, big.NewInt(300), key))
 		}
 	}
-	// Import the batch and verify that limits have been enforced
+	// Import the batch and verify the pool is full and executable.
 	pool.addRemotesSync(executableTxs)
-	pool.addRemotesSync(nonExecutableTxs)
 	pending, queued := pool.Stats()
 	slots := pool.all.Slots()
 	// sanity-check that the test prerequisites are ok (pending full)
+	if have, want := slots, target; have != want {
+		t.Fatalf("have %d, want %d", have, want)
+	}
 	if have, want := pending, slots; have != want {
 		t.Fatalf("have %d, want %d", have, want)
 	}

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -554,7 +554,6 @@ func closePeers(peers []*ethPeer) {
 // TestSealToBroadcastTimer verifies that the sealToBroadcastTimer metric is
 // updated when minedBroadcastLoop processes a NewMinedBlockEvent with SealedAt set.
 func TestSealToBroadcastTimer(t *testing.T) {
-	t.Parallel()
 	metrics.Enable()
 
 	handler := newTestHandlerWithBlocks(1)
@@ -574,11 +573,12 @@ func TestSealToBroadcastTimer(t *testing.T) {
 		SealedAt: time.Now(),
 	})
 
-	// Give the broadcast loop time to process
-	time.Sleep(200 * time.Millisecond)
-
-	if sealToBroadcastTimer.Snapshot().Count() <= countBefore {
-		t.Error("sealToBroadcastTimer should have been updated after NewMinedBlockEvent with SealedAt")
+	deadline := time.Now().Add(2 * time.Second)
+	for sealToBroadcastTimer.Snapshot().Count() <= countBefore {
+		if time.Now().After(deadline) {
+			t.Fatal("sealToBroadcastTimer should have been updated after NewMinedBlockEvent with SealedAt")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	// Test that zero SealedAt does NOT update the timer

--- a/eth/relay/service_test.go
+++ b/eth/relay/service_test.go
@@ -14,6 +14,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func waitCachedTask(t *testing.T, service *Service, hash common.Hash) TxTask {
+	t.Helper()
+
+	return waitCachedTaskWhere(t, service, hash, func(TxTask) bool { return true }, "expected task to be stored after processing")
+}
+
+func waitCachedTaskWhere(t *testing.T, service *Service, hash common.Hash, check func(TxTask) bool, msg string) TxTask {
+	t.Helper()
+
+	var task TxTask
+	require.Eventually(t, func() bool {
+		service.storeMu.RLock()
+		defer service.storeMu.RUnlock()
+
+		var exists bool
+		task, exists = service.store[hash]
+		return exists && check(task)
+	}, 2*time.Second, 10*time.Millisecond, msg)
+
+	return task
+}
+
 func TestNewService(t *testing.T) {
 	t.Parallel()
 
@@ -943,14 +965,8 @@ func TestTaskCacheOverride(t *testing.T) {
 		err := service.SubmitTransactionForPreconf(tx)
 		require.NoError(t, err, "expected no error queuing task")
 
-		// Give some time to process
-		time.Sleep(100 * time.Millisecond)
-
 		// Ensure task was stored correctly
-		service.storeMu.RLock()
-		task, exists := service.store[tx.Hash()]
-		service.storeMu.RUnlock()
-		require.True(t, exists, "expected task to be stored after processing")
+		task := waitCachedTask(t, service, tx.Hash())
 		require.True(t, task.preconfirmed, "expected task to be preconfirmed")
 		require.NoError(t, task.err, "expected no error in task")
 
@@ -966,10 +982,7 @@ func TestTaskCacheOverride(t *testing.T) {
 		service.updateTaskInCache(invalidTask)
 
 		// Verify that the original preconfirmed task remains unchanged
-		service.storeMu.RLock()
-		task, exists = service.store[tx.Hash()]
-		service.storeMu.RUnlock()
-		require.True(t, exists, "expected task to still exist in cache")
+		task = waitCachedTask(t, service, tx.Hash())
 		require.True(t, task.preconfirmed, "expected preconfirmed status to remain true")
 		require.NoError(t, task.err, "expected error to remain nil")
 	})
@@ -985,14 +998,8 @@ func TestTaskCacheOverride(t *testing.T) {
 		err := service.SubmitTransactionForPreconf(tx)
 		require.NoError(t, err, "expected no error queuing task")
 
-		// Give some time to process
-		time.Sleep(100 * time.Millisecond)
-
 		// Ensure task was stored correctly
-		service.storeMu.RLock()
-		task, exists := service.store[tx.Hash()]
-		service.storeMu.RUnlock()
-		require.True(t, exists, "expected task to be stored after processing")
+		task := waitCachedTask(t, service, tx.Hash())
 		require.False(t, task.preconfirmed, "expected task to not be preconfirmed")
 		require.ErrorIs(t, task.err, errPreconfValidationFailed, "expected errPreconfValidationFailed in task")
 
@@ -1002,10 +1009,7 @@ func TestTaskCacheOverride(t *testing.T) {
 		require.NoError(t, err, "expected no error from CheckTxPreconfStatus")
 
 		// Ensure the underlying task was updated to preconfirmed
-		service.storeMu.RLock()
-		task, exists = service.store[tx.Hash()]
-		service.storeMu.RUnlock()
-		require.True(t, exists, "expected task to still exist in cache")
+		task = waitCachedTask(t, service, tx.Hash())
 		require.True(t, task.preconfirmed, "expected preconfirmed status to be updated to true")
 		require.NoError(t, task.err, "expected error to be updated to nil")
 
@@ -1018,10 +1022,7 @@ func TestTaskCacheOverride(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Verify that the preconfirmed task remains unchanged
-		service.storeMu.RLock()
-		task, exists = service.store[tx.Hash()]
-		service.storeMu.RUnlock()
-		require.True(t, exists, "expected task to still exist in cache")
+		task = waitCachedTask(t, service, tx.Hash())
 		require.True(t, task.preconfirmed, "expected preconfirmed status to remain true")
 		require.NoError(t, task.err, "expected error to remain nil")
 
@@ -1041,10 +1042,7 @@ func TestTaskCacheOverride(t *testing.T) {
 		require.NoError(t, err, "expected no error from CheckTxPreconfStatus")
 
 		// Ensure task was stored correctly in cache
-		service.storeMu.RLock()
-		task, exists := service.store[tx.Hash()]
-		service.storeMu.RUnlock()
-		require.True(t, exists, "expected task to be stored after processing")
+		task := waitCachedTask(t, service, tx.Hash())
 		require.True(t, task.preconfirmed, "expected task to be preconfirmed")
 		require.NoError(t, task.err, "expected no error in task")
 
@@ -1060,10 +1058,7 @@ func TestTaskCacheOverride(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Verify that the original preconfirmed task remains unchanged
-		service.storeMu.RLock()
-		task, exists = service.store[tx.Hash()]
-		service.storeMu.RUnlock()
-		require.True(t, exists, "expected task to still exist in cache")
+		task = waitCachedTask(t, service, tx.Hash())
 		require.True(t, task.preconfirmed, "expected preconfirmed status to remain true")
 		require.NoError(t, task.err, "expected error to remain nil")
 
@@ -1090,10 +1085,7 @@ func TestTaskCacheOverride(t *testing.T) {
 		require.Error(t, err, "expected an error from CheckTxPreconfStatus")
 
 		// Ensure task was stored correctly in cache
-		service.storeMu.RLock()
-		task, exists := service.store[tx.Hash()]
-		service.storeMu.RUnlock()
-		require.True(t, exists, "expected task to be stored after processing")
+		task := waitCachedTask(t, service, tx.Hash())
 		require.False(t, task.preconfirmed, "expected preconfirmed to be false")
 		require.Error(t, task.err, "expected an error in task")
 
@@ -1106,10 +1098,9 @@ func TestTaskCacheOverride(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Verify that the underlying task is now updated
-		service.storeMu.RLock()
-		task, exists = service.store[tx.Hash()]
-		service.storeMu.RUnlock()
-		require.True(t, exists, "expected task to still exist in cache")
+		task = waitCachedTaskWhere(t, service, tx.Hash(), func(task TxTask) bool {
+			return task.preconfirmed && task.err == nil
+		}, "expected task to be updated after processing")
 		require.True(t, task.preconfirmed, "expected preconfirmed status to be true")
 		require.NoError(t, task.err, "expected no error for the task")
 

--- a/eth/tracers/dir.go
+++ b/eth/tracers/dir.go
@@ -19,6 +19,7 @@ package tracers
 import (
 	"encoding/json"
 	"math/big"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -64,6 +65,7 @@ var DefaultDirectory = directory{elems: make(map[string]elem)}
 // and a function to instantiate it. It falls back to a JS code evaluator
 // if no tracer of the given name exists.
 type directory struct {
+	mu     sync.RWMutex
 	elems  map[string]elem
 	jsEval jsCtorFn
 }
@@ -71,12 +73,18 @@ type directory struct {
 // Register registers a method as a lookup for tracers, meaning that
 // users can invoke a named tracer through that lookup.
 func (d *directory) Register(name string, f ctorFn, isJS bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	d.elems[name] = elem{ctor: f, isJS: isJS}
 }
 
 // RegisterJSEval registers a tracer that is able to parse
 // dynamic user-provided JS code.
 func (d *directory) RegisterJSEval(f jsCtorFn) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	d.jsEval = f
 }
 
@@ -87,18 +95,27 @@ func (d *directory) New(name string, ctx *Context, cfg json.RawMessage, chainCon
 	if len(cfg) == 0 {
 		cfg = json.RawMessage("{}")
 	}
-	if elem, ok := d.elems[name]; ok {
+	d.mu.RLock()
+	elem, ok := d.elems[name]
+	jsEval := d.jsEval
+	d.mu.RUnlock()
+
+	if ok {
 		return elem.ctor(ctx, cfg, chainConfig)
 	}
 	// Assume JS code
-	return d.jsEval(name, ctx, cfg, chainConfig)
+	return jsEval(name, ctx, cfg, chainConfig)
 }
 
 // IsJS will return true if the given tracer will evaluate
 // JS code. Because code evaluation has high overhead, this
 // info will be used in determining fast and slow code paths.
 func (d *directory) IsJS(name string) bool {
-	if elem, ok := d.elems[name]; ok {
+	d.mu.RLock()
+	elem, ok := d.elems[name]
+	d.mu.RUnlock()
+
+	if ok {
 		return elem.isJS
 	}
 	// JS eval will execute JS code

--- a/eth/tracers/dir_test.go
+++ b/eth/tracers/dir_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package tracers
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func TestDirectoryConcurrentRegisterAndLookup(t *testing.T) {
+	t.Parallel()
+
+	d := &directory{elems: make(map[string]elem)}
+	d.RegisterJSEval(func(string, *Context, json.RawMessage, *params.ChainConfig) (*Tracer, error) {
+		return &Tracer{}, nil
+	})
+	ctor := func(*Context, json.RawMessage, *params.ChainConfig) (*Tracer, error) {
+		return &Tracer{}, nil
+	}
+	d.Register("tracer-0", ctor, false)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			d.Register(fmt.Sprintf("tracer-%d", i), ctor, i%2 == 0)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			name := fmt.Sprintf("tracer-%d", i%8)
+			if _, err := d.New(name, &Context{}, nil, params.TestChainConfig); err != nil {
+				t.Errorf("New(%q) returned error: %v", name, err)
+			}
+			_ = d.IsJS(name)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestLiveDirectoryConcurrentRegisterAndLookup(t *testing.T) {
+	t.Parallel()
+
+	d := &liveDirectory{elems: make(map[string]ctorFunc)}
+	ctor := func(json.RawMessage) (*tracing.Hooks, error) {
+		return &tracing.Hooks{}, nil
+	}
+	d.Register("live-0", ctor)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			d.Register(fmt.Sprintf("live-%d", i), ctor)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = d.New(fmt.Sprintf("live-%d", i%8), nil)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/eth/tracers/live.go
+++ b/eth/tracers/live.go
@@ -19,6 +19,7 @@ package tracers
 import (
 	"encoding/json"
 	"errors"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/core/tracing"
 )
@@ -30,11 +31,15 @@ type ctorFunc func(config json.RawMessage) (*tracing.Hooks, error)
 var LiveDirectory = liveDirectory{elems: make(map[string]ctorFunc)}
 
 type liveDirectory struct {
+	mu    sync.RWMutex
 	elems map[string]ctorFunc
 }
 
 // Register registers a tracer constructor by name.
 func (d *liveDirectory) Register(name string, f ctorFunc) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	d.elems[name] = f
 }
 
@@ -43,7 +48,11 @@ func (d *liveDirectory) New(name string, config json.RawMessage) (*tracing.Hooks
 	if len(config) == 0 {
 		config = json.RawMessage("{}")
 	}
-	if f, ok := d.elems[name]; ok {
+	d.mu.RLock()
+	f, ok := d.elems[name]
+	d.mu.RUnlock()
+
+	if ok {
 		return f(config)
 	}
 	return nil, errors.New("not found")

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -404,7 +404,8 @@ type worker struct {
 	resubmitIntervalCh chan time.Duration
 	resubmitAdjustCh   chan *intervalAdjust
 
-	wg sync.WaitGroup
+	wg         sync.WaitGroup
+	prefetchWg sync.WaitGroup
 
 	currentMu sync.RWMutex // The lock used to protect the current environment
 	current   *environment // An environment for current running cycle.
@@ -699,6 +700,7 @@ func (w *worker) close() {
 	w.running.Store(false)
 	close(w.exitCh)
 	w.wg.Wait()
+	w.prefetchWg.Wait()
 }
 
 // recalcRecommit recalculates the resubmitting interval upon feedback.
@@ -2265,7 +2267,9 @@ func (w *worker) commitWork(interrupt *atomic.Int32, noempty bool, timestamp int
 		// when prefetch is disabled.
 		genParams.builderStarted = new(atomic.Bool)
 		genParams.builderPrefetchedTxHashes = &sync.Map{}
+		w.prefetchWg.Add(1)
 		go func() {
+			defer w.prefetchWg.Done()
 			defer func() {
 				if r := recover(); r != nil {
 					log.Error("Prefetch goroutine panicked", "err", r, "stack", string(debug.Stack()))

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -909,13 +909,21 @@ func testCommitInterruptExperimentBor(t *testing.T, delay uint, txCount int) {
 	// Start mining!
 	w.start()
 
-	// Wait for at least one block to be mined with a proper timeout
+	// Wait for the first non-empty block. Bor can pre-seal an empty block
+	// before the full block, and the test is about the interrupted full-block
+	// path rather than the empty pre-seal event.
 	var minedBlock *types.Block
-	select {
-	case ev := <-sub.Chan():
-		minedBlock = ev.Data.(core.NewMinedBlockEvent).Block
-	case <-time.After(8 * time.Second):
-		t.Fatal("timeout waiting for block to be mined")
+	timeout := time.After(8 * time.Second)
+	for minedBlock == nil {
+		select {
+		case ev := <-sub.Chan():
+			block := ev.Data.(core.NewMinedBlockEvent).Block
+			if block != nil && block.NumberU64() > 0 && block.Transactions().Len() > 0 {
+				minedBlock = block
+			}
+		case <-timeout:
+			t.Fatal("timeout waiting for non-empty block to be mined")
+		}
 	}
 
 	w.stop()
@@ -2397,7 +2405,12 @@ func TestPrefetchGoroutineLifecycle(t *testing.T) {
 	config.Recommit = 500 * time.Millisecond
 
 	w, b, cleanup := newTestWorker(t, config, chainConfig, engine, db, false, 0)
-	defer cleanup()
+	closed := false
+	defer func() {
+		if !closed {
+			cleanup()
+		}
+	}()
 
 	// Add transactions to keep prefetch busy
 	addTransactionBatch(b, 50, false)
@@ -2424,10 +2437,10 @@ func TestPrefetchGoroutineLifecycle(t *testing.T) {
 		time.Sleep(150 * time.Millisecond)
 	}
 
-	// Stop the worker and wait for cleanup
-	// Increased wait time to allow prefetch goroutines to complete IntermediateRoot
-	w.stop()
-	time.Sleep(3 * time.Second)
+	// Close the worker so its loops cannot enqueue more prefetchers while
+	// prefetch cleanup is being measured.
+	cleanup()
+	closed = true
 
 	// Force garbage collection to surface any use-after-free issues
 	// Extra wait to ensure all goroutines complete after GC
@@ -2640,13 +2653,18 @@ func TestRapidBlockProduction_WithoutWait(t *testing.T) {
 	w, b, engine, ctrl := setupBorWorkerWithPrefetch(t, 100, 200*time.Millisecond)
 	defer engine.Close()
 	defer ctrl.Finish()
+	closed := false
+	defer func() {
+		if !closed {
+			w.close()
+		}
+	}()
 
 	// Add many transactions
 	addTransactionBatch(b, 500, false)
 	time.Sleep(200 * time.Millisecond)
 
 	w.start()
-	defer w.stop()
 
 	goroutinesBefore := runtime.NumGoroutine()
 	t.Logf("Goroutines before test: %d", goroutinesBefore)
@@ -2673,7 +2691,8 @@ func TestRapidBlockProduction_WithoutWait(t *testing.T) {
 
 	wg.Wait()
 	t.Log("All block production requests sent, waiting for prefetch to complete...")
-	time.Sleep(5 * time.Second) // Let all prefetch complete
+	w.close()
+	closed = true
 
 	// Check for panics
 	panicCount := prefetchPanicMeter.Snapshot().Count()


### PR DESCRIPTION
## Summary

Fixes the concrete root causes found while investigating recent `Nightly Race Tests` failures on `develop`, plus the PR-specific CI failures observed after opening this draft.

Root-cause groups from the failed nightly runs:

- `27805712576` / job `82285008094`: real race in `eth/tracers`, where `DefaultDirectory.Register` mutated the tracer map while parallel trace tests called `DefaultDirectory.New` / `IsJS`.
- `27250826718`, `27594565164`, `27666087570`: miner prefetch lifecycle tests observed leaked goroutines because prefetchers were launched outside worker-owned lifecycle tracking, and tests relied on sleeps plus process-wide goroutine counts.
- `27250826718`: `TestCommitInterruptExperimentBor_NormalFlow` sometimes asserted against the intentionally empty pre-seal block instead of the later non-empty full block.
- `27524376676`: `TestTaskCacheOverride` used fixed sleeps after queuing async relay work, which is not reliable under `-race`.
- `27736998920` attempt 1: `TestSealToBroadcastTimer` read a global metric while running in parallel with other `eth` tests.
- `27805712576` / `TestTransactionFutureAttack`: investigated from logs and reran locally with the exact CI shuffle seed; no reproducer found and no production-code change made for this one. The existing code already rejects future transactions that would replace pending transactions.

PR-specific CI findings:

- `unit-tests (ubuntu-22.04)` job `82305542524`: `TestLockOrdering_RemovedNoDeadlock` failed during `fillPool` setup with `have 199, want 200`. The helper was hard-coded around the default 6144-slot pool but the new lock-ordering tests use a 200-slot pool, so setup massively overfilled the pool and could settle with one tx queued instead of pending.
- `integration-tests (ubuntu-22.04)` job `82305542510`: no integration test ran. The job failed during `sudo apt update && sudo apt install build-essential` because GitHub's hosted-runner Microsoft apt feeds (`packages.microsoft.com`) returned 403.

## Fix

- Add `sync.RWMutex` protection to tracer registries (`DefaultDirectory` and `LiveDirectory`) and add concurrent register/lookup regression tests.
- Track miner prefetch goroutines with `worker.prefetchWg` and wait for them during `worker.close()`.
- Update miner lifecycle tests to close the worker before checking goroutine postconditions.
- Update the commit-interrupt test to wait for the first non-empty mined block.
- Replace relay cache fixed sleeps with condition-based waits.
- Make `TestSealToBroadcastTimer` serial and poll for the positive metric update.
- Make `fillPool` fill exactly the configured pool capacity, preserving its "all stored txs are pending" precondition for small test pools.
- Harden CI Linux dependency installation by removing unused Azure CLI / Microsoft apt source files before installing `build-essential` from Ubuntu repositories.

## Validation

- `GOCACHE=/private/tmp/bor-gocache go test -race ./eth/tracers -run 'TestDirectoryConcurrentRegisterAndLookup|TestLiveDirectoryConcurrentRegisterAndLookup|TestStateHooks|TestTraceBlockByHash_WithStateSyncTx|TestTraceBlockByNumber_WithStateSyncTx|TestTraceBlockByNumber_StateSync_AllRegisteredTracers|TestStandardTraceBlockToFile_WithStateSyncTx|TestTraceChain' -shuffle=1781846753213106098 -count=1`
- `GOCACHE=/private/tmp/bor-gocache go test -race ./eth/relay -run TestTaskCacheOverride -shuffle=1781501173328289028 -count=20`
- `GOCACHE=/private/tmp/bor-gocache go test -race ./eth -run TestSealToBroadcastTimer -count=20`
- `GOCACHE=/private/tmp/bor-gocache go test -race ./miner -run 'TestPrefetchGoroutineLifecycle|TestRapidBlockProduction_WithoutWait|TestCommitInterruptExperimentBor_NormalFlow' -shuffle=1781065241612800871 -count=1`
- `GOCACHE=/private/tmp/bor-gocache go test -race ./core/txpool/legacypool -run TestTransactionFutureAttack -count=20 -shuffle=on`
- `GOCACHE=/private/tmp/bor-gocache go test -race ./core/txpool/legacypool -shuffle=1781845291804863595 -count=1`
- `GOCACHE=/private/tmp/bor-gocache go test ./core/txpool/legacypool -run 'TestLockOrdering_RemovedNoDeadlock|TestLockOrdering_ReplacePendingNoDeadlock|TestLockOrdering_PricedHeapNoDeadlock|TestTransactionFutureAttack|TestTransactionFuture1559|TestTransactionZAttack' -count=50 -shuffle=on`
- `GOCACHE=/private/tmp/bor-gocache go test ./core/txpool/legacypool -count=1`
- `GOCACHE=/private/tmp/bor-gocache go test -race ./core/txpool/legacypool -run 'TestLockOrdering_RemovedNoDeadlock|TestLockOrdering_ReplacePendingNoDeadlock|TestLockOrdering_PricedHeapNoDeadlock|TestTransactionFutureAttack|TestTransactionFuture1559|TestTransactionZAttack' -count=1 -shuffle=on`
- `GOCACHE=/private/tmp/bor-gocache go test -run '^$' -tags integration ./tests/...`
- `git diff --check`

## Risks / Follow-up

- I did not change `TestTransactionFutureAttack` because the logged 198/200 count drop did not reproduce in either isolated or full-package local race runs. If it recurs, the next step is to capture verbose txpool logs around `priced.Discard` and the future-tx `ErrFutureReplacePending` path.
- The integration-test fix must be confirmed by the GitHub Actions rerun because the failure was in hosted-runner apt sources before `make test-integration` started.
