### PR TITLE
miner: stabilize freed gas feedback test

### DIFF
--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -3463,9 +3463,8 @@ func TestBuildTxPlan(t *testing.T) {
 // what was already prefetched.
 //
 // Setup: 50 txs in pool, first 80% already marked as prefetched. Freed-gas channel
-// delivers 5 × 21000 gas BEFORE plan channel closes so the collect loop timer fires
-// and the overflow scan runs with a non-zero budget. Expected: the downstream
-// stream channel receives bonus txs from the unprefetched tail.
+// delivers 5 × 21000 gas while the plan channel remains open. Expected: the
+// downstream stream channel receives bonus txs from the unprefetched tail.
 func TestBuilderTxProvider_FreedGasFeedback(t *testing.T) {
 	t.Parallel()
 
@@ -3544,8 +3543,14 @@ func TestBuilderTxProvider_FreedGasFeedback(t *testing.T) {
 	}
 	close(gasFreedCh)
 
-	// Allow the 2ms timer to fire and the overflow scan to run. Then close planCh.
-	time.Sleep(20 * time.Millisecond)
+	// Keep the plan open until the overflow scan has produced an observable result.
+	// A fixed sleep can close the plan before the provider goroutine is scheduled.
+	var firstBonus *types.Transaction
+	select {
+	case firstBonus = <-streamCh:
+	case <-time.After(5 * time.Second):
+		interrupt.Store(true)
+	}
 	close(planCh)
 
 	select {
@@ -3555,7 +3560,8 @@ func TestBuilderTxProvider_FreedGasFeedback(t *testing.T) {
 	}
 
 	close(streamCh)
-	seen := make(map[common.Hash]struct{})
+	require.NotNil(t, firstBonus, "overflow scan did not forward a bonus transaction within timeout")
+	seen := map[common.Hash]struct{}{firstBonus.Hash(): {}}
 	for tx := range streamCh {
 		seen[tx.Hash()] = struct{}{}
 	}
@@ -3564,10 +3570,6 @@ func TestBuilderTxProvider_FreedGasFeedback(t *testing.T) {
 	t.Logf("streamCh received %d bonus txs (freed budget=%d gas, expected up to %d)",
 		forwarded, freedSignals*freedPerSignal, freedSignals)
 
-	// At least one bonus tx should reach the stream — the overflow scan found
-	// non-prefetched txs that fit within the freed-gas budget.
-	require.Greater(t, forwarded, 0,
-		"overflow scan should have forwarded bonus txs beyond the plan")
 	// None of the forwarded txs should be pre-prefetched.
 	for _, tx := range allTxs[:prePrefetchedCount] {
 		_, found := seen[tx.Hash()]


### PR DESCRIPTION
## Summary

[Nightly race run 29139050706](https://github.com/0xPolygon/bor/actions/runs/29139050706) failed `TestBuilderTxProvider_FreedGasFeedback` because the test closed the builder plan channel after a fixed 20 ms sleep. Under race-runner load, the provider goroutine could be scheduled after that close; it then correctly treated the closed plan as builder completion and exited before processing the buffered freed-gas signals. This is a flaky test timing bug, not a Bor runtime race.

The test now waits for the first observable bonus transaction before closing the plan channel. Its timeout also interrupts the provider so failure cleanup remains bounded.

## Executed tests

- `go test -race ./miner -run '^TestBuilderTxProvider_FreedGasFeedback$' -shuffle=1783745829243050644 -count=100`
- `go test -race ./miner -shuffle=1783745829243050644 -count=1`
- `git diff --check`
- Diffguard found no changed production Go files; the change is test-only.

## Rollout notes

Test-only change. It does not modify transaction selection, gas accounting, block production, consensus behavior, or operator configuration. The remaining risk is limited to validation under GitHub-hosted runner scheduling; draft PR CI will exercise that environment.
