### PR TITLE
core/state, core: exact-writer validation for v2 destruction-resolved reads

### DIFF
--- a/core/state/parallel_read_invariants_test.go
+++ b/core/state/parallel_read_invariants_test.go
@@ -155,3 +155,122 @@ func TestParallelReadRecordingCompleteness(t *testing.T) {
 		})
 	}
 }
+
+// TestParallelExactWriterAcrossDestruction pins the fix for value-equality
+// masking a reordered writer across a destruction boundary. For a read resolved
+// relative to a prior SELFDESTRUCT (writerIdx vs suicideIdx) and for the
+// existence markers, the winning writer's *position* — not just its value —
+// determines the result. So when the winning writer changes to one producing an
+// EQUAL value, validation must still fail; accepting it by value equality
+// settles a stale read and diverges from serial.
+//
+// Each case stages the metamorphic shape at the MVStore level: tx0 creates the
+// account and SELFDESTRUCTs it (write at idx 0 + SuicidePath at idx 0), tx2
+// re-creates it with an equal value, the read observes tx2's value, then tx2's
+// write is withdrawn (re-execution) so the winner falls back to tx0 — which is
+// at/below the destruction and therefore wiped. The recorded read must be
+// rejected. The destructor sits at tx index 0 on purpose: that is the exact
+// suicideIdx>=0 boundary, so a `>0` regression (which would drop ExactWriter
+// when the destruction is the first tx) is caught here too.
+func TestParallelExactWriterAcrossDestruction(t *testing.T) {
+	addr := common.HexToAddress("0x00000000000000000000000000000000000000e0")
+	slot := common.HexToHash("0x01")
+	codeKey := blockstm.NewSubpathKey(addr, CodePath)
+	nonceKey := blockstm.NewSubpathKey(addr, NoncePath)
+	stateKey := blockstm.NewStateKey(addr, slot)
+	createKey := blockstm.NewSubpathKey(addr, CreatePath)
+	suicideKey := blockstm.NewSubpathKey(addr, SuicidePath)
+	code := []byte{0x60, 0x00}
+	stateVal := common.HexToHash("0x2a")
+
+	cases := []struct {
+		name string
+		key  blockstm.Key // the read's key, withdrawn after the read to move the winner
+		// pre stages tx0's create+suicide and tx2's equal-valued re-create.
+		pre  func(s *blockstm.MVStore)
+		read func(p *ParallelStateDB)
+	}{
+		{
+			name: "GetState",
+			key:  stateKey,
+			pre: func(s *blockstm.MVStore) {
+				s.WriteInc(suicideKey, 0, 0, true)
+				s.WriteInc(stateKey, 0, 0, stateVal)
+				s.WriteInc(stateKey, 2, 0, stateVal)
+			},
+			read: func(p *ParallelStateDB) { p.GetState(addr, slot) },
+		},
+		{
+			name: "GetCommittedState", // the diffguard-flagged site (parallel_statedb.go:947)
+			key:  stateKey,
+			pre: func(s *blockstm.MVStore) {
+				s.WriteInc(suicideKey, 0, 0, true)
+				s.WriteInc(stateKey, 0, 0, stateVal)
+				s.WriteInc(stateKey, 2, 0, stateVal)
+			},
+			read: func(p *ParallelStateDB) { p.GetCommittedState(addr, slot) },
+		},
+		{
+			name: "GetCode",
+			key:  codeKey,
+			pre: func(s *blockstm.MVStore) {
+				s.WriteInc(suicideKey, 0, 0, true)
+				s.WriteInc(codeKey, 0, 0, code)
+				s.WriteInc(codeKey, 2, 0, code)
+			},
+			read: func(p *ParallelStateDB) { p.GetCode(addr) },
+		},
+		{
+			name: "GetCodeHash",
+			key:  codeKey,
+			pre: func(s *blockstm.MVStore) {
+				s.WriteInc(suicideKey, 0, 0, true)
+				s.WriteInc(codeKey, 0, 0, code)
+				s.WriteInc(codeKey, 2, 0, code)
+			},
+			read: func(p *ParallelStateDB) { p.GetCodeHash(addr) },
+		},
+		{
+			name: "GetNonce",
+			key:  nonceKey,
+			pre: func(s *blockstm.MVStore) {
+				s.WriteInc(suicideKey, 0, 0, true)
+				s.WriteInc(nonceKey, 0, 0, uint64(7))
+				s.WriteInc(nonceKey, 2, 0, uint64(7))
+			},
+			read: func(p *ParallelStateDB) { p.GetNonce(addr) },
+		},
+		{
+			// Existence markers: their value is always true, so value equality is
+			// pure noise — only the writer's position carries information.
+			name: "Exist_CreatePathMarker",
+			key:  createKey,
+			pre: func(s *blockstm.MVStore) {
+				s.WriteInc(suicideKey, 0, 0, true)
+				s.WriteInc(createKey, 0, 0, true)
+				s.WriteInc(createKey, 2, 0, true)
+			},
+			read: func(p *ParallelStateDB) { p.Exist(addr) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pdb, store, _ := newTestPDB(t, 5)
+			pdb.EnableReadTracking()
+
+			tc.pre(store)
+			tc.read(pdb)
+			// Re-execution of tx2 withdraws its write; the winner falls back to
+			// tx0, which is wiped by the same-index destruction. The recorded read
+			// (writer=2, equal value) must no longer validate.
+			store.Delete(tc.key, 2)
+
+			if res := pdb.ValidateDetailed(); res.Valid {
+				t.Fatalf("%s: a reordered writer across the destruction boundary produced an "+
+					"equal value and was accepted by value equality; the read must require an "+
+					"exact writer match and invalidate the tx", tc.name)
+			}
+		})
+	}
+}

--- a/core/state/parallel_statedb.go
+++ b/core/state/parallel_statedb.go
@@ -29,6 +29,15 @@ type StoreReadDesc struct {
 	WriterIdx int          // txIdx of writer (-1 = base)
 	WriterInc int          // incarnation of writer
 	StoreVal  interface{}  // actual value read (for value-based validation)
+	// ExactWriter disables the value-equality validation fallback for this
+	// read. Set when the winning writer's block-order position — not just its
+	// value — determined the read result: existence/ordering markers
+	// (CreatePath/SuicidePath) and any read resolved relative to a prior
+	// SELFDESTRUCT (writerIdx vs suicideIdx). For those reads a different
+	// writer producing an equal value can still flip the result (a reordered
+	// metamorphic CREATE2/SELFDESTRUCT moves the writer across the destruction
+	// boundary), so re-validation must require the same writer/incarnation.
+	ExactWriter bool
 }
 
 // BalReadDesc tracks a balance delta read for validation.
@@ -387,10 +396,17 @@ func (s *ParallelStateDB) EnableReadTracking() {
 }
 
 func (s *ParallelStateDB) recordStoreRead(key blockstm.Key, writerIdx, writerInc int, val interface{}) {
+	s.recordStoreReadEx(key, writerIdx, writerInc, val, false)
+}
+
+// recordStoreReadEx records a read, optionally marking it ExactWriter so
+// validation cannot accept a different writer by value equality. See
+// StoreReadDesc.ExactWriter.
+func (s *ParallelStateDB) recordStoreReadEx(key blockstm.Key, writerIdx, writerInc int, val interface{}, exact bool) {
 	if !s.trackReads {
 		return
 	}
-	s.StoreReads = append(s.StoreReads, StoreReadDesc{Key: key, WriterIdx: writerIdx, WriterInc: writerInc, StoreVal: val})
+	s.StoreReads = append(s.StoreReads, StoreReadDesc{Key: key, WriterIdx: writerIdx, WriterInc: writerInc, StoreVal: val, ExactWriter: exact})
 }
 
 func (s *ParallelStateDB) recordBalanceRead(addr common.Address, add, sub uint256.Int) {
@@ -548,12 +564,12 @@ func (s *ParallelStateDB) priorDestructedAt(addr common.Address) int {
 		}
 	}
 	suicideKey := blockstm.NewSubpathKey(addr, SuicidePath)
-	val, writerIdx, _, found := s.readStoreWait(suicideKey)
+	val, writerIdx, writerInc, found := s.readStoreWait(suicideKey)
 	idx := -1
 	if found {
 		idx = writerIdx
 		if _, seen := s.destructedSeen[addr]; !seen {
-			s.recordStoreRead(suicideKey, writerIdx, 0, val)
+			s.recordStoreReadEx(suicideKey, writerIdx, writerInc, val, true)
 		}
 	} else if _, seen := s.destructedSeen[addr]; !seen {
 		s.recordStoreRead(suicideKey, -1, 0, nil)
@@ -573,9 +589,9 @@ func (s *ParallelStateDB) priorDestructedAt(addr common.Address) int {
 // SELFDESTRUCT was followed by recreation.
 func (s *ParallelStateDB) priorCreatedAt(addr common.Address) int {
 	createKey := blockstm.NewSubpathKey(addr, CreatePath)
-	val, writerIdx, _, found := s.readStoreWait(createKey)
+	val, writerIdx, writerInc, found := s.readStoreWait(createKey)
 	if found {
-		s.recordStoreRead(createKey, writerIdx, 0, val)
+		s.recordStoreReadEx(createKey, writerIdx, writerInc, val, true)
 		return writerIdx
 	}
 	s.recordStoreRead(createKey, -1, 0, nil)
@@ -735,7 +751,7 @@ func (s *ParallelStateDB) GetNonce(addr common.Address) uint64 {
 	suicideIdx := s.priorDestructedAt(addr)
 	nonceKey := blockstm.NewSubpathKey(addr, NoncePath)
 	if val, writerIdx, writerInc, found := s.readStoreWait(nonceKey); found {
-		s.recordStoreRead(nonceKey, writerIdx, writerInc, val)
+		s.recordStoreReadEx(nonceKey, writerIdx, writerInc, val, suicideIdx >= 0)
 		// Only honor the nonce write if it landed AFTER the destruction.
 		// Otherwise the destruction wiped it.
 		if writerIdx > suicideIdx {
@@ -777,7 +793,7 @@ func (s *ParallelStateDB) GetCode(addr common.Address) []byte {
 	suicideIdx := s.priorDestructedAt(addr)
 	codeKey := blockstm.NewSubpathKey(addr, CodePath)
 	if val, writerIdx, writerInc, found := s.readCodeKey(addr, codeKey); found {
-		s.recordStoreRead(codeKey, writerIdx, writerInc, val)
+		s.recordStoreReadEx(codeKey, writerIdx, writerInc, val, suicideIdx >= 0)
 		if writerIdx > suicideIdx {
 			return val.([]byte)
 		}
@@ -813,7 +829,7 @@ func (s *ParallelStateDB) GetCodeHash(addr common.Address) common.Hash {
 	// value when the writer is later invalidated.
 	codeKey := blockstm.NewSubpathKey(addr, CodePath)
 	if val, writerIdx, writerInc, found := s.readCodeKey(addr, codeKey); found {
-		s.recordStoreRead(codeKey, writerIdx, writerInc, val)
+		s.recordStoreReadEx(codeKey, writerIdx, writerInc, val, suicideIdx >= 0)
 		// Honor the code write only if it happened after the destruction
 		// (otherwise the destruction wiped it).
 		if writerIdx > suicideIdx {
@@ -895,7 +911,7 @@ func (s *ParallelStateDB) GetState(addr common.Address, key common.Hash) common.
 	suicideIdx := s.priorDestructedAt(addr)
 	stateKey := blockstm.NewStateKey(addr, key)
 	if val, writerIdx, writerInc, found := s.readStoreWait(stateKey); found {
-		s.recordStoreRead(stateKey, writerIdx, writerInc, val)
+		s.recordStoreReadEx(stateKey, writerIdx, writerInc, val, suicideIdx >= 0)
 		// Honor the slot write only if it landed AFTER the destruction.
 		// Otherwise the destruction wiped storage and recreation alone
 		// doesn't restore old slots.
@@ -928,7 +944,7 @@ func (s *ParallelStateDB) GetCommittedState(addr common.Address, key common.Hash
 	mvKey := blockstm.NewStateKey(addr, key)
 	var result common.Hash
 	if val, writerIdx, writerInc, found := s.readStoreWait(mvKey); found {
-		s.recordStoreRead(mvKey, writerIdx, writerInc, val)
+		s.recordStoreReadEx(mvKey, writerIdx, writerInc, val, suicideIdx >= 0)
 		if writerIdx > suicideIdx {
 			result = val.(common.Hash)
 		}

--- a/core/state/parallel_statedb_validate.go
+++ b/core/state/parallel_statedb_validate.go
@@ -119,7 +119,11 @@ func storeReadMatches(rd *StoreReadDesc, curVal any, writer, inc int, found, isE
 	if writer == rd.WriterIdx && inc == rd.WriterInc {
 		return true
 	}
-	if found && rd.StoreVal != nil && valuesEqual(curVal, rd.StoreVal) {
+	// Value equality is unsound when the winning writer's position is
+	// load-bearing (rd.ExactWriter): a different writer with an equal value can
+	// still change the result, e.g. a reordered metamorphic CREATE2/SELFDESTRUCT
+	// that moves the code/storage/marker writer across the destruction boundary.
+	if !rd.ExactWriter && found && rd.StoreVal != nil && valuesEqual(curVal, rd.StoreVal) {
 		return true
 	}
 	if !found && rd.StoreVal == nil {

--- a/core/v2_metamorphic_parity_test.go
+++ b/core/v2_metamorphic_parity_test.go
@@ -1,0 +1,144 @@
+package core
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/blockstm"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/triedb"
+	"github.com/holiman/uint256"
+)
+
+// A metamorphic contract — created, destroyed, and conditionally re-created at
+// the same CREATE2 address within one block — must produce the same state root
+// under V2 BlockSTM as under serial execution. The conditional re-create makes a
+// later EXTCODEHASH read's winning CodePath writer depend on a value an earlier
+// (deliberately heavy) tx writes, so V2 speculates the re-create, then withdraws
+// it on re-execution; validation must not accept the now-stale code read by value
+// equality.
+//
+// Unlike the fuzzer's light-tx metamorphic seeds (which reproduce this only when
+// the scheduler happens to interleave the speculative deploy ahead of the heavy
+// tx — empirically a few percent of runs), the heavy gas-burn flag tx here forces
+// that interleaving, so this is a reliable, deterministic CI regression guard.
+// The loop hedges against the residual scheduling nondeterminism of BlockSTM.
+func TestV2SerialParity_MetamorphicCreate2(t *testing.T) {
+	// f: factory + victim.
+	//   empty calldata : CREATE2-deploy tgt then CALL it so tgt SELFDESTRUCTs in
+	//                    the same tx (true EIP-6780 deletion).
+	//   calldata[0]==1 : STATICCALL the flag holder; if flag==0, CREATE2-redeploy tgt.
+	//   calldata[0]==2 : f.slot0 = EXTCODEHASH(tgt)   (the victim read)
+	f := common.HexToAddress("0x000000000000000000000000000000000000aaaa")
+	fCode := common.FromHex("36156100835760003560f81c806002146100e85750602060006000600061bbbb5afa506000511561002c57005b6060600053600260015360616002536000600353600d600453606060055360006006536039600753606060085360026009536060600a536000600b5360f3600c536033600d5360ff600e536000600f60006000f550005b6060600053600260015360616002536000600353600d600453606060055360006006536039600753606060085360026009536060600a536000600b5360f3600c536033600d5360ff600e536000600f60006000f560006000600060006000855af15050005b5073fd0b03f591d1562409b6137e14ff608420f4e9463f60005500")
+
+	// c: flag holder. Empty calldata returns slot0; non-empty gas-burns (so it
+	// finishes last) and sets slot0 = 1.
+	c := common.HexToAddress("0x000000000000000000000000000000000000bbbb")
+	cCode := common.FromHex("366100105760005460005260206000f35b620138805b600190038060155750600160005500")
+
+	cfg := *params.MergedTestChainConfig
+	signer := types.NewLondonSigner(cfg.ChainID)
+	blockCtx := vm.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    Transfer,
+		GetHash:     func(uint64) common.Hash { return common.Hash{} },
+		Coinbase:    common.HexToAddress("0x00000000000000000000000000000000c0ffee00"),
+		GasLimit:    30_000_000,
+		BlockNumber: big.NewInt(1),
+		Time:        1,
+		BaseFee:     big.NewInt(7),
+		Random:      &common.Hash{},
+	}
+
+	buildRoot := func(tdb *triedb.Database, keys []*ecdsa.PrivateKey) common.Hash {
+		gen, _ := state.New(common.Hash{}, state.NewDatabase(tdb, nil))
+		gen.SetCode(f, fCode, tracing.CodeChangeUnspecified)
+		gen.SetCode(c, cCode, tracing.CodeChangeUnspecified)
+		for _, k := range keys {
+			gen.AddBalance(crypto.PubkeyToAddress(k.PublicKey), uint256.NewInt(1e18), tracing.BalanceChangeUnspecified)
+		}
+		root, _ := gen.Commit(0, false, false)
+		tdb.Commit(root, false)
+		return root
+	}
+
+	mkTxs := func(keys []*ecdsa.PrivateKey) ([]*types.Transaction, []*Message) {
+		mk := func(keyIdx int, to common.Address, data []byte) (*types.Transaction, *Message) {
+			tx, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+				ChainID: cfg.ChainID, Nonce: 0, GasTipCap: big.NewInt(0),
+				GasFeeCap: big.NewInt(7), Gas: 5_000_000, To: &to, Value: big.NewInt(0), Data: data,
+			}), signer, keys[keyIdx])
+			if err != nil {
+				t.Fatal(err)
+			}
+			msg, err := TransactionToMessage(tx, signer, blockCtx.BaseFee)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return tx, msg
+		}
+		// One sender per tx: a shared sender would re-execute every later tx on
+		// each re-exec (nonce/balance dependency), masking the bug.
+		txs := make([]*types.Transaction, 4)
+		msgs := make([]*Message, 4)
+		txs[0], msgs[0] = mk(0, f, nil)       // create + selfdestruct tgt
+		txs[1], msgs[1] = mk(1, c, []byte{1}) // heavy: set flag = 1 (finishes last)
+		txs[2], msgs[2] = mk(2, f, []byte{1}) // redeploy tgt iff flag still reads 0
+		txs[3], msgs[3] = mk(3, f, []byte{2}) // victim: f.slot0 = EXTCODEHASH(tgt)
+		return txs, msgs
+	}
+
+	// BlockSTM scheduling is nondeterministic; iterate so a regression is caught
+	// with overwhelming probability rather than relying on a single schedule.
+	const iters = 8
+	for i := range iters {
+		memdb := rawdb.NewMemoryDatabase()
+		tdb := triedb.NewDatabase(memdb, triedb.HashDefaults)
+		keys := make([]*ecdsa.PrivateKey, 4)
+		for j := range keys {
+			keys[j], _ = crypto.GenerateKey()
+		}
+		root := buildRoot(tdb, keys)
+		txs, msgs := mkTxs(keys)
+
+		// Serial.
+		serialDB, _ := state.New(root, state.NewDatabase(tdb, nil))
+		gp := new(GasPool).AddGas(blockCtx.GasLimit)
+		var usedGas uint64
+		serialEVM := vm.NewEVM(blockCtx, serialDB, &cfg, vm.Config{})
+		for j, tx := range txs {
+			serialDB.SetTxContext(tx.Hash(), j)
+			if _, err := ApplyTransactionWithEVM(msgs[j], gp, serialDB, blockCtx.BlockNumber,
+				common.Hash{}, blockCtx.Time, tx, &usedGas, serialEVM); err != nil {
+				t.Fatalf("iter %d serial tx %d: %v", i, j, err)
+			}
+		}
+
+		// V2 BlockSTM.
+		v2DB, _ := state.New(root, state.NewDatabase(tdb, nil))
+		base := v2DB.Copy()
+		base.EnableConcurrentReads()
+		tasks := make([]V2Task, len(txs))
+		for j := range txs {
+			tasks[j] = V2Task{Index: j, Tx: txs[j], Msg: msgs[j]}
+		}
+		ExecuteV2BlockSTM(context.Background(), tasks, base,
+			blockstm.NewMVStore(), blockstm.NewMVBalanceStore(),
+			blockCtx, common.Hash{}, vm.Config{}, &cfg, blockCtx.GasLimit, 4, v2DB, nil)
+		v2DB.Finalise(true)
+
+		if s, v := serialDB.IntermediateRoot(true), v2DB.IntermediateRoot(true); s != v {
+			t.Fatalf("iter %d: V2 state root %s diverges from serial %s for metamorphic CREATE2 block", i, v.Hex(), s.Hex())
+		}
+	}
+}

--- a/core/v2_serial_parity_fuzz_test.go
+++ b/core/v2_serial_parity_fuzz_test.go
@@ -278,6 +278,65 @@ func FuzzV2ExecutorVsSerial(f *testing.F) {
 			byte(kindTransferToFresh), 3, 0xff, 1, 0,
 			byte(kindTransferToSender), 4, 0, 3, 0,
 		},
+		// CREATE2 deploy then EXTCODEHASH/SIZE/BALANCE read of the live target.
+		{
+			byte(kindCreate2Deploy), 0, 0, 0, 0,
+			byte(kindReadTarget), 1, 0, 0, 0,
+		},
+		// Metamorphic: deploy+destroy in one tx (EIP-6780 deletion), re-create at
+		// the same address, then read — the destruction-resolved code-read lineage.
+		{
+			byte(kindCreate2AndDestroy), 0, 0, 0, 0,
+			byte(kindCreate2Deploy), 1, 0, 0, 0,
+			byte(kindReadTarget), 2, 0, 0, 0,
+		},
+		// Metamorphic interleaved across senders: destroy/read/re-create/read —
+		// maximizes reorder pressure on the target's create/suicide/code writers.
+		{
+			byte(kindCreate2AndDestroy), 0, 0, 0, 0,
+			byte(kindReadTarget), 1, 0, 0, 0,
+			byte(kindCreate2Deploy), 2, 0, 0, 0,
+			byte(kindReadTarget), 3, 0, 0, 0,
+		},
+		// Fund a dead target (balance-only account), then CREATE2 over it, read.
+		{
+			byte(kindFundTarget), 0, 0, 5, 0,
+			byte(kindCreate2Deploy), 1, 0, 0, 0,
+			byte(kindReadTarget), 2, 0, 0, 0,
+		},
+		// Deploy, separate-tx destroy (EIP-6780 keeps code since not same tx),
+		// then read — exercises SuicidePath writes without true deletion.
+		{
+			byte(kindCreate2Deploy), 0, 0, 0, 0,
+			byte(kindDestroyTarget), 1, 0, 0, 0,
+			byte(kindReadTarget), 2, 0, 0, 0,
+		},
+		// Flag-driven metamorphic reorder — the reported bug shape: deploy+destroy
+		// T (true deletion), fund the flag (steers a later deploy off the target),
+		// speculatively re-deploy T, then read its EXTCODEHASH. A V2 that accepts
+		// the stale code read by value equality diverges from serial.
+		{
+			byte(kindCreate2AndDestroy), 0, 0, 0, 0,
+			byte(kindSetFlag), 1, 0, 1, 0,
+			byte(kindCreate2Deploy), 2, 0, 0, 0,
+			byte(kindReadTarget), 3, 0, 0, 0,
+		},
+		// Reverting tx must not leak: destroy T, then REV speculatively re-deploys
+		// T + writes storage but REVERTs, then read — R must see T absent.
+		{
+			byte(kindCreate2AndDestroy), 0, 0, 0, 0,
+			byte(kindCallRevert), 1, 0, 0, 0,
+			byte(kindReadTarget), 2, 0, 0, 0,
+		},
+		// EIP-7702 delegated to the metamorphic target (authSel 0x40), interleaved
+		// with a destroy: resolving the authority's delegated code reads T's
+		// CodePath across the destruction lineage.
+		{
+			byte(kindCreate2Deploy), 0, 0, 0, 0,
+			byte(kind7702Auth), 1, 0x40, 0, 0,
+			byte(kindCreate2AndDestroy), 2, 0, 0, 0,
+			byte(kindReadTarget), 3, 0, 0, 0,
+		},
 	}
 	for _, s := range seeds {
 		f.Add(s, uint8(4)) // 4 workers
@@ -359,8 +418,50 @@ func TestV2ExecutorVsSerial_SeedCorpus(t *testing.T) {
 			{kind: kindTransferToFresh, senderIdx: 3, freshNonce: 0xff, valueGwei: 1},
 			{kind: kindTransferToSender, senderIdx: 4, recipientIdx: 0, valueGwei: 3},
 		},
+		"Create2DeployThenRead": {
+			{kind: kindCreate2Deploy, senderIdx: 0},
+			{kind: kindReadTarget, senderIdx: 1},
+		},
+		"MetamorphicRedeploy": {
+			{kind: kindCreate2AndDestroy, senderIdx: 0},
+			{kind: kindCreate2Deploy, senderIdx: 1},
+			{kind: kindReadTarget, senderIdx: 2},
+		},
+		"MetamorphicInterleaved": {
+			{kind: kindCreate2AndDestroy, senderIdx: 0},
+			{kind: kindReadTarget, senderIdx: 1},
+			{kind: kindCreate2Deploy, senderIdx: 2},
+			{kind: kindReadTarget, senderIdx: 3},
+		},
+		"FundThenCreate2Read": {
+			{kind: kindFundTarget, senderIdx: 0, valueGwei: 5},
+			{kind: kindCreate2Deploy, senderIdx: 1},
+			{kind: kindReadTarget, senderIdx: 2},
+		},
+		"DeployDestroySeparateRead": {
+			{kind: kindCreate2Deploy, senderIdx: 0},
+			{kind: kindDestroyTarget, senderIdx: 1},
+			{kind: kindReadTarget, senderIdx: 2},
+		},
+		"FlagDrivenMetamorphic": {
+			{kind: kindCreate2AndDestroy, senderIdx: 0},
+			{kind: kindSetFlag, senderIdx: 1, valueGwei: 1},
+			{kind: kindCreate2Deploy, senderIdx: 2},
+			{kind: kindReadTarget, senderIdx: 3},
+		},
+		"RevertNoLeak": {
+			{kind: kindCreate2AndDestroy, senderIdx: 0},
+			{kind: kindCallRevert, senderIdx: 1},
+			{kind: kindReadTarget, senderIdx: 2},
+		},
+		"Auth7702ToMetamorphic": {
+			{kind: kindCreate2Deploy, senderIdx: 0},
+			{kind: kind7702Auth, senderIdx: 1, authSel: 0x40},
+			{kind: kindCreate2AndDestroy, senderIdx: 2},
+			{kind: kindReadTarget, senderIdx: 3},
+		},
 	}
-	workerGrid := []int{1, 4, 8}
+	workerGrid := []int{1, 2, 3, 4, 6, 8}
 	for name, decoded := range cases {
 		for _, w := range workerGrid {
 			t.Run(name+"/w"+string(rune('0'+w)), func(t *testing.T) {
@@ -368,4 +469,108 @@ func TestV2ExecutorVsSerial_SeedCorpus(t *testing.T) {
 			})
 		}
 	}
+}
+
+// TestMetamorphicHarnessSemantics validates the metamorphic harness on the
+// serial path so the differential fuzzer's results are trustworthy: the
+// hand-laid-out target dispatch, the flag-conditional deploy, and the revert
+// rollback must all behave as the comments claim. A harness bug here would
+// otherwise hide (serial and V2 agreeing on a wrong value) or produce spurious
+// divergences.
+func TestMetamorphicHarnessSemantics(t *testing.T) {
+	h := metaHarness
+	slot := func(n int64) common.Hash { return common.BigToHash(big.NewInt(n)) }
+
+	runSerialState := func(decoded []fuzzTx) *state.StateDB {
+		t.Helper()
+		tdb, root := buildBaseStateRoot(t)
+		signer := types.LatestSigner(fuzzChainConfig)
+		baseFee := big.NewInt(1)
+		blockCtx := vm.BlockContext{
+			CanTransfer: CanTransfer,
+			Transfer:    Transfer,
+			GetHash:     func(uint64) common.Hash { return common.Hash{} },
+			Coinbase:    fuzzCoinbase,
+			GasLimit:    30_000_000,
+			BlockNumber: big.NewInt(1),
+			Time:        1,
+			BaseFee:     baseFee,
+			Random:      &common.Hash{},
+		}
+		txs, msgs := signedTxs(t, decoded, signer, baseFee)
+		sdb, err := state.New(root, state.NewDatabase(tdb, nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		gp := new(GasPool).AddGas(blockCtx.GasLimit)
+		var usedGas uint64
+		for i, tx := range txs {
+			sdb.SetTxContext(tx.Hash(), i)
+			evm := vm.NewEVM(blockCtx, sdb, fuzzChainConfig, vm.Config{})
+			if _, err := ApplyTransactionWithEVM(msgs[i], gp, sdb, blockCtx.BlockNumber, common.Hash{}, blockCtx.Time, tx, &usedGas, evm); err != nil {
+				t.Fatalf("tx %d: %v", i, err)
+			}
+		}
+		return sdb
+	}
+
+	// Deploy T, then read it: T is live; reader records a nonzero codehash and
+	// T's storage slot 0 (== 1, set by T's initcode) via the STATICCALL path.
+	sdb := runSerialState([]fuzzTx{{kind: kindCreate2Deploy, senderIdx: 0}, {kind: kindReadTarget, senderIdx: 1}})
+	if len(sdb.GetCode(h.target)) == 0 {
+		t.Fatal("deploy: target has no code")
+	}
+	if sdb.GetState(h.reader, common.Hash{}) == (common.Hash{}) {
+		t.Fatal("deploy+read: reader codehash slot is zero, want nonzero")
+	}
+	if got := sdb.GetState(h.reader, slot(3)).Big().Int64(); got != 1 {
+		t.Fatalf("deploy+read: reader storage-read slot = %d, want 1 (T dispatch broken)", got)
+	}
+
+	// Deploy + destroy in one tx, then read: T is gone, codehash reads zero.
+	sdb = runSerialState([]fuzzTx{{kind: kindCreate2AndDestroy, senderIdx: 0}, {kind: kindReadTarget, senderIdx: 1}})
+	if len(sdb.GetCode(h.target)) != 0 {
+		t.Fatal("deploy+destroy: target still has code")
+	}
+	if sdb.GetState(h.reader, common.Hash{}) != (common.Hash{}) {
+		t.Fatal("deploy+destroy+read: reader codehash slot nonzero, want zero")
+	}
+
+	// Reverting tx rolls back both its nested CREATE2 of T and its SSTORE.
+	sdb = runSerialState([]fuzzTx{{kind: kindCallRevert, senderIdx: 0}})
+	if len(sdb.GetCode(h.target)) != 0 {
+		t.Fatal("revert: target deployed despite REVERT (CREATE2 not rolled back)")
+	}
+	if sdb.GetState(h.reverter, common.Hash{}) != (common.Hash{}) {
+		t.Fatal("revert: reverter SSTORE survived REVERT")
+	}
+
+	// Funding the flag steers D's CREATE2 salt off zero, so T does NOT land at
+	// the canonical target address.
+	sdb = runSerialState([]fuzzTx{{kind: kindSetFlag, senderIdx: 0, valueGwei: 1}, {kind: kindCreate2Deploy, senderIdx: 1}})
+	if len(sdb.GetCode(h.target)) != 0 {
+		t.Fatal("flag funded: target deployed at salt-0 address despite nonzero flag")
+	}
+
+	// Transient storage is per-tx: two txs each calling TR must both see a zero
+	// transient value before their own TSTORE (slot1 stays 0); a leak across txs
+	// would make the second tx record 0xbeef. slot2 confirms the intra-tx
+	// TSTORE→TLOAD round-trip.
+	sdb = runSerialState([]fuzzTx{{kind: kindTransient, senderIdx: 0}, {kind: kindTransient, senderIdx: 1}})
+	if got := sdb.GetState(h.transient, slot(1)).Big().Int64(); got != 0 {
+		t.Fatalf("transient: slot1 = %d, want 0 (transient leaked across txs)", got)
+	}
+	if got := sdb.GetState(h.transient, slot(2)).Big().Uint64(); got != 0xbeef {
+		t.Fatalf("transient: slot2 = %d, want 0xbeef (TSTORE/TLOAD round-trip broken)", got)
+	}
+
+	// Smoke: the remaining new harness kinds execute without a consensus error
+	// (runSerialState fails the test on any apply error). Differential parity is
+	// checked by the fuzzer.
+	_ = runSerialState([]fuzzTx{
+		{kind: kindCreate2Deploy, senderIdx: 0},
+		{kind: kindDelegateRead, senderIdx: 1},
+		{kind: kindClearRefund, senderIdx: 2},
+		{kind: kindEmitLog, senderIdx: 3},
+	})
 }

--- a/core/v2_serial_parity_gen_test.go
+++ b/core/v2_serial_parity_gen_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/core/vm/program"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/triedb"
 )
@@ -118,6 +120,191 @@ var (
 	sweeperCode = common.FromHex("5f3560601cff")
 )
 
+// metamorphicHarness is the genesis-predeployed contract set that exercises the
+// CREATE2 + SELFDESTRUCT + re-create ("metamorphic") lineage the old vocabulary
+// could not reach. A target T is deployed at a deterministic CREATE2 address by
+// a single deployer, can be destroyed (separate-tx or same-tx), re-created at
+// the same address, and read back via EXTCODEHASH/EXTCODESIZE/BALANCE — the
+// destruction-resolved reads whose V2 validation depends on the winning
+// writer's position, not just its value.
+type metamorphicHarness struct {
+	deployer          common.Address // D: CREATE2-deploys T with salt = BALANCE(flag)
+	deployDestroy     common.Address // DD: deploys + destroys T in one tx (EIP-6780 true deletion)
+	reader            common.Address // R: records EXTCODEHASH/SIZE/BALANCE/SLOAD/EXTCODECOPY/SELFBALANCE/GAS into storage
+	target            common.Address // T: CREATE2(D, salt=0, targetInit) — i.e. when flag balance is 0
+	flag              common.Address // a plain account whose balance steers D's CREATE2 salt
+	reverter          common.Address // REV: writes storage + deploys T, then REVERTs (journal rollback)
+	transient         common.Address // TR: TLOAD/TSTORE (EIP-1153) — per-tx/per-incarnation isolation
+	delegate          common.Address // DC: DELEGATECALL T (code-of-T / storage-of-DC) across the lineage
+	clearRefund       common.Address // CLR: SSTORE nonzero→zero (gas refund parity)
+	logger            common.Address // LG: LOG1(EXTCODEHASH(T)) — bloom/log parity across the lineage
+	deployerCode      []byte
+	deployDestroyCode []byte
+	readerCode        []byte
+	reverterCode      []byte
+	transientCode     []byte
+	delegateCode      []byte
+	clearRefundCode   []byte
+	loggerCode        []byte
+	targetInit        []byte
+}
+
+// metaHarness is built once; all addresses/bytecodes are deterministic so serial
+// and V2 runs target identical state.
+var metaHarness = buildMetamorphicHarness()
+
+func buildMetamorphicHarness() metamorphicHarness {
+	deployer := common.HexToAddress("0x00000000000000000000000000000000000000d0")
+	deployDestroy := common.HexToAddress("0x00000000000000000000000000000000000000d1")
+	reader := common.HexToAddress("0x00000000000000000000000000000000000000e0")
+	flag := common.HexToAddress("0x00000000000000000000000000000000000000f1")
+	var salt [32]byte // 0 — the salt used when the flag account has zero balance
+
+	// T runtime: dispatch on the first calldata byte. Selector 1 returns
+	// storage slot 0 (so a caller can read T's storage across the
+	// create/destroy/re-create lineage — the GetState destruction-resolved
+	// victim read); any other selector (including empty calldata) selfdestructs
+	// to the caller. Hand-laid out so the JUMPI target lands on the JUMPDEST at
+	// offset 13; keep byte sizes fixed if editing.
+	//
+	//   00 PUSH0; 01 CALLDATALOAD; 02 PUSH1 0xf8; 04 SHR        -> selector
+	//   05 PUSH1 1; 07 EQ; 08 PUSH1 13; 10 JUMPI                -> if sel==1 goto 13
+	//   11 CALLER; 12 SELFDESTRUCT                              -> else destroy
+	//   13 JUMPDEST; 14 PUSH0 SLOAD; 16 PUSH0 MSTORE; 18 PUSH1 32 PUSH0 RETURN
+	targetRuntime := program.New().
+		Push0().Op(vm.CALLDATALOAD).Push(0xf8).Op(vm.SHR).
+		Push(1).Op(vm.EQ).
+		Push(13).Op(vm.JUMPI).
+		Op(vm.CALLER, vm.SELFDESTRUCT).
+		Op(vm.JUMPDEST).
+		Push0().Op(vm.SLOAD).Push0().Op(vm.MSTORE).Push(32).Push0().Op(vm.RETURN).
+		Bytes()
+	// T initcode: set slot0=1 so a live T carries storage state (its presence in
+	// the trie when alive and absence when destroyed is what the state-root
+	// comparison checks), then return the runtime.
+	targetInit := program.New().Sstore(0, 1).ReturnViaCodeCopy(targetRuntime).Bytes()
+	// Deterministic CREATE2 address when salt == 0 (flag balance 0).
+	target := crypto.CreateAddress2(deployer, salt, crypto.Keccak256(targetInit))
+
+	// D deploys T via CREATE2 with salt = BALANCE(flag). When the flag account
+	// has zero balance the salt is 0 and T lands at `target`; once the flag is
+	// funded the salt changes and the deploy lands elsewhere — so whether T
+	// exists at `target` depends on a value another tx writes. This is the
+	// reorderable input the executor must invalidate on: a tx that speculatively
+	// reads flag balance 0, deploys T, then re-executes after the flag is funded
+	// must withdraw its CodePath/CreatePath writes at `target`.
+	//
+	// Hand-built (jump-free) because the salt comes off the stack (BALANCE), not
+	// a constant, so program.Create2's constant-salt helper can't be used.
+	// CREATE2 pops value, offset, size, salt (value on top).
+	deployerCode := program.New().
+		Mstore(targetInit, 0).     // initcode → mem[0:len]
+		Push(flag).Op(vm.BALANCE). // [salt = balance(flag)]
+		Push(len(targetInit)).     // [salt, size]
+		Push(0).                   // [salt, size, offset]
+		Push(0).                   // [salt, size, offset, value]
+		Op(vm.CREATE2).            // [addr]
+		Op(vm.POP, vm.STOP).
+		Bytes()
+
+	// DD: call D (creates T this tx iff flag balance 0), then call T (T
+	// selfdestructs this tx). Created and destroyed in one tx → EIP-6780
+	// deletes the account.
+	deployDestroyCode := program.New().
+		Call(nil, deployer, 0, 0, 0, 0, 0).Op(vm.POP).
+		Call(nil, target, 0, 0, 0, 0, 0).Op(vm.POP).
+		Op(vm.STOP).Bytes()
+
+	// R: record destruction-resolved reads of T into slots 0/1/2 via opcodes
+	// (CodePath + balance), then slot 3 via a STATICCALL that makes T return its
+	// storage slot 0 (StatePath victim read across the lineage).
+	readerCode := program.New().
+		Push(target).Op(vm.EXTCODEHASH).Push(0).Op(vm.SSTORE).
+		Push(target).Op(vm.EXTCODESIZE).Push(1).Op(vm.SSTORE).
+		Push(target).Op(vm.BALANCE).Push(2).Op(vm.SSTORE).
+		Push(1).Push(0).Op(vm.MSTORE8). // mem[0] = selector 1
+		StaticCall(nil, target, 0, 1, 0, 32).Op(vm.POP).
+		Push(0).Op(vm.MLOAD).Push(3).Op(vm.SSTORE).
+		// EXTCODECOPY T's first word → slot4 (CodePath read via a different opcode).
+		ExtcodeCopy(target, 0, 0, 32).Push(0).Op(vm.MLOAD).Push(4).Op(vm.SSTORE).
+		// SELFBALANCE → slot5; GAS canary → slot6 (gas determinism amplifier).
+		Op(vm.SELFBALANCE).Push(5).Op(vm.SSTORE).
+		Op(vm.GAS).Push(6).Op(vm.SSTORE).
+		Op(vm.STOP).Bytes()
+
+	reverter := common.HexToAddress("0x00000000000000000000000000000000000000e1")
+	// REV: deploy T (via D) and write storage, then REVERT. Both effects — the
+	// CreatePath/CodePath writes from the nested CREATE2 and the SSTORE — must be
+	// rolled back and never published to other txs. A V2 that leaks a reverted
+	// frame's writes diverges from serial.
+	reverterCode := program.New().
+		Call(nil, deployer, 0, 0, 0, 0, 0).Op(vm.POP).
+		Sstore(0, 0xdead).
+		Push0().Push0().Op(vm.REVERT).
+		Bytes()
+
+	// TR: TLOAD/TSTORE (EIP-1153). slot1 records the transient value BEFORE any
+	// TSTORE — it must read 0 on every tx and every re-execution (transient is
+	// per-tx and reset on each incarnation); a V2 that leaks transient across
+	// txs/incarnations makes slot1 nonzero and diverges. slot2 confirms TSTORE
+	// then TLOAD round-trips within the tx.
+	transient := common.HexToAddress("0x00000000000000000000000000000000000000e2")
+	transientCode := program.New().
+		Push0().Op(vm.TLOAD).Push(1).Op(vm.SSTORE).
+		Push(0xbeef).Push0().Op(vm.TSTORE).
+		Push0().Op(vm.TLOAD).Push(2).Op(vm.SSTORE).
+		Op(vm.STOP).Bytes()
+
+	// DC: DELEGATECALL T's read path. Resolving the delegate target reads T's
+	// CodePath (a different opcode path than EXTCODEHASH), executed against DC's
+	// own storage — exercised across T's destroy/re-create lineage.
+	delegate := common.HexToAddress("0x00000000000000000000000000000000000000e3")
+	delegateCode := program.New().
+		Push(1).Push(0).Op(vm.MSTORE8). // mem[0] = selector 1 (T's read path)
+		DelegateCall(nil, target, 0, 1, 0, 32).Op(vm.POP).
+		Push(0).Op(vm.MLOAD).Push(0).Op(vm.SSTORE).
+		Op(vm.STOP).Bytes()
+
+	// CLR: set then clear two slots (nonzero→zero) to trigger SSTORE clear
+	// refunds; gas used (hence the receipt) must match between serial and V2.
+	clearRefund := common.HexToAddress("0x00000000000000000000000000000000000000e4")
+	clearRefundCode := program.New().
+		Sstore(0, 1).Sstore(0, 0).
+		Sstore(1, 1).Sstore(1, 0).
+		Op(vm.STOP).Bytes()
+
+	// LG: emit LOG1 whose data is EXTCODEHASH(T) and whose topic is constant.
+	// The log payload tracks T's lineage, so bloom + logs (compared per receipt)
+	// must agree across a destroy/re-create reorder.
+	logger := common.HexToAddress("0x00000000000000000000000000000000000000e5")
+	loggerCode := program.New().
+		Push(target).Op(vm.EXTCODEHASH).Push0().Op(vm.MSTORE).
+		Push(0xabcd).Push(32).Push0().Op(vm.LOG1).
+		Op(vm.STOP).Bytes()
+
+	return metamorphicHarness{
+		deployer:          deployer,
+		deployDestroy:     deployDestroy,
+		reader:            reader,
+		target:            target,
+		flag:              flag,
+		reverter:          reverter,
+		transient:         transient,
+		delegate:          delegate,
+		clearRefund:       clearRefund,
+		logger:            logger,
+		deployerCode:      deployerCode,
+		deployDestroyCode: deployDestroyCode,
+		readerCode:        readerCode,
+		reverterCode:      reverterCode,
+		transientCode:     transientCode,
+		delegateCode:      delegateCode,
+		clearRefundCode:   clearRefundCode,
+		loggerCode:        loggerCode,
+		targetInit:        targetInit,
+	}
+}
+
 // fuzzTxKind enumerates the tx shapes the generator produces.
 type fuzzTxKind uint8
 
@@ -129,6 +316,20 @@ const (
 	kindCallSelfDestructPair
 	kind7702Auth
 	kindNonceOnlyAccount
+	// Metamorphic CREATE2 lineage (see metamorphicHarness). Appended after the
+	// original kinds so existing seed-corpus byte values keep their meaning.
+	kindCreate2Deploy     // call D: CREATE2-deploy T (salt = flag balance; re-creates if destroyed)
+	kindCreate2AndDestroy // call DD: deploy + destroy T in one tx (EIP-6780 deletion)
+	kindDestroyTarget     // call T directly: T selfdestructs (no-op if T absent)
+	kindReadTarget        // call R: EXTCODEHASH/SIZE/BALANCE(T) → storage
+	kindFundTarget        // send value to T: funds a dead T, or bounces off a live one
+	kindSetFlag           // fund the flag account: flips D's CREATE2 salt (reorderable input)
+	kindCallRevert        // call REV: writes storage + deploys T, then REVERTs (journal rollback)
+	kindTransient         // call TR: TLOAD/TSTORE isolation (EIP-1153)
+	kindDelegateRead      // call DC: DELEGATECALL T's read path
+	kindClearRefund       // call CLR: SSTORE nonzero→zero refund
+	kindEmitLog           // call LG: LOG1(EXTCODEHASH(T))
+	kindCount             // sentinel: number of tx kinds
 )
 
 // fuzzTx is one tx in a decoded scenario.
@@ -140,6 +341,7 @@ type fuzzTx struct {
 	valueGwei    uint16 // small value so balances don't run out
 	createKind   uint8  // for kindContractCreate — selects which canned bytecode
 	authSel      uint8  // for kind7702Auth/kindNonceOnlyAccount — low bits pick the authority, 0x80 delegates to X (else clears)
+	txType       uint8  // 0=dynamicfee(1559), 1=legacy, 2=accesslist(2930); ignored for 7702/nonce-only
 }
 
 // canned contract bytecodes used by kindContractCreate. Each one is
@@ -178,7 +380,7 @@ func decodeScenario(data []byte) []fuzzTx {
 	i := 0
 	for i+4 < len(data) && len(out) < fuzzMaxTxs {
 		// Layout: [kind(1) | sender(1) | aux(1) | valueLo(1) | valueHi(1)]
-		kind := fuzzTxKind(data[i] % 7)
+		kind := fuzzTxKind(data[i] % byte(kindCount))
 		senderIdx := int(data[i+1]) % numFuzzSenders
 		aux := data[i+2]
 		valueGwei := uint16(data[i+3]) | (uint16(data[i+4]) << 8)
@@ -190,6 +392,9 @@ func decodeScenario(data []byte) []fuzzTx {
 			kind:      kind,
 			senderIdx: senderIdx,
 			valueGwei: valueGwei,
+			// Tx envelope type from the value byte's high bits, which %4096
+			// discards — so it doesn't perturb valueGwei.
+			txType: (data[i+4] >> 4) % 3,
 		}
 		switch kind {
 		case kindTransferToSender:
@@ -275,11 +480,60 @@ func signedTxs(t testing.TB, decoded []fuzzTx, signer types.Signer, baseFee *big
 			a := sdPairEntry
 			to = &a
 			gas = fuzzGasLimit
+		case kindCreate2Deploy:
+			a := metaHarness.deployer
+			to = &a
+			gas = fuzzGasLimit
+		case kindCreate2AndDestroy:
+			a := metaHarness.deployDestroy
+			to = &a
+			gas = fuzzGasLimit
+		case kindDestroyTarget:
+			a := metaHarness.target
+			to = &a
+			gas = fuzzGasLimit
+		case kindReadTarget:
+			a := metaHarness.reader
+			to = &a
+			gas = fuzzGasLimit
+		case kindFundTarget:
+			a := metaHarness.target
+			to = &a
+			gas = fuzzGasLimit
+		case kindSetFlag:
+			a := metaHarness.flag
+			to = &a
+		case kindCallRevert:
+			a := metaHarness.reverter
+			to = &a
+			gas = fuzzGasLimit
+		case kindTransient:
+			a := metaHarness.transient
+			to = &a
+			gas = fuzzGasLimit
+		case kindDelegateRead:
+			a := metaHarness.delegate
+			to = &a
+			gas = fuzzGasLimit
+		case kindClearRefund:
+			a := metaHarness.clearRefund
+			to = &a
+			gas = fuzzGasLimit
+		case kindEmitLog:
+			a := metaHarness.logger
+			to = &a
+			gas = fuzzGasLimit
 		case kind7702Auth:
 			authIdx := int(d.authSel) % numFuzzAuthorities
 			target := common.Address{} // zero address clears the delegation
 			if d.authSel&0x80 != 0 {
 				target = sdPairEntry
+			} else if d.authSel&0x40 != 0 {
+				// Delegate to the metamorphic target: resolving the authority's
+				// delegated code reads T's CodePath, which a concurrent
+				// destroy/re-create moves across the destruction boundary —
+				// the 7702 × metamorphic interaction.
+				target = metaHarness.target
 			}
 			auth, err := types.SignSetCode(fuzzAuthKeys[authIdx], types.SetCodeAuthorization{
 				ChainID: *uint256.MustFromBig(signer.ChainID()),
@@ -298,6 +552,11 @@ func signedTxs(t testing.TB, decoded []fuzzTx, signer types.Signer, baseFee *big
 
 		// Compute value in wei from gwei; 0 is a legal value too.
 		value := new(big.Int).Mul(big.NewInt(int64(d.valueGwei)), big.NewInt(1e9))
+		// kindSetFlag must move the flag account's balance off zero so D's salt
+		// actually flips; force a minimum of 1 wei when the decoded value is 0.
+		if d.kind == kindSetFlag && value.Sign() == 0 {
+			value = big.NewInt(1)
+		}
 		var inner types.TxData
 		if d.kind == kind7702Auth {
 			// To is the authority itself, so post-application calls run its
@@ -315,15 +574,40 @@ func signedTxs(t testing.TB, decoded []fuzzTx, signer types.Signer, baseFee *big
 				AuthList:  authList,
 			}
 		} else {
-			inner = &types.DynamicFeeTx{
-				ChainID:   signer.ChainID(),
-				Nonce:     nonce,
-				GasTipCap: big.NewInt(1),
-				GasFeeCap: big.NewInt(1e9),
-				Gas:       gas,
-				To:        to,
-				Value:     value,
-				Data:      data,
+			// Vary the tx envelope so V2 must handle every type identically.
+			switch d.txType {
+			case 1: // legacy
+				inner = &types.LegacyTx{
+					Nonce:    nonce,
+					GasPrice: big.NewInt(1e9),
+					Gas:      gas,
+					To:       to,
+					Value:    value,
+					Data:     data,
+				}
+			case 2: // EIP-2930 access list — pre-warms the target's slot 0
+				alGas := max(gas, 30000) // cover the access-list intrinsic gas
+				inner = &types.AccessListTx{
+					ChainID:    signer.ChainID(),
+					Nonce:      nonce,
+					GasPrice:   big.NewInt(1e9),
+					Gas:        alGas,
+					To:         to,
+					Value:      value,
+					Data:       data,
+					AccessList: types.AccessList{{Address: metaHarness.target, StorageKeys: []common.Hash{{}}}},
+				}
+			default: // EIP-1559 dynamic fee
+				inner = &types.DynamicFeeTx{
+					ChainID:   signer.ChainID(),
+					Nonce:     nonce,
+					GasTipCap: big.NewInt(1),
+					GasFeeCap: big.NewInt(1e9),
+					Gas:       gas,
+					To:        to,
+					Value:     value,
+					Data:      data,
+				}
 			}
 		}
 		tx, err := types.SignTx(types.NewTx(inner), signer, fuzzKeys[d.senderIdx])
@@ -464,6 +748,14 @@ func buildBaseStateRoot(t testing.TB) (*triedb.Database, common.Hash) {
 	sdb.SetCode(sdPairHelper, sdPairHelperCode, 0)
 	sdb.AddBalance(sdPairHelper, uint256.NewInt(10), 0)
 	sdb.SetCode(sweeperAddr, sweeperCode, 0)
+	sdb.SetCode(metaHarness.deployer, metaHarness.deployerCode, 0)
+	sdb.SetCode(metaHarness.deployDestroy, metaHarness.deployDestroyCode, 0)
+	sdb.SetCode(metaHarness.reader, metaHarness.readerCode, 0)
+	sdb.SetCode(metaHarness.reverter, metaHarness.reverterCode, 0)
+	sdb.SetCode(metaHarness.transient, metaHarness.transientCode, 0)
+	sdb.SetCode(metaHarness.delegate, metaHarness.delegateCode, 0)
+	sdb.SetCode(metaHarness.clearRefund, metaHarness.clearRefundCode, 0)
+	sdb.SetCode(metaHarness.logger, metaHarness.loggerCode, 0)
 	root, err := sdb.Commit(0, false, false)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

BlockSTM v2's read-validation (`storeReadMatches`) accepted a recorded read whenever the current MVStore value equaled the recorded value, even when the **winning writer's block-order position** changed. For reads resolved relative to a prior `SELFDESTRUCT` (the `writerIdx > suicideIdx` pattern) and for the `CreatePath`/`SuicidePath` existence markers, the writer's *position* — not its value — determines the result. A reordered metamorphic `CREATE2` + same-tx `SELFDESTRUCT` could therefore move a code/storage/marker writer across the destruction boundary while its value stayed equal; validation wrongly skipped re-execution and v2 settled a **state root that differed from serial**.

Fix (first commit): a per-read `ExactWriter` flag on `StoreReadDesc` that disables the value-equality fallback for

- `CreatePath`/`SuicidePath` markers — always (their value is always `true`, so value-equality can only ever mask a reorder), and
- `Nonce`/`Code`/`Storage` reads when a prior destruction is in play (`suicideIdx >= 0`).

The common no-destruction path keeps the value-equality optimization, so the cost is bounded to the rare destruction-interleaved case. Marker reads now record the real writer incarnation. This covers all six destruction-resolved read sites (`Exist`, `GetNonce`, `GetCode`, `GetCodeHash`, `GetState`, `GetCommittedState`), so the storage- and nonce-slot twins of the code-path symptom are closed by construction rather than chased individually.

Test coverage (second commit): the old differential vocabulary could not express `CREATE2`, metamorphic re-create at a destroyed address, or a reorderable deploy decision, so the divergence was unreachable by the fuzzer. The grammar now adds CREATE2 deploy / deploy+destroy-in-one-tx (EIP-6780) / separate-tx destroy / re-create / `EXTCODEHASH`·`EXTCODESIZE`·`EXTCODECOPY`·`BALANCE`·`SELFBALANCE`·`SLOAD` reads of the target, a flag-conditional deployer (reorderable salt), `TLOAD`/`TSTORE`, `DELEGATECALL`, SSTORE clear-refund, contract `LOG`, a `GAS` canary, 7702 delegation to the metamorphic target, a reverting tx (journal rollback), and legacy / EIP-2930 / EIP-1559 envelopes.

## Executed tests

| Check | Result |
|---|---|
| `TestAllBlocksConsistency` (`BOR_BLOCKSTM_TEST=1`, 241 real mainnet blocks, v2-parallel vs serial) | **241/241 consistent, 0 failures** |
| `FuzzV2ExecutorVsSerial` over the expanded grammar (post-fix) | 1,016,614 execs, 0 divergences (pre-fix it finds the divergence in ~19s) |
| `TestV2SerialParity_MetamorphicCreate2` (new deterministic regression) | catches pre-fix (5/5), passes post-fix |
| `TestMetamorphicHarnessSemantics`, `TestV2ExecutorVsSerial_SeedCorpus` (worker grid `{1,2,3,4,6,8}`), `core/state` unit suite, existing v2 selfdestruct/balance/gas-determinism tests | green |

Standard CI gates (lint, unit/integration, diffguard w/ mutation, govulncheck, kurtosis e2e) still to run on this PR.

## Rollout notes

- **Consensus-affecting for BlockSTM v2 only.** v2 is not present in any released version (absent from `v2.8.3`); the default configuration runs v2 non-enforced with serial as the source of truth and validates the v2 root against the block header, falling back to serial on mismatch. There is therefore **no behavior change for current production nodes** and **no coordinated upgrade required** — this hardens v2 before it ships as a primary execution path.
- Not operator-facing. No config, genesis, fork-activation, or precompile changes; backward compatible.
- Cross-client parity (Erigon) is unaffected: serial execution output is unchanged; this only changes when v2 re-executes a tx internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
