### PR TITLE
Fix new tx flow race test

### DIFF
--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -1034,14 +1034,10 @@ func TestCommitInterruptExperimentBor_NewTxFlow(t *testing.T) {
 
 	// Ensure that the last block was 3 and only 2/3 transactions are mined because
 	// of the 500ms timeout and 1s block time.
-	// Access w.current safely using getCurrent()
-	current := w.getCurrent()
-	if current == nil || current.header == nil {
-		t.Fatal("worker current state is not initialized")
-	}
-	assert.Equal(t, current.header.Number.Uint64(), uint64(3))
-	assert.Equal(t, current.tcount, 2)
-	assert.Equal(t, len(current.txs), 2)
+	require.Eventually(t, func() bool {
+		block := w.pendingBlock()
+		return block != nil && block.NumberU64() == 3 && block.Transactions().Len() == 2
+	}, 2*time.Second, 10*time.Millisecond, "expected pending block 3 with 2 transactions")
 }
 
 // nolint:paralleltest


### PR DESCRIPTION
## Summary

Fixes the remaining post-merge nightly race failure reported in `#code-releases`.

Failed run investigated:

- `Nightly Race Tests` run `27860313646`, job `82455109644`, on `develop` commit `8d00b811` (`Fix nightly race test flakes (#2278)`), started `2026-06-20T04:34:17Z`.

Root cause:

- `TestCommitInterruptExperimentBor_NewTxFlow` read `w.current.tcount` and `w.current.txs` while the worker `mainLoop` was still executing `commitTransaction`.
- The race detector reported reads at `miner/worker_test.go:1043-1044` racing with writes at `miner/worker.go:1333-1335`.
- This is test fragility, not a production data race: the test was inspecting the live mutable build environment directly.

## Fix

- Assert through the worker's pending block snapshot (`w.pendingBlock()`), which is published under `snapshotMu`, instead of reading the mutable `w.current` environment.
- Keep the original test intent: block 3 should contain exactly 2 transactions after the induced 500ms per-tx delay and 1s block window.

## Validation

- `GOCACHE=/private/tmp/bor-gocache go test -race ./miner -run TestCommitInterruptExperimentBor_NewTxFlow -shuffle=1781933163806473281 -count=10`
- `GOCACHE=/private/tmp/bor-gocache go test -race ./miner -run 'TestCommitInterruptExperimentBor_NormalFlow|TestCommitInterruptExperimentBor_NewTxFlow|TestCommitInterruptPending' -shuffle=1781933163806473281 -count=1`
- `GOCACHE=/private/tmp/bor-gocache go test -race ./miner -shuffle=1781933163806473281 -count=1`
- `git diff --check`

## Notes

- The next scheduled nightly race run after the failure, `27893673850` on `2026-06-21T04:37:25Z`, passed. This PR still removes the concrete race-detector finding from the failed June 20 run.
