### PR TITLE
Stabilize skeleton timeout requeue test

### DIFF
--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -223,8 +223,9 @@ type skeleton struct {
 
 	// Callback hooks used during testing
 	syncStarting func() // callback triggered after a sync cycle is inited but before started
-	// requestFailed is invoked after a failed request has been reverted and the
-	// peer has been requeued into the idle set, if it remains backed off.
+	// requestFailed is invoked on the skeleton sync runloop after a failed
+	// request has been reverted and the peer has been requeued into the idle
+	// set, if it remains backed off. Callers must not block.
 	requestFailed func(peer string)
 }
 

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -222,7 +222,8 @@ type skeleton struct {
 	terminated chan struct{}    // Channel to signal that the syncer is dead
 
 	// Callback hooks used during testing
-	syncStarting func() // callback triggered after a sync cycle is inited but before started
+	syncStarting  func() // callback triggered after a sync cycle is inited but before started
+	requestFailed func(peer string)
 }
 
 // newSkeleton creates a new sync skeleton that tracks a potentially dangling
@@ -995,6 +996,9 @@ func (s *skeleton) handleRequestFail(req *headerRequest) {
 	s.revertRequest(req)
 	if peer := s.peers.Peer(req.peer); peer != nil && peer.backedOff() {
 		s.idles[req.peer] = peer
+	}
+	if s.requestFailed != nil {
+		s.requestFailed(req.peer)
 	}
 }
 

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -222,7 +222,9 @@ type skeleton struct {
 	terminated chan struct{}    // Channel to signal that the syncer is dead
 
 	// Callback hooks used during testing
-	syncStarting  func() // callback triggered after a sync cycle is inited but before started
+	syncStarting func() // callback triggered after a sync cycle is inited but before started
+	// requestFailed is invoked after a failed request has been reverted and the
+	// peer has been requeued into the idle set, if it remains backed off.
 	requestFailed func(peer string)
 }
 
@@ -996,9 +998,9 @@ func (s *skeleton) handleRequestFail(req *headerRequest) {
 	s.revertRequest(req)
 	if peer := s.peers.Peer(req.peer); peer != nil && peer.backedOff() {
 		s.idles[req.peer] = peer
-	}
-	if s.requestFailed != nil {
-		s.requestFailed(req.peer)
+		if s.requestFailed != nil {
+			s.requestFailed(req.peer)
+		}
 	}
 }
 

--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -682,13 +682,27 @@ func TestSkeletonSyncBacksOffOnTimeout(t *testing.T) {
 	}
 
 	var dropped atomic.Bool
+	requeued := make(chan struct{}, 1)
 	skeleton := newSkeleton(db, peerset, func(string) { dropped.Store(true) }, newHookedBackfiller())
+	skeleton.requestFailed = func(string) {
+		select {
+		case requeued <- struct{}{}:
+		default:
+		}
+	}
 	if err := skeleton.Sync(chain[len(chain)-1], nil, true); err != nil {
 		t.Fatalf("failed to announce sync head: %v", err)
 	}
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) && !peer.backedOff() {
 		time.Sleep(20 * time.Millisecond)
+	}
+
+	select {
+	case <-requeued:
+	case <-time.After(5 * time.Second):
+		skeleton.Terminate()
+		t.Fatal("timed-out skeleton peer was never requeued")
 	}
 
 	skeleton.Terminate()

--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -697,6 +697,10 @@ func TestSkeletonSyncBacksOffOnTimeout(t *testing.T) {
 	for time.Now().Before(deadline) && !peer.backedOff() {
 		time.Sleep(20 * time.Millisecond)
 	}
+	if !peer.backedOff() {
+		skeleton.Terminate()
+		t.Fatal("timed-out skeleton peer never backed off")
+	}
 
 	select {
 	case <-requeued:


### PR DESCRIPTION
### Root cause
The nightly failure was in `eth/downloader` test `TestSkeletonSyncBacksOffOnTimeout`. The test was terminating the skeleton sync before the event loop had a guaranteed chance to process the timeout revert and requeue the backed-off peer, so the final `s.idles` assertion was racing teardown.

### Fix
Added a small test-only hook on `skeleton` to signal when `handleRequestFail` has run, then had the test wait for that signal before terminating the sync. This makes the assertion check the actual requeue event instead of a racy post-terminate snapshot.

### Validation
Ran `go test -race ./eth/downloader -run TestSkeletonSyncBacksOffOnTimeout -shuffle=1782709738330060787 -count=10` on the nightly head, then `go test -race ./eth/downloader -count=1`. Both passed.

### Remaining risk
This is intentionally minimal and test-only, but the extra hook is still production code surface and should be kept scoped to downloader tests.
