### PR TITLE
core, eth, miner: port JumpDest cache improvements from geth

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -4511,7 +4511,7 @@ func (bc *BlockChain) verifyPendingHeaders() {
 func (bc *BlockChain) StateSizer() *state.SizeTracker {
 	return bc.stateSizer
 }
-
+// JumpDestCache returns the chain-global shared JUMPDEST analysis cache.
 func (bc *BlockChain) JumpDestCache() vm.JumpDestCache {
 	return bc.jumpDestCache
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -787,8 +787,10 @@ func reportReaderStats(prefetch, process, parallel state.ReaderWithStats) {
 	accountHitFromPrefetchUniqueMeter.Mark(procPF.AccountHitFromPrefetchUnique + parPF.AccountHitFromPrefetchUnique)
 }
 
-// sharedBlockCaches holds VM-level caches that are shared between the
-// prefetcher goroutine and the V2 BlockSTM workers for a single block.
+// sharedBlockCaches bundles the VM-level caches passed to the prefetcher
+// goroutine and the V2 BlockSTM workers. jumpDests is the chain-global,
+// cross-block cache (owned by BlockChain); keccak and ecrecover are
+// per-block, allocated fresh for each block.
 type sharedBlockCaches struct {
 	jumpDests vm.JumpDestCache
 	keccak    *sync.Map

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -372,6 +372,7 @@ type BlockChain struct {
 	triedb        *triedb.Database                 // The database handler for maintaining trie nodes.
 	statedb       *state.CachingDB                 // State database to reuse between imports (contains state cache)
 	txIndexer     *txIndexer                       // Transaction indexer, might be nil if not enabled
+	jumpDestCache vm.JumpDestCache                 // Shared JUMPDEST analysis cache for block processing
 
 	hc               *HeaderChain
 	rmLogsFeed       event.Feed
@@ -471,6 +472,7 @@ func NewBlockChain(db ethdb.Database, genesis *Genesis, engine consensus.Engine,
 		cfg:                 cfg,
 		db:                  db,
 		triedb:              triedb,
+		jumpDestCache:       NewJumpDestCache(),
 		triegc:              prque.New[int64, common.Hash](nil),
 		quit:                make(chan struct{}),
 		chainmu:             syncx.NewClosableMutex(),
@@ -793,9 +795,9 @@ type sharedBlockCaches struct {
 	ecrecover *sync.Map
 }
 
-func newSharedBlockCaches() *sharedBlockCaches {
+func newSharedBlockCaches(jumpDests vm.JumpDestCache) *sharedBlockCaches {
 	return &sharedBlockCaches{
-		jumpDests: vm.NewSyncJumpDestCache(),
+		jumpDests: jumpDests,
 		keccak:    &sync.Map{},
 		ecrecover: &sync.Map{},
 	}
@@ -817,7 +819,7 @@ func (bc *BlockChain) startPrefetchGoroutine(block *types.Block, throwaway *stat
 		vmCfg := bc.cfg.VmConfig
 		vmCfg.Tracer = nil
 		caches.applyTo(&vmCfg)
-		bc.prefetcher.Prefetch(block, throwaway, vmCfg, false, followupInterrupt)
+		bc.prefetcher.Prefetch(block, throwaway, bc.jumpDestCache, vmCfg, false, followupInterrupt)
 		blockPrefetchExecuteTimer.Update(time.Since(start))
 		if followupInterrupt.Load() {
 			blockPrefetchInterruptMeter.Mark(1)
@@ -845,7 +847,7 @@ func (bc *BlockChain) ProcessBlock(block *types.Block, parent *types.Header, wit
 	defer reportReaderStats(prefetch, process, parallel)
 
 	// Shared caches for this block — used by both prefetcher and V2 workers.
-	sharedCaches := newSharedBlockCaches()
+	sharedCaches := newSharedBlockCaches(bc.jumpDestCache)
 	bc.startPrefetchGoroutine(block, throwaway, sharedCaches, followupInterrupt)
 
 	type Result struct {
@@ -877,7 +879,7 @@ func (bc *BlockChain) ProcessBlock(block *types.Block, parent *types.Header, wit
 			parallelStatedb.StartPrefetcher("chain", witness, nil)
 			v2VmCfg := bc.cfg.VmConfig
 			sharedCaches.applyTo(&v2VmCfg)
-			res, err := bc.parallelProcessor.Process(block, parallelStatedb, v2VmCfg, nil, ctx)
+			res, err := bc.parallelProcessor.Process(block, parallelStatedb, bc.jumpDestCache, v2VmCfg, nil, ctx)
 			blockExecutionParallelTimer.UpdateSince(pstart)
 			var localVtime time.Duration
 			if err == nil {
@@ -907,7 +909,7 @@ func (bc *BlockChain) ProcessBlock(block *types.Block, parent *types.Header, wit
 		go func() {
 			pstart := time.Now()
 			statedb.StartPrefetcher("chain", witness, nil)
-			res, err := bc.processor.Process(block, statedb, bc.cfg.VmConfig, nil, ctx)
+			res, err := bc.processor.Process(block, statedb, bc.jumpDestCache, bc.cfg.VmConfig, nil, ctx)
 			blockExecutionSerialTimer.UpdateSince(pstart)
 			var localVtime time.Duration
 			if err == nil {
@@ -3529,7 +3531,7 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 
 	// Process block using the parent state as reference point
 	pstart := time.Now()
-	res, err := bc.processor.Process(block, statedb, bc.cfg.VmConfig, nil, context.Background())
+	res, err := bc.processor.Process(block, statedb, bc.jumpDestCache, bc.cfg.VmConfig, nil, context.Background())
 	if err != nil {
 		bc.reportBlock(block, res, err)
 		return nil, err
@@ -3567,8 +3569,12 @@ func (bc *BlockChain) processBlock(block *types.Block, statedb *state.StateDB, s
 		task := types.NewBlockWithHeader(context).WithBody(*block.Body())
 		author := NewEVMBlockContext(block.Header(), bc.hc, nil).Coinbase
 
+		sharedCaches := newSharedBlockCaches(bc.jumpDestCache)
+		vmConfig := bc.cfg.VmConfig
+		sharedCaches.applyTo(&vmConfig)
+
 		// Run the stateless self-cross-validation
-		crossStateRoot, crossReceiptRoot, _, _, err := ExecuteStateless(bc.chainConfig, bc.cfg.VmConfig, task, witness, &author, bc.engine, diskdb)
+		crossStateRoot, crossReceiptRoot, _, _, err := ExecuteStateless(bc.chainConfig, vmConfig, task, witness, &author, bc.engine, diskdb)
 		if err != nil {
 			return nil, fmt.Errorf("stateless self-validation failed: %v", err)
 		}
@@ -4366,7 +4372,11 @@ func (bc *BlockChain) ProcessBlockWithWitnesses(block *types.Block, witness *sta
 	// Bor: Calculate EvmBlockContext with Root and ReceiptHash to properly get the author
 	author := NewEVMBlockContext(block.Header(), bc.hc, nil).Coinbase
 
-	crossStateRoot, crossReceiptRoot, statedb, res, err := ExecuteStateless(bc.chainConfig, bc.cfg.VmConfig, task, witness, &author, bc.engine, bc.statedb.TrieDB().Disk())
+	sharedCaches := newSharedBlockCaches(bc.jumpDestCache)
+	vmConfig := bc.cfg.VmConfig
+	sharedCaches.applyTo(&vmConfig)
+
+	crossStateRoot, crossReceiptRoot, statedb, res, err := ExecuteStateless(bc.chainConfig, vmConfig, task, witness, &author, bc.engine, bc.statedb.TrieDB().Disk())
 	// Currently, we don't return the error, because we don't have a way to handle Span update statelessly
 	// TODO: Return the error once we have a way to handle Span update
 	if err != nil {
@@ -4498,4 +4508,8 @@ func (bc *BlockChain) verifyPendingHeaders() {
 // StateSizer returns the state size tracker, or nil if it's not initialized
 func (bc *BlockChain) StateSizer() *state.SizeTracker {
 	return bc.stateSizer
+}
+
+func (bc *BlockChain) JumpDestCache() vm.JumpDestCache {
+	return bc.jumpDestCache
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -4511,6 +4511,7 @@ func (bc *BlockChain) verifyPendingHeaders() {
 func (bc *BlockChain) StateSizer() *state.SizeTracker {
 	return bc.stateSizer
 }
+
 // JumpDestCache returns the chain-global shared JUMPDEST analysis cache.
 func (bc *BlockChain) JumpDestCache() vm.JumpDestCache {
 	return bc.jumpDestCache

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -244,7 +244,7 @@ func testParallelBlockChainImport(t *testing.T, scheme string, enforceParallelPr
 type AlwaysFailParallelStateProcessor struct {
 }
 
-func (p *AlwaysFailParallelStateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, address *common.Address, interruptCtx context.Context) (*ProcessResult, error) {
+func (p *AlwaysFailParallelStateProcessor) Process(block *types.Block, statedb *state.StateDB, jumpDestCache vm.JumpDestCache, cfg vm.Config, address *common.Address, interruptCtx context.Context) (*ProcessResult, error) {
 	return nil, errors.New("always fail")
 }
 
@@ -256,9 +256,9 @@ func NewSlowSerialStateProcessor(s Processor) *SlowSerialStateProcessor {
 	return &SlowSerialStateProcessor{s: s}
 }
 
-func (p *SlowSerialStateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, address *common.Address, interruptCtx context.Context) (*ProcessResult, error) {
+func (p *SlowSerialStateProcessor) Process(block *types.Block, statedb *state.StateDB, jumpDestCache vm.JumpDestCache, cfg vm.Config, address *common.Address, interruptCtx context.Context) (*ProcessResult, error) {
 	time.Sleep(100 * time.Millisecond)
-	return p.s.Process(block, statedb, cfg, nil, interruptCtx)
+	return p.s.Process(block, statedb, jumpDestCache, cfg, address, interruptCtx)
 }
 
 func TestSuccessfulBlockImportParallelFailed(t *testing.T) {

--- a/core/jumpdest.go
+++ b/core/jumpdest.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/lru"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+var (
+	jumpDestHitMeter  = metrics.NewRegisteredMeter("chain/cache/jumpdest/hit", nil)
+	jumpDestMissMeter = metrics.NewRegisteredMeter("chain/cache/jumpdest/miss", nil)
+)
+
+const (
+	// jumpDestBuckets is the number of independent LRU shards. Code hashes
+	// are dispatched by the low bits of the first byte to spread load across
+	// shards and reduce mutex contention from the parallel prefetcher.
+	jumpDestBuckets = 8
+
+	// jumpDestBucketSize is the per-shard byte budget.
+	jumpDestBucketSize = 8 * 1024 * 1024
+)
+
+// shardedJumpDestCache is a thread-safe, byte-bounded LRU of JUMPDEST analysis
+// bitmaps, sharded into independent buckets to reduce lock contention. It is
+// owned by BlockChain and shared across block processing and prefetching,
+// keyed by the immutable contract code hash.
+type shardedJumpDestCache struct {
+	buckets [jumpDestBuckets]struct {
+		dest *lru.SizeConstrainedCache[common.Hash, vm.BitVec]
+	}
+}
+
+// NewJumpDestCache constructs the analysis cache.
+func NewJumpDestCache() vm.JumpDestCache {
+	c := new(shardedJumpDestCache)
+	for i := range c.buckets {
+		c.buckets[i].dest = lru.NewSizeConstrainedCache[common.Hash, vm.BitVec](jumpDestBucketSize)
+	}
+	return c
+}
+
+// Load retrieves the cached jumpdest analysis for the given code hash.
+func (c *shardedJumpDestCache) Load(hash common.Hash) (vm.BitVec, bool) {
+	bucket := &c.buckets[hash[0]&(jumpDestBuckets-1)]
+	v, ok := bucket.dest.Get(hash)
+	if ok {
+		jumpDestHitMeter.Mark(1)
+	} else {
+		jumpDestMissMeter.Mark(1)
+	}
+	return v, ok
+}
+
+// Store saves the jumpdest analysis for the given code hash.
+func (c *shardedJumpDestCache) Store(hash common.Hash, b vm.BitVec) {
+	bucket := &c.buckets[hash[0]&(jumpDestBuckets-1)]
+	bucket.dest.Add(hash, b)
+}

--- a/core/mainnet_witness_benchmark_test.go
+++ b/core/mainnet_witness_benchmark_test.go
@@ -533,7 +533,7 @@ var benchVMConfig = vm.Config{
 	EnableEVMSwitchDispatch: true,
 }
 
-func processSerial(pb *preparedBlock, config *params.ChainConfig, engine consensus.Engine) (*ProcessResult, error) {
+func processSerial(pb *preparedBlock, config *params.ChainConfig, engine consensus.Engine, jumpDestCache vm.JumpDestCache) (*ProcessResult, error) {
 	db := pb.baseState.Copy()
 	hc := &HeaderChain{
 		config:      config,
@@ -541,7 +541,7 @@ func processSerial(pb *preparedBlock, config *params.ChainConfig, engine consens
 		headerCache: pb.headerCache,
 		engine:      engine,
 	}
-	return NewStateProcessor(hc).Process(pb.block, db, benchVMConfig, &pb.author, context.Background())
+	return NewStateProcessor(hc).Process(pb.block, db, jumpDestCache, benchVMConfig, &pb.author, context.Background())
 }
 
 func processParallel(pb *preparedBlock, config *params.ChainConfig, engine consensus.Engine, numProcs int) (*ProcessResult, error) {
@@ -557,10 +557,10 @@ func processParallel(pb *preparedBlock, config *params.ChainConfig, engine conse
 		headerCache: pb.headerCache,
 		engine:      engine,
 	}
-	return NewParallelStateProcessor(hc, bc).Process(pb.block, db, vm.Config{}, &pb.author, context.Background())
+	return NewParallelStateProcessor(hc, bc).Process(pb.block, db, nil, vm.Config{}, &pb.author, context.Background())
 }
 
-func processV2(pb *preparedBlock, config *params.ChainConfig, engine consensus.Engine, numWorkers int) (*ProcessResult, *state.StateDB, error) {
+func processV2(pb *preparedBlock, config *params.ChainConfig, engine consensus.Engine, numWorkers int, jumpDestCache vm.JumpDestCache) (*ProcessResult, *state.StateDB, error) {
 	db := pb.baseState.Copy()
 	bc := &BlockChain{
 		chainConfig: config,
@@ -572,7 +572,12 @@ func processV2(pb *preparedBlock, config *params.ChainConfig, engine consensus.E
 		headerCache: pb.headerCache,
 		engine:      engine,
 	}
-	res, err := NewV2StateProcessor(hc, bc, numWorkers).Process(pb.block, db, benchVMConfig, &pb.author, context.Background())
+	// V2 workers read the shared cache via vm.Config.SharedJumpDestCache; the
+	// explicit param mirrors production wiring so this stays correct if that
+	// config field is retired in favor of the parameter.
+	cfg := benchVMConfig
+	cfg.SharedJumpDestCache = jumpDestCache
+	res, err := NewV2StateProcessor(hc, bc, numWorkers).Process(pb.block, db, jumpDestCache, cfg, &pb.author, context.Background())
 	return res, db, err
 }
 
@@ -595,7 +600,7 @@ func executeStatelessSerial(config *params.ChainConfig, block *types.Block, witn
 	}
 	processor := NewStateProcessor(headerChain)
 
-	res, err := processor.Process(block, db, vm.Config{}, author, context.Background())
+	res, err := processor.Process(block, db, nil, vm.Config{}, author, context.Background())
 	if err != nil {
 		return common.Hash{}, common.Hash{}, nil, err
 	}
@@ -657,7 +662,7 @@ func executeStatelessParallel(config *params.ChainConfig, block *types.Block, wi
 
 	processor := NewParallelStateProcessor(hc, bc)
 
-	res, err := processor.Process(block, db, vm.Config{}, author, context.Background())
+	res, err := processor.Process(block, db, nil, vm.Config{}, author, context.Background())
 	if err != nil {
 		return common.Hash{}, common.Hash{}, nil, err
 	}
@@ -1138,9 +1143,10 @@ func BenchmarkMainnetStatelessSerial(b *testing.B) {
 
 	b.Run("AllBlocks", func(b *testing.B) {
 		b.ReportAllocs()
+		jdc := NewJumpDestCache()
 		for i := 0; i < b.N; i++ {
 			for j := range prepared {
-				if _, err := processSerial(&prepared[j], config, engine); err != nil {
+				if _, err := processSerial(&prepared[j], config, engine, jdc); err != nil {
 					b.Fatalf("block %s: %v", testBlockHexes[j], err)
 				}
 			}
@@ -1155,8 +1161,9 @@ func BenchmarkMainnetStatelessSerial(b *testing.B) {
 		name := fmt.Sprintf("Block_%s_%dtx_%dMgas", testBlockHexes[i], len(pb.block.Transactions()), pb.block.GasUsed()/1e6)
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
+			jdc := NewJumpDestCache()
 			for n := 0; n < b.N; n++ {
-				if _, err := processSerial(pb, config, engine); err != nil {
+				if _, err := processSerial(pb, config, engine, jdc); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -1214,8 +1221,8 @@ func BenchmarkMainnetStatelessParallel(b *testing.B) {
 }
 
 // processV2Serial is the legacy serial-V2 path (one tx at a time through ParallelStateDB).
-func processV2Serial(pb *preparedBlock, config *params.ChainConfig, engine consensus.Engine) error {
-	_, _, err := processV2(pb, config, engine, 1)
+func processV2Serial(pb *preparedBlock, config *params.ChainConfig, engine consensus.Engine, jumpDestCache vm.JumpDestCache) error {
+	_, _, err := processV2(pb, config, engine, 1, jumpDestCache)
 	return err
 }
 
@@ -1321,9 +1328,10 @@ func BenchmarkParallelStateDBV2(b *testing.B) {
 
 	b.Run("AllBlocks", func(b *testing.B) {
 		b.ReportAllocs()
+		jdc := NewJumpDestCache()
 		for i := 0; i < b.N; i++ {
 			for j := range prepared {
-				if err := processV2Serial(&prepared[j], config, engine); err != nil {
+				if err := processV2Serial(&prepared[j], config, engine, jdc); err != nil {
 					b.Fatalf("block %s: %v", testBlockHexes[j], err)
 				}
 			}
@@ -1338,8 +1346,9 @@ func BenchmarkParallelStateDBV2(b *testing.B) {
 		name := fmt.Sprintf("Block_%s_%dtx_%dMgas", testBlockHexes[i], len(pb.block.Transactions()), pb.block.GasUsed()/1e6)
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
+			jdc := NewJumpDestCache()
 			for n := 0; n < b.N; n++ {
-				if err := processV2Serial(pb, config, engine); err != nil {
+				if err := processV2Serial(pb, config, engine, jdc); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -1417,8 +1426,8 @@ func TestV2BlockSTMWorkerScaling(t *testing.T) {
 	}
 }
 
-func processV2BlockSTM(pb *preparedBlock, config *params.ChainConfig, engine consensus.Engine, numWorkers int) error {
-	_, _, err := processV2(pb, config, engine, numWorkers)
+func processV2BlockSTM(pb *preparedBlock, config *params.ChainConfig, engine consensus.Engine, numWorkers int, jdc vm.JumpDestCache) error {
+	_, _, err := processV2(pb, config, engine, numWorkers, jdc)
 	return err
 }
 
@@ -1578,9 +1587,10 @@ func BenchmarkV2Embedded(b *testing.B) {
 
 	b.Run("Serial", func(b *testing.B) {
 		b.ReportAllocs()
+		jdc := NewJumpDestCache()
 		for i := 0; i < b.N; i++ {
 			for j := range prepared {
-				processSerial(&prepared[j], config, engine)
+				processSerial(&prepared[j], config, engine, jdc)
 			}
 		}
 		b.StopTimer()
@@ -1590,9 +1600,10 @@ func BenchmarkV2Embedded(b *testing.B) {
 	for _, numWorkers := range []int{4, 8, 16} {
 		b.Run(fmt.Sprintf("V2/%dw", numWorkers), func(b *testing.B) {
 			b.ReportAllocs()
+			jdc := NewJumpDestCache()
 			for i := 0; i < b.N; i++ {
 				for j := range prepared {
-					processV2BlockSTM(&prepared[j], config, engine, numWorkers)
+					processV2BlockSTM(&prepared[j], config, engine, numWorkers, jdc)
 				}
 			}
 			b.StopTimer()
@@ -1622,9 +1633,10 @@ func BenchmarkV2AllBlocks(b *testing.B) {
 
 	b.Run("Serial", func(b *testing.B) {
 		b.ReportAllocs()
+		jdc := NewJumpDestCache()
 		for i := 0; i < b.N; i++ {
 			for j := range prepared {
-				processSerial(&prepared[j], config, engine)
+				processSerial(&prepared[j], config, engine, jdc)
 			}
 		}
 		b.StopTimer()
@@ -1634,9 +1646,10 @@ func BenchmarkV2AllBlocks(b *testing.B) {
 	for _, numWorkers := range []int{4, 8, 16} {
 		b.Run(fmt.Sprintf("V2/%dw", numWorkers), func(b *testing.B) {
 			b.ReportAllocs()
+			jdc := NewJumpDestCache()
 			for i := 0; i < b.N; i++ {
 				for j := range prepared {
-					processV2BlockSTM(&prepared[j], config, engine, numWorkers)
+					processV2BlockSTM(&prepared[j], config, engine, numWorkers, jdc)
 				}
 			}
 			b.StopTimer()
@@ -1684,7 +1697,7 @@ func processV2BlockSTMWithWitness(pb *preparedBlock, config *params.ChainConfig,
 		headerCache: pb.headerCache,
 		engine:      engine,
 	}
-	_, err = NewV2StateProcessor(hc, bc, numWorkers).Process(pb.block, db, benchVMConfig, &pb.author, context.Background())
+	_, err = NewV2StateProcessor(hc, bc, numWorkers).Process(pb.block, db, nil, benchVMConfig, &pb.author, context.Background())
 	return err
 }
 

--- a/core/mainnet_witness_benchmark_test.go
+++ b/core/mainnet_witness_benchmark_test.go
@@ -1612,6 +1612,90 @@ func BenchmarkV2Embedded(b *testing.B) {
 	}
 }
 
+// BenchmarkJumpDestCache isolates the cross-block JUMPDEST analysis cache's
+// effect on serial EVM execution over the witness block set. Both arms run the
+// SAME blocks through the SAME serial processor; the only variable is cache
+// lifetime:
+//
+//	PerBlock : nil cache — StateProcessor uses a fresh per-block analysis map,
+//	           so a contract is re-analyzed on the first touch of every block
+//	           (matches develop: within-block dedup only).
+//	Shared   : one cache reused across all blocks (this PR): a hot contract is
+//	           analyzed once and reused on every later block.
+//
+// A warmup pass primes the shared trie clean-cache before either arm is timed.
+// This is essential: a memprofile shows trie.decodeRef/decodeFull are ~60% of
+// allocations in these witness replays, so whichever arm ran second would read
+// a trie cache the first arm populated and look ~40% leaner — an artifact that
+// dwarfs the analysis signal. With the warmup, both arms measure against an
+// equally-warm trie, and the Shared arm rebuilds its JUMPDEST cache from empty
+// each iteration so the result is stable across -count / -benchtime.
+//
+// Read allocs/op with -benchmem (deterministic; each cache hit skips one
+// codeBitmap allocation). Expect a SMALL delta — analysis is a minor fraction of
+// whole-block execution — so this mostly confirms the cache doesn't regress and
+// quantifies its modest upside on this workload. For the least-ambiguous read,
+// run each arm in its own process and compare:
+//
+//	BOR_BLOCKSTM_TEST=1 go test -run='^$' -bench='JumpDestCache/PerBlock' -benchmem -count=8 ./core/ > a.txt
+//	BOR_BLOCKSTM_TEST=1 go test -run='^$' -bench='JumpDestCache/Shared'   -benchmem -count=8 ./core/ > b.txt
+//	benchstat a.txt b.txt
+//
+// Findings (2026-07, Polygon mainnet): the two arms are statistically
+// indistinguishable here, and a CPU profile of a real pebble-backed bor node
+// shows codeBitmap/isCode below the noise floor (<0.01% of CPU; block work is
+// dominated by state access — pathdb diff-layer lookups). The cross-block cache
+// is correct and cheap but yields no measurable whole-block speedup on bor's
+// cost profile; upstream go-ethereum's ~8% (engine_newPayload, ETH mainnet) does
+// not translate. Keep this as a regression guard, not as evidence of a win.
+func BenchmarkJumpDestCache(b *testing.B) {
+	if os.Getenv("BOR_BLOCKSTM_TEST") == "" {
+		b.Skip("skipping slow benchmark: set BOR_BLOCKSTM_TEST=1 to run")
+	}
+	alchemyURL := getAlchemyURL(b)
+	allBlocks, diskdb := loadBlocksFromDir(b, witnessDir, alchemyURL)
+	b.Logf("loaded %d blocks total", len(allBlocks))
+
+	config := params.BorMainnetChainConfig
+	engine := &benchConsensus{}
+	prepared := prepareBlocks(allBlocks, diskdb, config)
+
+	totalGas := uint64(0)
+	for _, pb := range prepared {
+		totalGas += pb.block.GasUsed()
+	}
+
+	// Warm the shared trie clean-cache so both arms are timed against an equally
+	// warm trie (removes the cold/warm ordering bias described above).
+	for j := range prepared {
+		if _, err := processSerial(&prepared[j], config, engine, nil); err != nil {
+			b.Fatalf("warmup block %d: %v", prepared[j].block.NumberU64(), err)
+		}
+	}
+
+	// shared=false => nil cache (fresh per-block map, develop-equivalent).
+	// shared=true  => one cache per iteration, reused across all blocks (this PR).
+	run := func(b *testing.B, shared bool) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var jdc vm.JumpDestCache
+			if shared {
+				jdc = NewJumpDestCache()
+			}
+			for j := range prepared {
+				if _, err := processSerial(&prepared[j], config, engine, jdc); err != nil {
+					b.Fatalf("block %d: %v", prepared[j].block.NumberU64(), err)
+				}
+			}
+		}
+		b.StopTimer()
+		b.ReportMetric(float64(totalGas)*float64(b.N)/b.Elapsed().Seconds()/1e6, "mgas/s")
+	}
+
+	b.Run("PerBlock", func(b *testing.B) { run(b, false) })
+	b.Run("Shared", func(b *testing.B) { run(b, true) })
+}
+
 // BenchmarkV2AllBlocks benchmarks all 241 witness blocks.
 // Run with: BOR_BLOCKSTM_TEST=1 go test -run='^$' -bench=BenchmarkV2AllBlocks ./core/
 func BenchmarkV2AllBlocks(b *testing.B) {

--- a/core/parallel_state_processor.go
+++ b/core/parallel_state_processor.go
@@ -389,7 +389,7 @@ func warmOnce(reader state.Reader, addr common.Address, seen map[common.Address]
 	reader.Account(addr) //nolint:errcheck
 }
 
-func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, author *common.Address, interruptCtx context.Context) (processResult *ProcessResult, err error) {
+func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.StateDB, jumpDestCache vm.JumpDestCache, cfg vm.Config, author *common.Address, interruptCtx context.Context) (processResult *ProcessResult, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Error("recovered from panic during parallel execution", "err", r)
@@ -421,7 +421,6 @@ func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.Stat
 	}
 
 	tasks := make([]blockstm.ExecTask, 0, len(block.Transactions()))
-	sharedJumpDests := vm.NewSyncJumpDestCache()
 
 	shouldDelayFeeCal := true
 
@@ -443,7 +442,14 @@ func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.Stat
 
 	context := NewEVMBlockContext(header, p.bc.hc, author)
 
+	if jumpDestCache == nil {
+		jumpDestCache = vm.NewSyncJumpDestCache()
+	}
+
 	vmenv := vm.NewEVM(context, statedb, config, cfg)
+	if jumpDestCache != nil {
+		vmenv.SetJumpDestCache(jumpDestCache)
+	}
 
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, vmenv)
@@ -495,7 +501,7 @@ func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.Stat
 			dependencies:      deps[i],
 			coinbase:          coinbase,
 			blockContext:      blockContext,
-			jumpDests:         sharedJumpDests,
+			jumpDests:         jumpDestCache,
 		}
 
 		tasks = append(tasks, task)
@@ -1097,7 +1103,7 @@ func (p *V2StateProcessor) chainConfig() *params.ChainConfig {
 // the transaction messages using V2 BlockSTM parallel execution.
 // The caller should provide a statedb that is NOT shared with any read-only base.
 // In production, ProcessBlock creates an independent parallelStatedb for this.
-func (p *V2StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, author *common.Address, interruptCtx context.Context) (*ProcessResult, error) {
+func (p *V2StateProcessor) Process(block *types.Block, statedb *state.StateDB, jumpDestCache vm.JumpDestCache, cfg vm.Config, author *common.Address, interruptCtx context.Context) (*ProcessResult, error) {
 	// Tracer hooks are not goroutine-safe; concurrent V2 workers sharing
 	// one Tracer would race. Refuse so ProcessBlock's fallback runs V1.
 	if cfg.Tracer != nil {

--- a/core/parallel_state_processor.go
+++ b/core/parallel_state_processor.go
@@ -442,14 +442,19 @@ func (p *ParallelStateProcessor) Process(block *types.Block, statedb *state.Stat
 
 	context := NewEVMBlockContext(header, p.bc.hc, author)
 
+	// Resolve the JUMPDEST cache: an explicit param wins; otherwise honor a
+	// shared cache already wired via cfg.SharedJumpDestCache (e.g. the global,
+	// prefetcher-warmed cache) instead of discarding it; only when neither is
+	// set fall back to a fresh per-block cache shared across workers.
+	if jumpDestCache == nil {
+		jumpDestCache = cfg.SharedJumpDestCache
+	}
 	if jumpDestCache == nil {
 		jumpDestCache = vm.NewSyncJumpDestCache()
 	}
 
 	vmenv := vm.NewEVM(context, statedb, config, cfg)
-	if jumpDestCache != nil {
-		vmenv.SetJumpDestCache(jumpDestCache)
-	}
+	vmenv.SetJumpDestCache(jumpDestCache)
 
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, vmenv)

--- a/core/parallel_state_processor.go
+++ b/core/parallel_state_processor.go
@@ -638,13 +638,13 @@ type v2Env struct {
 	vmConfig    vm.Config
 	chainConfig *params.ChainConfig
 	gasLimit    uint64
-	// jumpDests is a fallback per-v2Env JUMPDEST cache used only when the
-	// caller did NOT supply vmConfig.SharedJumpDestCache. In production,
-	// blockchain.go wires sharedCaches.jumpDests (warmed by the prefetcher)
-	// onto vmConfig and vm.NewEVM picks it up — overriding it here would
-	// throw away the prefetcher's analysis. The fallback path matters for
-	// callers that bypass ProcessBlock (benchmarks, single-block witness
-	// processing) where no shared cache is provided.
+	// jumpDests is a fallback per-v2Env JUMPDEST cache, used only when the
+	// caller didn't supply vmConfig.SharedJumpDestCache. In production,
+	// blockchain.go sets that field to the chain-global cache, which
+	// vm.NewEVM installs onto each worker — overriding it here would discard
+	// the cross-block analysis shared with the rest of the chain. The
+	// fallback matters for callers that bypass ProcessBlock (benchmarks,
+	// single-block witness processing) where no shared cache is provided.
 	jumpDests vm.JumpDestCache
 	safeBase  *state.SafeBase             // shared across all workers (with read cache)
 	recycleCh chan *state.ParallelStateDB // pool of reusable PDBs
@@ -964,7 +964,7 @@ func newV2Env(base *state.StateDB, store *blockstm.MVStore, bals *blockstm.MVBal
 	wireStorageCaches(base, sharedSafeBase)
 	// Allocate the per-v2Env fallback only when the caller didn't supply a
 	// shared cache. Production (blockchain.go) sets vmConfig.SharedJumpDestCache
-	// on the prefetcher-warmed cache, so allocating here would just be dead
+	// to the chain-global cache, so allocating here would just be dead
 	// memory. Benchmarks and single-block witness paths bypass that wiring.
 	var fallbackJumpDests vm.JumpDestCache
 	if vmConfig.SharedJumpDestCache == nil {

--- a/core/parallel_state_processor_review_test.go
+++ b/core/parallel_state_processor_review_test.go
@@ -673,7 +673,7 @@ func TestExecuteV2BlockSTM_HonoursCancellation(t *testing.T) {
 func TestV2StateProcessor_RefusesTracer(t *testing.T) {
 	p := NewV2StateProcessor(nil, nil, 2)
 	cfg := vm.Config{Tracer: &tracing.Hooks{}}
-	_, err := p.Process(nil, nil, cfg, nil, nil)
+	_, err := p.Process(nil, nil, nil, cfg, nil, nil)
 	if !errors.Is(err, errV2TracerUnsupported) {
 		t.Fatalf("V2.Process with tracer: got %v, want errV2TracerUnsupported", err)
 	}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -60,14 +60,14 @@ type PrefetchResult struct {
 // This is a thin wrapper over PrefetchStream: it feeds the block's transactions
 // into a channel, closes it, and runs the stream to completion. Behavior is
 // identical to the pre-stream implementation.
-func (p *StatePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, cfg vm.Config, intermediateRootPrefetch bool, interrupt *atomic.Bool) *PrefetchResult {
+func (p *StatePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, jumpDestCache vm.JumpDestCache, cfg vm.Config, intermediateRootPrefetch bool, interrupt *atomic.Bool) *PrefetchResult {
 	txs := block.Transactions()
 	ch := make(chan *types.Transaction, len(txs))
 	for _, tx := range txs {
 		ch <- tx
 	}
 	close(ch)
-	return p.PrefetchStream(block.Header(), statedb, cfg, intermediateRootPrefetch, interrupt, nil, ch, nil)
+	return p.PrefetchStream(block.Header(), statedb, jumpDestCache, cfg, intermediateRootPrefetch, interrupt, nil, ch, nil)
 }
 
 // PrefetchStream warms state caches by executing transactions read from txsCh
@@ -91,6 +91,7 @@ func (p *StatePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 func (p *StatePrefetcher) PrefetchStream(
 	header *types.Header,
 	statedb *state.StateDB,
+	jumpDestCache vm.JumpDestCache,
 	cfg vm.Config,
 	intermediateRootPrefetch bool,
 	hardKill *atomic.Bool,
@@ -106,6 +107,7 @@ func (p *StatePrefetcher) PrefetchStream(
 		statedb:                  statedb,
 		reader:                   statedb.Reader(),
 		signer:                   types.MakeSigner(p.config, header.Number, header.Time),
+		jumpDestCache:            jumpDestCache,
 		cfg:                      cfg,
 		intermediateRootPrefetch: intermediateRootPrefetch,
 		hardKill:                 hardKill,
@@ -158,6 +160,7 @@ type streamCtx struct {
 	statedb                  *state.StateDB
 	reader                   state.Reader
 	signer                   types.Signer
+	jumpDestCache            vm.JumpDestCache
 	cfg                      vm.Config
 	intermediateRootPrefetch bool
 	hardKill                 *atomic.Bool
@@ -191,7 +194,7 @@ func (s *streamCtx) runWorker() {
 func (s *streamCtx) processTx(tx *types.Transaction) {
 	idx := int(s.txIndex.Add(1) - 1)
 	gasUsed, ok := s.p.prefetchOneTx(
-		tx, idx, s.header, s.statedb, s.reader, s.signer, s.cfg,
+		tx, idx, s.header, s.statedb, s.reader, s.signer, s.jumpDestCache, s.cfg,
 		s.intermediateRootPrefetch, s.evmInterrupt, &s.fails,
 	)
 	if !ok {
@@ -217,6 +220,7 @@ func (p *StatePrefetcher) prefetchOneTx(
 	statedb *state.StateDB,
 	reader state.Reader,
 	signer types.Signer,
+	jumpDestCache vm.JumpDestCache,
 	cfg vm.Config,
 	intermediateRootPrefetch bool,
 	interrupt *atomic.Bool,
@@ -247,6 +251,9 @@ func (p *StatePrefetcher) prefetchOneTx(
 	stateCpy.SetTxContext(tx.Hash(), txIdx)
 
 	evm := vm.NewEVM(NewEVMBlockContext(header, p.chain, nil), stateCpy, p.config, cfg)
+	if jumpDestCache != nil {
+		evm.SetJumpDestCache(jumpDestCache)
+	}
 	evm.SetInterrupt(interrupt)
 
 	result, err := ApplyMessage(evm, msg, new(GasPool).AddGas(header.GasLimit))

--- a/core/state_prefetcher_intermediate_root_test.go
+++ b/core/state_prefetcher_intermediate_root_test.go
@@ -200,7 +200,7 @@ func runIRTrial(t testing.TB, chain *BlockChain, txs []*types.Transaction, flag 
 	for i, tx := range txs {
 		_, _ = prefetcher.prefetchOneTx(
 			tx, i, header, throwaway, throwaway.Reader(),
-			signer, cfg, flag, &interrupt, &fails,
+			signer, chain.JumpDestCache(), cfg, flag, &interrupt, &fails,
 		)
 	}
 	prefetchDur := time.Since(prefetchStart)
@@ -548,7 +548,7 @@ func runIRPebbleTrial(
 	for i, tx := range txs {
 		_, _ = prefetcher.prefetchOneTx(
 			tx, i, header, throwaway, throwaway.Reader(),
-			signer, cfg, flag, &interrupt, &fails,
+			signer, chain.JumpDestCache(), cfg, flag, &interrupt, &fails,
 		)
 	}
 	prefetchDur := time.Since(prefetchStart)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -62,7 +62,7 @@ func (p *StateProcessor) chainConfig() *params.ChainConfig {
 // Process returns the receipts and logs accumulated during the process and
 // returns the amount of gas that was used in the process. If any of the
 // transactions failed to execute due to insufficient gas it will return an error.
-func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, author *common.Address, interruptCtx context.Context) (*ProcessResult, error) {
+func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, jumpDestCache vm.JumpDestCache, cfg vm.Config, author *common.Address, interruptCtx context.Context) (*ProcessResult, error) {
 	var (
 		config      = p.chainConfig()
 		receipts    types.Receipts
@@ -96,7 +96,9 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 	context = NewEVMBlockContext(header, p.chain, author)
 	evm := vm.NewEVM(context, tracingStateDB, p.chainConfig(), cfg)
-
+	if jumpDestCache != nil {
+		evm.SetJumpDestCache(jumpDestCache)
+	}
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, evm)
 	}

--- a/core/stateless.go
+++ b/core/stateless.go
@@ -67,7 +67,7 @@ func ExecuteStateless(config *params.ChainConfig, vmconfig vm.Config, block *typ
 	processor := NewStateProcessor(headerChain)
 	validator := NewBlockValidator(config, nil) // No chain, we only validate the state, not the block
 
-	res, err := processor.Process(block, db, vmconfig, author, context.Background())
+	res, err := processor.Process(block, db, nil, vmconfig, author, context.Background())
 	if err != nil {
 		return common.Hash{}, common.Hash{}, nil, nil, err
 	}

--- a/core/types.go
+++ b/core/types.go
@@ -42,7 +42,7 @@ type Prefetcher interface {
 	// Prefetch processes the state changes according to the Ethereum rules by running
 	// the transaction messages using the statedb, but any changes are discarded. The
 	// only goal is to pre-cache transaction signatures and state trie nodes.
-	Prefetch(block *types.Block, statedb *state.StateDB, cfg vm.Config, intermediateRootPrefetch bool, interrupt *atomic.Bool) *PrefetchResult
+	Prefetch(block *types.Block, statedb *state.StateDB, jumpDestCache vm.JumpDestCache, cfg vm.Config, intermediateRootPrefetch bool, interrupt *atomic.Bool) *PrefetchResult
 }
 
 // Processor is an interface for processing blocks using a given initial state.
@@ -50,7 +50,7 @@ type Processor interface {
 	// Process processes the state changes according to the Ethereum rules by running
 	// the transaction messages using the statedb and applying any rewards to both
 	// the processor (coinbase) and any included uncles.
-	Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, author *common.Address, interruptCtx context.Context) (*ProcessResult, error)
+	Process(block *types.Block, statedb *state.StateDB, jumpDestCache vm.JumpDestCache, cfg vm.Config, author *common.Address, interruptCtx context.Context) (*ProcessResult, error)
 }
 
 // ProcessResult contains the values computed by Process.

--- a/core/v2_blockstm_test.go
+++ b/core/v2_blockstm_test.go
@@ -261,7 +261,7 @@ func TestV2GasDeterminism(t *testing.T) {
 		bc := &BlockChain{hc: &HeaderChain{config: config, chainDb: memdb,
 			headerCache: lru.NewCache[common.Hash, *types.Header](256), engine: engine}}
 
-		res, err := NewV2StateProcessor(hc, bc, 16).Process(bd.block, sdb, vm.Config{}, &author, context.Background())
+		res, err := NewV2StateProcessor(hc, bc, 16).Process(bd.block, sdb, nil, vm.Config{}, &author, context.Background())
 		if err != nil {
 			t.Fatalf("run %d: %v", run, err)
 		}

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -156,7 +156,7 @@ func (eth *Ethereum) hashState(ctx context.Context, block *types.Block, reexec u
 		if current = eth.blockchain.GetBlockByNumber(next); current == nil {
 			return nil, nil, fmt.Errorf("block #%d not found", next)
 		}
-		_, err := eth.blockchain.Processor().Process(current, statedb, vm.Config{}, nil, nil)
+		_, err := eth.blockchain.Processor().Process(current, statedb, nil, vm.Config{}, nil, nil)
 		if err != nil {
 			return nil, nil, fmt.Errorf("processing block %d failed: %v", current.NumberU64(), err)
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1291,6 +1291,7 @@ func (w *worker) makeEnv(header *types.Header, coinbase common.Address, witness 
 		prefetchedTxHashes: genParams.prefetchedTxHashes,
 	}
 	env.evm.SetInterrupt(&w.interruptBlockBuilding)
+	env.evm.SetJumpDestCache(w.chain.JumpDestCache())
 
 	// Keep track of transactions which return errors so they can be removed
 	env.tcount = 0
@@ -2478,7 +2479,7 @@ func (w *worker) runPrefetcher(parent *types.Header, throwaway *state.StateDB, g
 		// pebble's block cache, which under realistic clean-cache sizes is already
 		// resident. Upstream go-ethereum's prefetcher does not compute intermediate
 		// roots either.
-		prefetcher.PrefetchStream(header, throwaway, w.vmConfig(), false,
+		prefetcher.PrefetchStream(header, throwaway, w.chain.JumpDestCache(), w.vmConfig(), false,
 			hardKill, evmAbort, txsCh, onSuccess)
 	}()
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1291,7 +1291,9 @@ func (w *worker) makeEnv(header *types.Header, coinbase common.Address, witness 
 		prefetchedTxHashes: genParams.prefetchedTxHashes,
 	}
 	env.evm.SetInterrupt(&w.interruptBlockBuilding)
-	env.evm.SetJumpDestCache(w.chain.JumpDestCache())
+	if jdc := w.chain.JumpDestCache(); jdc != nil {
+		env.evm.SetJumpDestCache(jdc)
+	}
 
 	// Keep track of transactions which return errors so they can be removed
 	env.tcount = 0

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -3644,7 +3644,7 @@ func TestPrefetchStream_HardKillExits(t *testing.T) {
 	hardKill := new(atomic.Bool)
 	done := make(chan *core.PrefetchResult, 1)
 	go func() {
-		done <- prefetcher.PrefetchStream(header, throwaway, w.vmConfig(), true,
+		done <- prefetcher.PrefetchStream(header, throwaway, nil, w.vmConfig(), true,
 			hardKill, nil, txsCh, nil)
 	}()
 
@@ -3693,7 +3693,7 @@ func TestPrefetchStream_EvmAbortSkipsAndResumes(t *testing.T) {
 	streamDone := make(chan struct{})
 	go func() {
 		defer close(streamDone)
-		prefetcher.PrefetchStream(header, throwaway, w.vmConfig(), true,
+		prefetcher.PrefetchStream(header, throwaway, nil, w.vmConfig(), true,
 			hardKill, evmAbort, txsCh, onSuccess)
 	}()
 
@@ -3743,7 +3743,7 @@ func TestPrefetchStream_BlockEquivalence(t *testing.T) {
 
 	// Path A: block-oriented Prefetch.
 	block := types.NewBlock(header, &types.Body{Transactions: allTxs}, nil, trie.NewStackTrie(nil))
-	resultA := prefetcher.Prefetch(block, throwaway, w.vmConfig(), true, nil)
+	resultA := prefetcher.Prefetch(block, throwaway, nil, w.vmConfig(), true, nil)
 	require.NotNil(t, resultA)
 
 	// Path B: streaming PrefetchStream over the same txs on a fresh throwaway state.
@@ -3755,7 +3755,7 @@ func TestPrefetchStream_BlockEquivalence(t *testing.T) {
 		ch <- tx
 	}
 	close(ch)
-	resultB := prefetcher.PrefetchStream(header, throwawayB, w.vmConfig(), true,
+	resultB := prefetcher.PrefetchStream(header, throwawayB, nil, w.vmConfig(), true,
 		nil, nil, ch, nil)
 	require.NotNil(t, resultB)
 


### PR DESCRIPTION
## Summary
Port https://github.com/ethereum/go-ethereum/pull/34850 from Geth. 

This PR introduces a global shared JumpDest cache which can be used across blocks instead of current per-block cache. 

## Executed tests
Yet to be tested on Production nodes for regressions and benchmarking. 