### PR TITLE
miner: recover veblop producer stall when a build wedges with no pending task

### DIFF
--- a/miner/veblop_fallback_test.go
+++ b/miner/veblop_fallback_test.go
@@ -1,0 +1,119 @@
+package miner
+
+import "testing"
+
+// TestDecideVeblopFallback covers the producer stall-fallback decision logic in
+// newWorkLoop's veblop-timer branch.
+//
+// Regression context (mainnet incident): a block producer froze because a build
+// wedged inside commitWork left pendingWorkBlock pinned at currentBlock+1 with no
+// sealing task (pendingTasks empty). The old guard skipped recovery on
+// `pendingWorkBlock == nextBlock` alone, so the producer never resubmitted work
+// and only a restart recovered.
+//
+// The fix must ALSO not interrupt a build that is merely slow-but-live (same
+// pendingWorkBlock==next, no-task state, but progressing). The two are told apart
+// by how long the build has been outstanding (pendingWorkAgeSec) — never by
+// block-timestamp age (chainAgeSec), which is meaningless when the head carries
+// an old timestamp (e.g. genesis).
+func TestDecideVeblopFallback(t *testing.T) {
+	const (
+		current    = uint64(100)
+		next       = current + 1
+		timeout    = int64(1) // veblop timeout (block period) in seconds
+		stallAfter = 3 * timeout
+		bigAge     = int64(1_000_000) // genesis-like huge chain age
+	)
+
+	tests := []struct {
+		name              string
+		pendingWorkBlock  uint64
+		hasPendingTasks   bool
+		chainAgeSec       int64
+		pendingWorkAgeSec int64
+		want              veblopFallbackDecision
+	}{
+		{
+			// THE BUG: build wedged in commitWork pinned pendingWorkBlock=next,
+			// produced no task, and has been outstanding well past a normal build.
+			name:              "wedged build, outstanding past threshold -> recommit",
+			pendingWorkBlock:  next,
+			hasPendingTasks:   false,
+			chainAgeSec:       bigAge,
+			pendingWorkAgeSec: 5 * timeout,
+			want:              veblopRecommit,
+		},
+		{
+			// THE REGRESSION GUARD: at genesis chainAge is huge, but the build was
+			// just submitted and is still in progress — must NOT be interrupted.
+			name:              "in-progress build at genesis (huge chainAge, fresh build) -> wait",
+			pendingWorkBlock:  next,
+			hasPendingTasks:   false,
+			chainAgeSec:       bigAge,
+			pendingWorkAgeSec: 0,
+			want:              veblopWait,
+		},
+		{
+			name:              "task in flight for next block -> skip",
+			pendingWorkBlock:  next,
+			hasPendingTasks:   true,
+			chainAgeSec:       bigAge,
+			pendingWorkAgeSec: 10 * timeout,
+			want:              veblopSkip,
+		},
+		{
+			// Nothing claimed for next block and chain stale -> resubmit.
+			name:              "no work claimed, stale -> recommit",
+			pendingWorkBlock:  0,
+			hasPendingTasks:   false,
+			chainAgeSec:       timeout,
+			pendingWorkAgeSec: 0,
+			want:              veblopRecommit,
+		},
+		{
+			// Nothing claimed but chain still fresh -> wait.
+			name:              "no work claimed, fresh -> wait",
+			pendingWorkBlock:  0,
+			hasPendingTasks:   false,
+			chainAgeSec:       timeout - 1,
+			pendingWorkAgeSec: 0,
+			want:              veblopWait,
+		},
+		{
+			// A task is sealing and pendingWorkBlock was already cleared by
+			// commitWork's deferred reset -> never resubmit on top of it.
+			name:              "task sealing, pendingWorkBlock cleared -> skip",
+			pendingWorkBlock:  0,
+			hasPendingTasks:   true,
+			chainAgeSec:       bigAge,
+			pendingWorkAgeSec: 0,
+			want:              veblopSkip,
+		},
+		{
+			name:              "wedge boundary: outstanding exactly at threshold -> recommit",
+			pendingWorkBlock:  next,
+			hasPendingTasks:   false,
+			chainAgeSec:       bigAge,
+			pendingWorkAgeSec: stallAfter,
+			want:              veblopRecommit,
+		},
+		{
+			name:              "wedge boundary: just below threshold -> wait",
+			pendingWorkBlock:  next,
+			hasPendingTasks:   false,
+			chainAgeSec:       bigAge,
+			pendingWorkAgeSec: stallAfter - 1,
+			want:              veblopWait,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decideVeblopFallback(tt.pendingWorkBlock, next, tt.hasPendingTasks, tt.chainAgeSec, timeout, tt.pendingWorkAgeSec, stallAfter)
+			if got != tt.want {
+				t.Fatalf("decideVeblopFallback(pwb=%d, next=%d, hasTasks=%v, chainAge=%d, timeout=%d, workAge=%d, stallAfter=%d) = %d, want %d",
+					tt.pendingWorkBlock, next, tt.hasPendingTasks, tt.chainAgeSec, timeout, tt.pendingWorkAgeSec, stallAfter, got, tt.want)
+			}
+		})
+	}
+}

--- a/miner/veblop_fallback_test.go
+++ b/miner/veblop_fallback_test.go
@@ -1,6 +1,9 @@
 package miner
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // TestDecideVeblopFallback covers the producer stall-fallback decision logic in
 // newWorkLoop's veblop-timer branch.
@@ -13,106 +16,149 @@ import "testing"
 //
 // The fix must ALSO not interrupt a build that is merely slow-but-live (same
 // pendingWorkBlock==next, no-task state, but progressing). The two are told apart
-// by how long the build has been outstanding (pendingWorkAgeSec) — never by
-// block-timestamp age (chainAgeSec), which is meaningless when the head carries
+// by how long the build has been outstanding (pendingWorkAge) — never by
+// block-timestamp age (chainAge), which is meaningless when the head carries
 // an old timestamp (e.g. genesis).
 func TestDecideVeblopFallback(t *testing.T) {
 	const (
 		current    = uint64(100)
 		next       = current + 1
-		timeout    = int64(1) // veblop timeout (block period) in seconds
+		timeout    = time.Second // veblop timeout (block period)
 		stallAfter = 3 * timeout
-		bigAge     = int64(1_000_000) // genesis-like huge chain age
+		bigAge     = 1_000_000 * time.Second // genesis-like huge chain age
 	)
 
 	tests := []struct {
-		name              string
-		pendingWorkBlock  uint64
-		hasPendingTasks   bool
-		chainAgeSec       int64
-		pendingWorkAgeSec int64
-		want              veblopFallbackDecision
+		name             string
+		pendingWorkBlock uint64
+		hasPendingTasks  bool
+		chainAge         time.Duration
+		veblopTimeout    time.Duration
+		pendingWorkAge   time.Duration
+		stallThreshold   time.Duration
+		want             veblopFallbackDecision
 	}{
 		{
 			// THE BUG: build wedged in commitWork pinned pendingWorkBlock=next,
 			// produced no task, and has been outstanding well past a normal build.
-			name:              "wedged build, outstanding past threshold -> recommit",
-			pendingWorkBlock:  next,
-			hasPendingTasks:   false,
-			chainAgeSec:       bigAge,
-			pendingWorkAgeSec: 5 * timeout,
-			want:              veblopRecommit,
+			name:             "wedged build, outstanding past threshold -> recommit",
+			pendingWorkBlock: next,
+			hasPendingTasks:  false,
+			chainAge:         bigAge,
+			veblopTimeout:    timeout,
+			pendingWorkAge:   5 * timeout,
+			stallThreshold:   stallAfter,
+			want:             veblopRecommit,
 		},
 		{
 			// THE REGRESSION GUARD: at genesis chainAge is huge, but the build was
 			// just submitted and is still in progress — must NOT be interrupted.
-			name:              "in-progress build at genesis (huge chainAge, fresh build) -> wait",
-			pendingWorkBlock:  next,
-			hasPendingTasks:   false,
-			chainAgeSec:       bigAge,
-			pendingWorkAgeSec: 0,
-			want:              veblopWait,
+			name:             "in-progress build at genesis (huge chainAge, fresh build) -> wait",
+			pendingWorkBlock: next,
+			hasPendingTasks:  false,
+			chainAge:         bigAge,
+			veblopTimeout:    timeout,
+			pendingWorkAge:   0,
+			stallThreshold:   stallAfter,
+			want:             veblopWait,
 		},
 		{
-			name:              "task in flight for next block -> skip",
-			pendingWorkBlock:  next,
-			hasPendingTasks:   true,
-			chainAgeSec:       bigAge,
-			pendingWorkAgeSec: 10 * timeout,
-			want:              veblopSkip,
+			name:             "task in flight for next block -> skip",
+			pendingWorkBlock: next,
+			hasPendingTasks:  true,
+			chainAge:         bigAge,
+			veblopTimeout:    timeout,
+			pendingWorkAge:   10 * timeout,
+			stallThreshold:   stallAfter,
+			want:             veblopSkip,
 		},
 		{
 			// Nothing claimed for next block and chain stale -> resubmit.
-			name:              "no work claimed, stale -> recommit",
-			pendingWorkBlock:  0,
-			hasPendingTasks:   false,
-			chainAgeSec:       timeout,
-			pendingWorkAgeSec: 0,
-			want:              veblopRecommit,
+			name:             "no work claimed, stale -> recommit",
+			pendingWorkBlock: 0,
+			hasPendingTasks:  false,
+			chainAge:         timeout,
+			veblopTimeout:    timeout,
+			pendingWorkAge:   0,
+			stallThreshold:   stallAfter,
+			want:             veblopRecommit,
 		},
 		{
 			// Nothing claimed but chain still fresh -> wait.
-			name:              "no work claimed, fresh -> wait",
-			pendingWorkBlock:  0,
-			hasPendingTasks:   false,
-			chainAgeSec:       timeout - 1,
-			pendingWorkAgeSec: 0,
-			want:              veblopWait,
+			name:             "no work claimed, fresh -> wait",
+			pendingWorkBlock: 0,
+			hasPendingTasks:  false,
+			chainAge:         timeout - time.Millisecond,
+			veblopTimeout:    timeout,
+			pendingWorkAge:   0,
+			stallThreshold:   stallAfter,
+			want:             veblopWait,
 		},
 		{
 			// A task is sealing and pendingWorkBlock was already cleared by
 			// commitWork's deferred reset -> never resubmit on top of it.
-			name:              "task sealing, pendingWorkBlock cleared -> skip",
-			pendingWorkBlock:  0,
-			hasPendingTasks:   true,
-			chainAgeSec:       bigAge,
-			pendingWorkAgeSec: 0,
-			want:              veblopSkip,
+			name:             "task sealing, pendingWorkBlock cleared -> skip",
+			pendingWorkBlock: 0,
+			hasPendingTasks:  true,
+			chainAge:         bigAge,
+			veblopTimeout:    timeout,
+			pendingWorkAge:   0,
+			stallThreshold:   stallAfter,
+			want:             veblopSkip,
 		},
 		{
-			name:              "wedge boundary: outstanding exactly at threshold -> recommit",
-			pendingWorkBlock:  next,
-			hasPendingTasks:   false,
-			chainAgeSec:       bigAge,
-			pendingWorkAgeSec: stallAfter,
-			want:              veblopRecommit,
+			name:             "wedge boundary: outstanding exactly at threshold -> recommit",
+			pendingWorkBlock: next,
+			hasPendingTasks:  false,
+			chainAge:         bigAge,
+			veblopTimeout:    timeout,
+			pendingWorkAge:   stallAfter,
+			want:             veblopRecommit,
+			stallThreshold:   stallAfter,
 		},
 		{
-			name:              "wedge boundary: just below threshold -> wait",
-			pendingWorkBlock:  next,
-			hasPendingTasks:   false,
-			chainAgeSec:       bigAge,
-			pendingWorkAgeSec: stallAfter - 1,
-			want:              veblopWait,
+			name:             "wedge boundary: just below threshold -> wait",
+			pendingWorkBlock: next,
+			hasPendingTasks:  false,
+			chainAge:         bigAge,
+			veblopTimeout:    timeout,
+			pendingWorkAge:   stallAfter - time.Millisecond,
+			stallThreshold:   stallAfter,
+			want:             veblopWait,
+		},
+		{
+			// SUB-SECOND PRECISION GUARD (mainnet runs a 1.5s block time): the
+			// threshold is 3x1.5s = 4.5s. A build outstanding 4s is still live and
+			// must wait; whole-second truncation would have set the threshold to
+			// 3x1s = 3s and wrongly interrupted it at 4s.
+			name:             "1.5s block time: 4s-old build is below 4.5s threshold -> wait",
+			pendingWorkBlock: next,
+			hasPendingTasks:  false,
+			chainAge:         bigAge,
+			veblopTimeout:    1500 * time.Millisecond,
+			pendingWorkAge:   4 * time.Second,
+			stallThreshold:   3 * 1500 * time.Millisecond,
+			want:             veblopWait,
+		},
+		{
+			// Same 1.5s block time: once the build passes 4.5s it is wedged.
+			name:             "1.5s block time: 5s-old build is past 4.5s threshold -> recommit",
+			pendingWorkBlock: next,
+			hasPendingTasks:  false,
+			chainAge:         bigAge,
+			veblopTimeout:    1500 * time.Millisecond,
+			pendingWorkAge:   5 * time.Second,
+			stallThreshold:   3 * 1500 * time.Millisecond,
+			want:             veblopRecommit,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := decideVeblopFallback(tt.pendingWorkBlock, next, tt.hasPendingTasks, tt.chainAgeSec, timeout, tt.pendingWorkAgeSec, stallAfter)
+			got := decideVeblopFallback(tt.pendingWorkBlock, next, tt.hasPendingTasks, tt.chainAge, tt.veblopTimeout, tt.pendingWorkAge, tt.stallThreshold)
 			if got != tt.want {
-				t.Fatalf("decideVeblopFallback(pwb=%d, next=%d, hasTasks=%v, chainAge=%d, timeout=%d, workAge=%d, stallAfter=%d) = %d, want %d",
-					tt.pendingWorkBlock, next, tt.hasPendingTasks, tt.chainAgeSec, timeout, tt.pendingWorkAgeSec, stallAfter, got, tt.want)
+				t.Fatalf("decideVeblopFallback(pwb=%d, next=%d, hasTasks=%v, chainAge=%v, timeout=%v, workAge=%v, stall=%v) = %d, want %d",
+					tt.pendingWorkBlock, next, tt.hasPendingTasks, tt.chainAge, tt.veblopTimeout, tt.pendingWorkAge, tt.stallThreshold, got, tt.want)
 			}
 		})
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -754,12 +754,18 @@ const (
 // alone, so case (b) never recovered without a process restart.
 //
 // These two cases are distinguished ONLY by how long the build has been
-// outstanding (pendingWorkAgeSec = time since the build was submitted), NOT by
-// block-timestamp age (chainAgeSec is meaningless when the head carries an old
+// outstanding (pendingWorkAge = time since the build was submitted), NOT by
+// block-timestamp age (chainAge is meaningless when the head carries an old
 // timestamp, e.g. at genesis). We recover only once the outstanding build clearly
-// exceeds a normal build duration (stallThresholdSec), so a slow-but-live build is
+// exceeds a normal build duration (stallThreshold), so a slow-but-live build is
 // never interrupted.
-func decideVeblopFallback(pendingWorkBlock, nextBlock uint64, hasPendingTasks bool, chainAgeSec, veblopTimeoutSec, pendingWorkAgeSec, stallThresholdSec int64) veblopFallbackDecision {
+//
+// All durations are compared at their native resolution: pendingWorkAge is real
+// elapsed wall-clock (sub-second precise), so the threshold stays accurate at the
+// sub-second block times mainnet runs (miner block time is 1.5s). chainAge is the
+// exception — it derives from integer block timestamps, so it is inherently
+// second-granular regardless of representation.
+func decideVeblopFallback(pendingWorkBlock, nextBlock uint64, hasPendingTasks bool, chainAge, veblopTimeout, pendingWorkAge, stallThreshold time.Duration) veblopFallbackDecision {
 	// A sealing task is in flight; never interrupt it.
 	if hasPendingTasks {
 		return veblopSkip
@@ -767,13 +773,13 @@ func decideVeblopFallback(pendingWorkBlock, nextBlock uint64, hasPendingTasks bo
 	if pendingWorkBlock == nextBlock {
 		// Build outstanding for the next block. Recover only if it has been
 		// outstanding long enough to be considered wedged rather than in-progress.
-		if pendingWorkAgeSec >= stallThresholdSec {
+		if pendingWorkAge >= stallThreshold {
 			return veblopRecommit
 		}
 		return veblopWait
 	}
 	// Nothing is claimed for the next block — resubmit once the chain is stale.
-	if chainAgeSec >= veblopTimeoutSec {
+	if chainAge >= veblopTimeout {
 		return veblopRecommit
 	}
 	return veblopWait
@@ -905,28 +911,33 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 			chainAgeSec := time.Now().Unix() - int64(currentBlock.Time)
 			lastStallWarnAt = w.warnIfStalled(currentBlock, chainAgeSec, veblopTimeout, pendingWorkBlock, pendingTasksCount, lastStallWarnAt)
 
-			veblopTimeoutSec := int64(veblopTimeout.Seconds())
-			if veblopTimeoutSec < 1 {
-				veblopTimeoutSec = 1
+			// veblopTimeout is already floored to the miner block time by commit();
+			// guard only the degenerate non-positive case so the threshold can't
+			// collapse to zero and interrupt builds instantly. Do NOT round up to a
+			// whole second — that would break sub-second block times.
+			effTimeout := veblopTimeout
+			if effTimeout <= 0 {
+				effTimeout = time.Second
 			}
 			// A build is treated as wedged only after it has been outstanding for
-			// noticeably longer than a normal build (matches warnIfStalled's
-			// 3x-timeout stale threshold), so a slow-but-live build is never
-			// interrupted. Measured from submit time, not block-timestamp age.
-			stallThresholdSec := 3 * veblopTimeoutSec
-			pendingWorkAgeSec := int64(0)
+			// noticeably longer than a normal build (~3x the block period, the same
+			// staleness multiple warnIfStalled uses), so a slow-but-live build is
+			// never interrupted. Measured from submit time, not block-timestamp age,
+			// at full sub-second resolution.
+			stallThreshold := 3 * effTimeout
+			var pendingWorkAge time.Duration
 			if !pendingWorkSubmittedAt.IsZero() {
-				pendingWorkAgeSec = int64(time.Since(pendingWorkSubmittedAt).Seconds())
+				pendingWorkAge = time.Since(pendingWorkSubmittedAt)
 			}
 
 			switch decideVeblopFallback(
 				pendingWorkBlock,
 				currentBlock.Number.Uint64()+1,
 				hasPendingTasks,
-				chainAgeSec,
-				veblopTimeoutSec,
-				pendingWorkAgeSec,
-				stallThresholdSec,
+				time.Duration(chainAgeSec)*time.Second,
+				effTimeout,
+				pendingWorkAge,
+				stallThreshold,
 			) {
 			case veblopRecommit:
 				// No sealing task is in flight and the producer is not making
@@ -3111,7 +3122,11 @@ func (w *worker) clearPending(number uint64) {
 // be captured under pendingMu by the caller — reading it here unguarded
 // would race with taskLoop / resultLoop.
 func (w *worker) warnIfStalled(currentBlock *types.Header, chainAgeSec int64, veblopTimeout time.Duration, pendingWorkBlock uint64, pendingTasksCount int, lastWarnAt time.Time) time.Time {
-	if chainAgeSec <= 3*int64(veblopTimeout.Seconds()) {
+	// Compare in time.Duration so the 3x staleness threshold honors sub-second
+	// block times (mainnet runs a 1.5s block time) — the same 3x multiple the
+	// recovery path in decideVeblopFallback uses. chainAge itself is inherently
+	// second-granular (it derives from integer block timestamps).
+	if time.Duration(chainAgeSec)*time.Second <= 3*veblopTimeout {
 		return lastWarnAt
 	}
 	if pendingWorkBlock != currentBlock.Number.Uint64()+1 && pendingTasksCount == 0 {
@@ -3123,7 +3138,7 @@ func (w *worker) warnIfStalled(currentBlock *types.Header, chainAgeSec int64, ve
 	log.Warn("Possible producer stall: veblop fallback skipping while chain is stale",
 		"currentBlock", currentBlock.Number.Uint64(),
 		"chainAgeSec", chainAgeSec,
-		"veblopTimeoutSec", int64(veblopTimeout.Seconds()),
+		"veblopTimeout", veblopTimeout,
 		"pendingWorkBlock", pendingWorkBlock,
 		"pendingTasksCount", pendingTasksCount,
 		"peerCount", w.eth.PeerCount())

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -725,6 +725,60 @@ func recalcRecommit(minRecommit, prev time.Duration, target float64, inc bool) t
 	return prev
 }
 
+// veblopFallbackDecision is the action the veblop stall-fallback takes when its
+// timer fires. See decideVeblopFallback.
+type veblopFallbackDecision int
+
+const (
+	// veblopWait: the next block is being built normally (chain not yet stale)
+	// or work is otherwise progressing — just rearm the timer.
+	veblopWait veblopFallbackDecision = iota
+	// veblopSkip: a sealing task is genuinely in flight for the next block —
+	// nothing to do.
+	veblopSkip
+	// veblopRecommit: the chain is stale and there is no sealing task in flight,
+	// so the producer must (re)submit work to make progress.
+	veblopRecommit
+)
+
+// decideVeblopFallback decides what the veblop stall-fallback should do when its
+// timer fires. It is a pure function so the decision can be unit-tested without
+// driving the whole newWorkLoop.
+//
+// The critical case is `pendingWorkBlock == nextBlock && !hasPendingTasks`: a
+// previous build pinned pendingWorkBlock (commitWork only clears it via a
+// deferred Store(0) that runs on return) but produced no sealing task. This can
+// mean either (a) a build is legitimately in progress and just hasn't registered
+// its task yet, or (b) the build wedged inside commitWork and never will — the
+// mainnet stall. The old logic skipped recovery on `pendingWorkBlock == nextBlock`
+// alone, so case (b) never recovered without a process restart.
+//
+// These two cases are distinguished ONLY by how long the build has been
+// outstanding (pendingWorkAgeSec = time since the build was submitted), NOT by
+// block-timestamp age (chainAgeSec is meaningless when the head carries an old
+// timestamp, e.g. at genesis). We recover only once the outstanding build clearly
+// exceeds a normal build duration (stallThresholdSec), so a slow-but-live build is
+// never interrupted.
+func decideVeblopFallback(pendingWorkBlock, nextBlock uint64, hasPendingTasks bool, chainAgeSec, veblopTimeoutSec, pendingWorkAgeSec, stallThresholdSec int64) veblopFallbackDecision {
+	// A sealing task is in flight; never interrupt it.
+	if hasPendingTasks {
+		return veblopSkip
+	}
+	if pendingWorkBlock == nextBlock {
+		// Build outstanding for the next block. Recover only if it has been
+		// outstanding long enough to be considered wedged rather than in-progress.
+		if pendingWorkAgeSec >= stallThresholdSec {
+			return veblopRecommit
+		}
+		return veblopWait
+	}
+	// Nothing is claimed for the next block — resubmit once the chain is stale.
+	if chainAgeSec >= veblopTimeoutSec {
+		return veblopRecommit
+	}
+	return veblopWait
+}
+
 // newWorkLoop is a standalone goroutine to submit new sealing work upon received events.
 //
 //nolint:gocognit
@@ -741,6 +795,11 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		// emitted a stall warning so the log isn't flooded while the
 		// producer is stuck.
 		lastStallWarnAt time.Time
+		// pendingWorkSubmittedAt records when we last submitted a sealing build
+		// for the next block. The veblop fallback uses time-since-submit (not
+		// block-timestamp age) to tell a wedged build apart from one that is
+		// simply still in progress.
+		pendingWorkSubmittedAt time.Time
 	)
 
 	timer := time.NewTimer(0)
@@ -755,17 +814,38 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 	defer veblopTimer.Stop()
 
 	// commit aborts in-flight transaction execution with given signal and resubmits a new one.
-	commit := func(noempty bool, s int32) {
+	// It returns true if the new work request was submitted to mainLoop.
+	//
+	// When nonblocking is true the request is sent with a non-blocking send: if
+	// mainLoop is not currently ready to receive (e.g. it is wedged inside
+	// commitWork — exactly the state that pins pendingWorkBlock with no pending
+	// task), the request is dropped and commit returns false instead of blocking
+	// newWorkLoop on the unbuffered newWorkCh. This keeps newWorkLoop alive so it
+	// keeps emitting the stall warning and retrying every tick.
+	commit := func(noempty bool, s int32, nonblocking bool) bool {
 		if interrupt != nil {
 			interrupt.Store(s)
 		}
 
-		interrupt = new(atomic.Int32)
-		select {
-		case w.newWorkCh <- &newWorkReq{interrupt: interrupt, timestamp: timestamp, noempty: noempty}:
-		case <-w.exitCh:
-			return
+		newInterrupt := new(atomic.Int32)
+		req := &newWorkReq{interrupt: newInterrupt, timestamp: timestamp, noempty: noempty}
+		if nonblocking {
+			select {
+			case w.newWorkCh <- req:
+			case <-w.exitCh:
+				return false
+			default:
+				// mainLoop not ready (busy or wedged); don't block.
+				return false
+			}
+		} else {
+			select {
+			case w.newWorkCh <- req:
+			case <-w.exitCh:
+				return false
+			}
 		}
+		interrupt = newInterrupt
 		timer.Reset(recommit)
 		veblopTimeout = time.Duration(w.chainConfig.Bor.CalculatePeriod(w.chain.CurrentBlock().Number.Uint64())) * time.Second
 		if veblopTimeout < w.blockTime {
@@ -773,6 +853,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		}
 		veblopTimer.Reset(veblopTimeout)
 		w.newTxs.Store(0)
+		return true
 	}
 
 	for {
@@ -782,7 +863,8 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 
 			timestamp = time.Now().Unix()
 			w.pendingWorkBlock.Store(w.chain.CurrentBlock().Number.Uint64() + 1)
-			commit(false, commitInterruptNewHead)
+			pendingWorkSubmittedAt = time.Now()
+			commit(false, commitInterruptNewHead, false)
 
 		case head := <-w.chainHeadCh:
 			w.clearPending(head.Header.Number.Uint64())
@@ -795,7 +877,8 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 
 			timestamp = time.Now().Unix()
 			w.pendingWorkBlock.Store(head.Header.Number.Uint64() + 1)
-			commit(false, commitInterruptNewHead)
+			pendingWorkSubmittedAt = time.Now()
+			commit(false, commitInterruptNewHead, false)
 
 		case <-veblopTimer.C:
 			currentBlock := w.chain.CurrentBlock()
@@ -819,19 +902,51 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 			hasPendingTasks := pendingTasksCount > 0
 
 			pendingWorkBlock := w.pendingWorkBlock.Load()
-			lastStallWarnAt = w.warnIfStalled(currentBlock, time.Now().Unix()-int64(currentBlock.Time), veblopTimeout, pendingWorkBlock, pendingTasksCount, lastStallWarnAt)
-			if pendingWorkBlock == currentBlock.Number.Uint64()+1 {
-				// Next block is already being worked on, reset the timer.
-				veblopTimer.Reset(veblopTimeout)
-				continue
+			chainAgeSec := time.Now().Unix() - int64(currentBlock.Time)
+			lastStallWarnAt = w.warnIfStalled(currentBlock, chainAgeSec, veblopTimeout, pendingWorkBlock, pendingTasksCount, lastStallWarnAt)
+
+			veblopTimeoutSec := int64(veblopTimeout.Seconds())
+			if veblopTimeoutSec < 1 {
+				veblopTimeoutSec = 1
+			}
+			// A build is treated as wedged only after it has been outstanding for
+			// noticeably longer than a normal build (matches warnIfStalled's
+			// 3x-timeout stale threshold), so a slow-but-live build is never
+			// interrupted. Measured from submit time, not block-timestamp age.
+			stallThresholdSec := 3 * veblopTimeoutSec
+			pendingWorkAgeSec := int64(0)
+			if !pendingWorkSubmittedAt.IsZero() {
+				pendingWorkAgeSec = int64(time.Since(pendingWorkSubmittedAt).Seconds())
 			}
 
-			if !hasPendingTasks && time.Now().Unix()-int64(currentBlock.Time) >= int64(veblopTimeout.Seconds()) {
+			switch decideVeblopFallback(
+				pendingWorkBlock,
+				currentBlock.Number.Uint64()+1,
+				hasPendingTasks,
+				chainAgeSec,
+				veblopTimeoutSec,
+				pendingWorkAgeSec,
+				stallThresholdSec,
+			) {
+			case veblopRecommit:
+				// No sealing task is in flight and the producer is not making
+				// progress — either nothing is claimed for the next block, or a
+				// build wedged inside commitWork and left pendingWorkBlock pinned.
+				// Resubmit with a non-blocking send so newWorkLoop never wedges on
+				// the unbuffered newWorkCh if mainLoop is itself blocked; only claim
+				// pendingWorkBlock once the request is actually accepted.
 				timestamp = time.Now().Unix()
-				w.pendingWorkBlock.Store(currentBlock.Number.Uint64() + 1)
-				commit(false, commitInterruptNewHead)
-				// veblopTimer is already reset by commit() so we don't need to reset it here.
-			} else {
+				if commit(false, commitInterruptNewHead, true) {
+					w.pendingWorkBlock.Store(currentBlock.Number.Uint64() + 1)
+					pendingWorkSubmittedAt = time.Now()
+				} else {
+					// mainLoop not ready; retry on the next tick.
+					veblopTimer.Reset(veblopTimeout)
+				}
+				// On success commit() already reset veblopTimer.
+			default:
+				// veblopSkip (task genuinely in flight) or veblopWait (chain not
+				// yet stale) — nothing to submit, just rearm the timer.
 				veblopTimer.Reset(veblopTimeout)
 			}
 


### PR DESCRIPTION
## Problem

While stress-testing the veblop block-production path, a producer can enter a permanent stall: it stops producing/importing at a fixed height and recovers only after a process restart. Symptoms are `Possible producer stall: veblop fallback skipping while chain is stale` logged repeatedly with a static `currentBlock` and `pendingTasksCount=0` — the producer's own stall detector fires, but the fallback never actually recovers.

## Root cause

`newWorkLoop`'s veblop stall-fallback skipped recovery whenever `pendingWorkBlock == currentBlock+1`, treating that value as proof the next block was being built. But `commitWork` only clears `pendingWorkBlock` via a `defer ...Store(0)` that runs **on return**. If a build blocks inside `commitWork` and never returns, `pendingWorkBlock` stays pinned at `currentBlock+1` with **no sealing task** (`pendingTasks` empty). In that state the fallback short-circuited forever — the producer never resubmitted work, and the only escape was a restart.

(A build blocking inside `commitWork` is a separate concern being investigated independently. This PR addresses the recovery path so that such a hang is no longer permanent.)

## Fix

- The fallback now treats `pendingWorkBlock == next` as "work in flight" **only when a sealing task actually backs it**. When `pendingWorkBlock == next` but no task exists, it distinguishes a *wedged* build from a *slow-but-live* one by **how long the build has been outstanding** (time since submit), not by block-timestamp age (`chainAge` is meaningless when the head carries an old timestamp, e.g. genesis). Recovery fires only past a 3×-blocktime threshold, so a live build is never interrupted.
- The fallback re-commit uses a **non-blocking** send, so `newWorkLoop` cannot itself wedge on the unbuffered `newWorkCh` when `mainLoop` is the blocked goroutine. It keeps emitting the stall warning and retrying every tick, and auto-recovers the moment `mainLoop` is unblocked.
- The decision is extracted into a pure `decideVeblopFallback` function so it can be unit-tested without driving the whole loop.

## Testing

- New table-driven unit test `TestDecideVeblopFallback` covering: the wedged-build case (the bug), the genesis in-progress-build case (regression guard against interrupting a live build), task-in-flight, the no-work-claimed paths, and the wedge threshold boundaries.
- Verified as a true regression test: the suite goes **red** against the pre-fix logic (the wedged-build cases return "skip" instead of "recommit") and **green** against this fix.
- Full `miner/` package suite passes (this caught an over-aggressive first attempt that used `chainAge` and interrupted live builds at genesis).

## Scope / follow-ups

This restores producer-loop liveness and auto-recovery once the underlying build unblocks. It does **not** by itself resolve a hard `mainLoop` deadlock; that underlying build-blocking concern is tracked separately.
