### PR TITLE
core/rawdb: avoid the freezer read-lock for recent header lookups

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -34,6 +34,13 @@ import (
 
 // ReadCanonicalHash retrieves the hash assigned to a canonical block number.
 func ReadCanonicalHash(db ethdb.Reader, number uint64) common.Hash {
+	// Fast path: recent entries live in the key-value store and are removed only
+	// after being copied to the freezer (chainFreezer.freeze), so a KV hit is
+	// always valid. Reading KV first lets recent lookups skip the freezer
+	// read-lock and avoid serializing behind an in-progress freeze.
+	if data, _ := db.Get(headerHashKey(number)); len(data) > 0 {
+		return common.BytesToHash(data)
+	}
 	var data []byte
 	db.ReadAncients(func(reader ethdb.AncientReaderOp) error {
 		data, _ = reader.Ancient(ChainFreezerHashTable, number)
@@ -406,6 +413,14 @@ func ReadHeaderRange(db ethdb.Reader, number uint64, count uint64) []rlp.RawValu
 
 // ReadHeaderRLP retrieves a block header in its raw RLP database encoding.
 func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {
+	// Fast path: recent entries live in the key-value store (keyed by number+hash)
+	// and are removed only after being copied to the freezer (chainFreezer.freeze),
+	// so a KV hit is always valid. Reading KV first lets recent lookups skip the
+	// freezer read-lock and avoid serializing behind an in-progress freeze.
+	if data, _ := db.Get(headerKey(number, hash)); len(data) > 0 {
+		return data
+	}
+
 	var data []byte
 
 	_ = db.ReadAncients(func(reader ethdb.AncientReaderOp) error {
@@ -607,6 +622,13 @@ func DeleteBody(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
 
 // ReadTdRLP retrieves a block's total difficulty corresponding to the hash in RLP encoding.
 func ReadTdRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {
+	// Fast path: recent entries live in the key-value store (keyed by number+hash)
+	// and are removed only after being copied to the freezer (chainFreezer.freeze),
+	// so a KV hit is always valid. Reading KV first lets recent lookups skip the
+	// freezer read-lock and avoid serializing behind an in-progress freeze.
+	if data, _ := db.Get(headerTDKey(number, hash)); len(data) > 0 {
+		return data
+	}
 	var data []byte
 	db.ReadAncients(func(reader ethdb.AncientReaderOp) error {
 		// Check if the data is in ancients

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -33,11 +33,11 @@ import (
 )
 
 // readRecentFromKV returns the value stored under key in the key-value store,
-// or nil if absent. Recent canonical-hash, header and total-difficulty entries
-// live in the key-value store and are removed only after being copied to the
-// freezer (chainFreezer.freeze), so a key-value hit is always valid. Reading the
-// key-value store first lets recent lookups skip the freezer read-lock instead
-// of serializing behind an in-progress freeze.
+// or nil if absent. Canonical entries are moved to the freezer before being
+// deleted from the key-value store (chainFreezer.freeze).
+// Non-canonical entries are KV-only. Reading the key-value store first lets
+// recent lookups skip the freezer read-lock
+// instead of serializing behind an in-progress freeze.
 func readRecentFromKV(db ethdb.KeyValueReader, key []byte) []byte {
 	data, _ := db.Get(key)
 	return data

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -32,13 +32,20 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
+// readRecentFromKV returns the value stored under key in the key-value store,
+// or nil if absent. Recent canonical-hash, header and total-difficulty entries
+// live in the key-value store and are removed only after being copied to the
+// freezer (chainFreezer.freeze), so a key-value hit is always valid. Reading the
+// key-value store first lets recent lookups skip the freezer read-lock instead
+// of serializing behind an in-progress freeze.
+func readRecentFromKV(db ethdb.KeyValueReader, key []byte) []byte {
+	data, _ := db.Get(key)
+	return data
+}
+
 // ReadCanonicalHash retrieves the hash assigned to a canonical block number.
 func ReadCanonicalHash(db ethdb.Reader, number uint64) common.Hash {
-	// Fast path: recent entries live in the key-value store and are removed only
-	// after being copied to the freezer (chainFreezer.freeze), so a KV hit is
-	// always valid. Reading KV first lets recent lookups skip the freezer
-	// read-lock and avoid serializing behind an in-progress freeze.
-	if data, _ := db.Get(headerHashKey(number)); len(data) > 0 {
+	if data := readRecentFromKV(db, headerHashKey(number)); len(data) > 0 {
 		return common.BytesToHash(data)
 	}
 	var data []byte
@@ -413,11 +420,7 @@ func ReadHeaderRange(db ethdb.Reader, number uint64, count uint64) []rlp.RawValu
 
 // ReadHeaderRLP retrieves a block header in its raw RLP database encoding.
 func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {
-	// Fast path: recent entries live in the key-value store (keyed by number+hash)
-	// and are removed only after being copied to the freezer (chainFreezer.freeze),
-	// so a KV hit is always valid. Reading KV first lets recent lookups skip the
-	// freezer read-lock and avoid serializing behind an in-progress freeze.
-	if data, _ := db.Get(headerKey(number, hash)); len(data) > 0 {
+	if data := readRecentFromKV(db, headerKey(number, hash)); len(data) > 0 {
 		return data
 	}
 
@@ -622,11 +625,7 @@ func DeleteBody(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
 
 // ReadTdRLP retrieves a block's total difficulty corresponding to the hash in RLP encoding.
 func ReadTdRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {
-	// Fast path: recent entries live in the key-value store (keyed by number+hash)
-	// and are removed only after being copied to the freezer (chainFreezer.freeze),
-	// so a KV hit is always valid. Reading KV first lets recent lookups skip the
-	// freezer read-lock and avoid serializing behind an in-progress freeze.
-	if data, _ := db.Get(headerTDKey(number, hash)); len(data) > 0 {
+	if data := readRecentFromKV(db, headerTDKey(number, hash)); len(data) > 0 {
 		return data
 	}
 	var data []byte

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -25,12 +25,14 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/sha3"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -548,6 +550,97 @@ func TestAncientStorage(t *testing.T) {
 
 	if blob := ReadTdRLP(db, fakeHash, number); len(blob) != 0 {
 		t.Fatalf("invalid td returned")
+	}
+}
+
+// TestRecentReadsBypassFreezerLock verifies that lookups for recent (key-value
+// resident) blocks do not block on the freezer write-lock held by an in-progress
+// freeze. Reads of recent canonical hashes, headers and TDs must take the
+// leveldb fast path and return without acquiring the freezer read-lock.
+func TestRecentReadsBypassFreezerLock(t *testing.T) {
+	frdir := t.TempDir()
+
+	db, err := Open(NewMemoryDatabase(), OpenOptions{Ancient: frdir})
+	if err != nil {
+		t.Fatalf("failed to create database with ancient backend: %v", err)
+	}
+	defer db.Close()
+
+	// Write a recent block to the key-value store (not the freezer).
+	header := &types.Header{Number: big.NewInt(100), Extra: []byte("recent")}
+	hash, number := header.Hash(), header.Number.Uint64()
+	WriteHeader(db, header)
+	WriteCanonicalHash(db, hash, number)
+	WriteTd(db, hash, number, big.NewInt(42))
+
+	// Hold the freezer write-lock for the duration of the test, simulating an
+	// in-progress freeze. ModifyAncients holds the exclusive lock while fn runs.
+	held := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+
+	go func() {
+		_, _ = db.ModifyAncients(func(ethdb.AncientWriteOp) error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held // ensure the write-lock is actually held before reading
+
+	// Recent reads must complete while the freezer write-lock is held.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if got := ReadCanonicalHash(db, number); got != hash {
+			t.Errorf("canonical hash: got %x, want %x", got, hash)
+		}
+		if blob := ReadHeaderRLP(db, hash, number); len(blob) == 0 {
+			t.Errorf("header not returned via fast path")
+		}
+		if blob := ReadTdRLP(db, hash, number); len(blob) == 0 {
+			t.Errorf("td not returned via fast path")
+		}
+	}()
+
+	select {
+	case <-done:
+		// Reads completed without the freezer read-lock — fast path works.
+	case <-time.After(5 * time.Second):
+		t.Fatal("recent reads blocked on the freezer write-lock; leveldb fast path not taken")
+	}
+}
+
+// TestReadCanonicalHashAncientFallback ensures ReadCanonicalHash still resolves
+// a frozen entry via the ancient store when it is absent from the key-value
+// store: the leveldb fast path must fall through on a miss rather than return
+// the zero hash.
+func TestReadCanonicalHashAncientFallback(t *testing.T) {
+	frdir := t.TempDir()
+
+	db, err := Open(NewMemoryDatabase(), OpenOptions{Ancient: frdir})
+	if err != nil {
+		t.Fatalf("failed to create database with ancient backend: %v", err)
+	}
+	defer db.Close()
+
+	block := types.NewBlockWithHeader(&types.Header{
+		Number:      big.NewInt(0),
+		Extra:       []byte("test block"),
+		UncleHash:   types.EmptyUncleHash,
+		TxHash:      types.EmptyTxsHash,
+		ReceiptHash: types.EmptyReceiptsHash,
+	})
+	WriteAncientBlocks(db, []*types.Block{block}, types.EncodeBlockReceiptLists([]types.Receipts{nil}), types.EncodeBlockReceiptLists([]types.Receipts{nil}), big.NewInt(100))
+
+	// The canonical hash lives only in the ancient store (never written to
+	// leveldb), so the fast path must miss and fall through to it.
+	if got := ReadCanonicalHash(db, block.NumberU64()); got != block.Hash() {
+		t.Fatalf("frozen canonical hash: got %x, want %x", got, block.Hash())
+	}
+	// A number with no entry anywhere must return the zero hash.
+	if got := ReadCanonicalHash(db, 999); got != (common.Hash{}) {
+		t.Fatalf("missing canonical hash: got %x, want zero", got)
 	}
 }
 

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -577,16 +577,27 @@ func TestRecentReadsBypassFreezerLock(t *testing.T) {
 	// in-progress freeze. ModifyAncients holds the exclusive lock while fn runs.
 	held := make(chan struct{})
 	release := make(chan struct{})
+	modifyDone := make(chan error, 1)
 	defer close(release)
 
 	go func() {
-		_, _ = db.ModifyAncients(func(ethdb.AncientWriteOp) error {
+		_, err := db.ModifyAncients(func(ethdb.AncientWriteOp) error {
 			close(held)
 			<-release
 			return nil
 		})
+		modifyDone <- err
 	}()
-	<-held // ensure the write-lock is actually held before reading
+
+	// Wait until the write-lock is held, but fail fast rather than hang if
+	// ModifyAncients returns early or never acquires it.
+	select {
+	case <-held:
+	case err := <-modifyDone:
+		t.Fatalf("ModifyAncients returned before holding the write-lock: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the freezer write-lock to be held")
+	}
 
 	// Recent reads must complete while the freezer write-lock is held.
 	done := make(chan struct{})


### PR DESCRIPTION
## Summary

`ReadCanonicalHash`, `ReadHeaderRLP`, and `ReadTdRLP` wrap every lookup in `db.ReadAncients`, which acquires the freezer's `writeLock.RLock`. A freeze cycle (`ModifyAncients`) holds the exclusive `writeLock` while it writes a batch to the ancient store and fsyncs it — so during a freeze, every header/canonical-hash/TD read blocks until it finishes.

Recent blocks are never in the freezer, so this reads the key-value store first and only falls through to the (unchanged) ancient path on a miss. Recent lookups no longer touch the freezer lock.

`chainFreezer.freeze` writes a block to the ancient store before deleting it from the key-value store, so a KV miss is always covered by the ancient read — there is no window where a block is in neither. The locked ancient path is unchanged; only an unlocked KV fast path is added in front.

On a Polygon validator, the Heimdall milestone-proposition path (`GetBorChainBlockInfoInBatch` → `HeaderByNumber` → `ReadAncients`) hit its bor RPC deadline whenever a freeze held the lock, so the vote extension shipped without a milestone proposition.

### Contention

Before
<img width="1124" height="872" alt="01-contention-before" src="https://github.com/user-attachments/assets/b031f60d-9696-4592-95d8-d5b21da1cc10" />

After
<img width="1237" height="726" alt="02-contention-after" src="https://github.com/user-attachments/assets/2d6d36d8-7154-40ca-9dbe-a139c1103f8a" />

Executed tests

- go test -race ./core/rawdb/ — full package green.
- `TestRecentReadsBypassFreezerLock` — reproduces the contention: holds the freezer writeLock and asserts recent reads still return. Fails on `develop` (read blocks, 5s timeout); passes with this change.
- `TestReadCanonicalHashAncientFallback` — confirms the ancient fallback still resolves frozen entries absent from the KV store.
- `diffguard` mutation testing: 100% (9/9 killed), Tier-1 logic 100%; all gates PASS.

Production verification (Polygon mainnet validator, 14h+ soak)

pprof on the running node + Heimdall logs, before vs after deploy:

<img width="1505" height="481" alt="03-metrics-before-after" src="https://github.com/user-attachments/assets/29d836e5-1d08-49a7-bec6-3bc97a91cbf5" />

Rollout notes

- Not consensus-affecting. Read-path only; the ancient fallback and all write paths are unchanged, and return values are identical to before.
- Backwards-compatible. No DB format, schema, or wire changes. No coordinated upgrade required.
- Not operator-facing. No config or flag changes.