### PR TITLE
agents: fetch team standards from 0xPolygon/pos-standards

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
-      "WebFetch(domain:gist.githubusercontent.com)"
+      "WebFetch(domain:raw.githubusercontent.com)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 At the start of every session, fetch the latest PoS team standards from:
 
-`<https://gist.githubusercontent.com/marcello33/370756d88be9c4cc8459b6afe969085c/raw/team-standards.md>`
+`<https://raw.githubusercontent.com/0xPolygon/pos-standards/main/team-standards.md>`
 
 These rules apply to every change in this repo unless this repo's
 `.claude/rules/` explicitly overrides them.


### PR DESCRIPTION
## Summary

Moves the session-start team-standards fetch from the personal-account gist to the org-owned mirror `0xPolygon/pos-standards` (same content, same mechanism — only the URL changes, now behind org-gated review instead of a personal account). Companion to 0xPolygon/pos-team-workspace#16.

## Executed tests

Docs/config-only change; no runtime surface. Verified no gist references remain in the repo; the new raw URL goes live with the mirror's first publish.

## Rollout notes

No consensus or build impact. Merge only after the mirror's first publish is live (workspace PR #16 merged + published) — tracked by the PoS team.
