### PR TITLE
build: update Polygon Cosmos SDK to fix govulncheck failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build
@@ -107,7 +107,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build
@@ -147,7 +147,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/diffguard.yml
+++ b/.github/workflows/diffguard.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/kurtosis-e2e.yml
+++ b/.github/workflows/kurtosis-e2e.yml
@@ -23,6 +23,8 @@ jobs:
   build-bor:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      bor_image_artifact_id: ${{ steps.upload_bor_image.outputs.artifact-id }}
     steps:
       - name: Checkout bor
         uses: actions/checkout@v5
@@ -33,16 +35,23 @@ jobs:
       - name: Save bor docker image
         run: docker save bor:local | gzip > bor-image.tar.gz
 
+      - name: Verify bor image archive
+        run: test -s bor-image.tar.gz
+
       - name: Upload bor docker image
-        uses: actions/upload-artifact@v4
+        id: upload_bor_image
+        uses: actions/upload-artifact@v6
         with:
           name: bor-image
           path: bor-image.tar.gz
-          retention-days: 1
+          retention-days: 7
+          overwrite: true
 
   build-heimdall-v2:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      heimdall_image_artifact_id: ${{ steps.upload_heimdall_image.outputs.artifact-id }}
     steps:
       - name: Checkout heimdall-v2
         uses: actions/checkout@v5
@@ -56,12 +65,17 @@ jobs:
       - name: Save heimdall-v2 docker image
         run: docker save heimdall-v2:local | gzip > heimdall-v2-image.tar.gz
 
+      - name: Verify heimdall-v2 image archive
+        run: test -s heimdall-v2-image.tar.gz
+
       - name: Upload heimdall-v2 docker image
-        uses: actions/upload-artifact@v4
+        id: upload_heimdall_image
+        uses: actions/upload-artifact@v6
         with:
           name: heimdall-v2-image
           path: heimdall-v2-image.tar.gz
-          retention-days: 1
+          retention-days: 7
+          overwrite: true
 
   e2e-tests:
     needs:
@@ -102,14 +116,14 @@ jobs:
 
       # Load images
       - name: Download bor docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          name: bor-image
+          artifact-ids: ${{ needs.build-bor.outputs.bor_image_artifact_id }}
 
       - name: Download heimdall-v2 docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          name: heimdall-v2-image
+          artifact-ids: ${{ needs.build-heimdall-v2.outputs.heimdall_image_artifact_id }}
 
       - name: Load bor docker image
         run: |

--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -23,6 +23,8 @@ jobs:
   build-bor:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      bor_image_artifact_id: ${{ steps.upload_bor_image.outputs.artifact-id }}
     steps:
       - name: Checkout bor
         uses: actions/checkout@v5
@@ -33,16 +35,23 @@ jobs:
       - name: Save bor docker image
         run: docker save bor:local | gzip > bor-image.tar.gz
 
+      - name: Verify bor image archive
+        run: test -s bor-image.tar.gz
+
       - name: Upload bor docker image
-        uses: actions/upload-artifact@v4
+        id: upload_bor_image
+        uses: actions/upload-artifact@v6
         with:
           name: bor-image
           path: bor-image.tar.gz
-          retention-days: 1
+          retention-days: 7
+          overwrite: true
 
   build-heimdall-v2:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      heimdall_image_artifact_id: ${{ steps.upload_heimdall_image.outputs.artifact-id }}
     steps:
       - name: Checkout heimdall-v2
         uses: actions/checkout@v5
@@ -56,12 +65,17 @@ jobs:
       - name: Save heimdall-v2 docker image
         run: docker save heimdall-v2:local | gzip > heimdall-v2-image.tar.gz
 
+      - name: Verify heimdall-v2 image archive
+        run: test -s heimdall-v2-image.tar.gz
+
       - name: Upload heimdall-v2 docker image
-        uses: actions/upload-artifact@v4
+        id: upload_heimdall_image
+        uses: actions/upload-artifact@v6
         with:
           name: heimdall-v2-image
           path: heimdall-v2-image.tar.gz
-          retention-days: 1
+          retention-days: 7
+          overwrite: true
 
   e2e-tests:
     needs:
@@ -102,14 +116,14 @@ jobs:
 
       # Load images
       - name: Download bor docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          name: bor-image
+          artifact-ids: ${{ needs.build-bor.outputs.bor_image_artifact_id }}
 
       - name: Download heimdall-v2 docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          name: heimdall-v2-image
+          artifact-ids: ${{ needs.build-heimdall-v2.outputs.heimdall_image_artifact_id }}
 
       - name: Load bor docker image
         run: |

--- a/.github/workflows/nightly-govulncheck.yml
+++ b/.github/workflows/nightly-govulncheck.yml
@@ -26,7 +26,7 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/nightly-govulncheck.yml
+++ b/.github/workflows/nightly-govulncheck.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
+  push:
+    branches:
+      - vbhattac/fix-govulncheck
 
 concurrency:
   group: nightly-govulncheck-${{ github.ref }}
@@ -11,15 +14,13 @@ concurrency:
 
 jobs:
   govulncheck:
-    name: Run govulncheck on develop
+    name: Run govulncheck
     runs-on: ubuntu24.04-16core-64GB-600SSD-bor
     permissions:
       contents: read
 
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: develop
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/nightly-govulncheck.yml
+++ b/.github/workflows/nightly-govulncheck.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
-  push:
-    branches:
-      - vbhattac/fix-govulncheck
 
 concurrency:
   group: nightly-govulncheck-${{ github.ref }}
@@ -14,13 +11,15 @@ concurrency:
 
 jobs:
   govulncheck:
-    name: Run govulncheck
+    name: Run govulncheck on develop
     runs-on: ubuntu24.04-16core-64GB-600SSD-bor
     permissions:
       contents: read
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: develop
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/nightly-govulncheck.yml
+++ b/.github/workflows/nightly-govulncheck.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
-  push:
-    branches:
-      - vbhattac/fix-govulncheck
 
 concurrency:
   group: nightly-govulncheck-${{ github.ref }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # This file configures github.com/golangci/golangci-lint.
 version: '2'
 run:
-  go: '1.26.3'
+  go: '1.26.5'
   tests: true
 linters:
   default: none

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ─── BUILDER STAGE ───────────────────────────────────────────────────────────────
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 ARG BOR_DIR=/var/lib/bor/
 ENV BOR_DIR=$BOR_DIR

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/cmd/keeper/go.mod
+++ b/cmd/keeper/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum/go-ethereum/cmd/keeper
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20260104020744-7268a54d0358

--- a/go.mod
+++ b/go.mod
@@ -354,7 +354,7 @@ replace (
 	github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1
 	github.com/cometbft/cometbft => github.com/0xPolygon/cometbft v0.3.8-polygon
 	github.com/cometbft/cometbft-db => github.com/0xPolygon/cometbft-db v0.14.1-polygon
-	github.com/cosmos/cosmos-sdk => github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715053728-c70ef2ad19ac
+	github.com/cosmos/cosmos-sdk => github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715060632-d5213f0685ae
 	github.com/ethereum/go-ethereum => github.com/0xPolygon/bor v1.14.14-0.20260219070410-6b0405c0a5ca
 	github.com/ethereum/go-ethereum/common/math => github.com/0xPolygon/bor/common/math v1.5.5
 	go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/ethereum/go-ethereum
 
 // Note: Change the go image version in Dockerfile if you change this.
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/0xPolygon/crand v1.0.3
@@ -11,6 +11,7 @@ require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/JekaMas/go-grpc-net-conn v0.0.0-20220708155319-6aff21f2d13d
 	github.com/Microsoft/go-winio v0.6.2
+	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/VictoriaMetrics/fastcache v1.13.0
 	github.com/aws/aws-sdk-go-v2 v1.27.2
 	github.com/aws/aws-sdk-go-v2/config v1.18.45
@@ -209,6 +210,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cockroachdb/apd/v2 v2.0.2 // indirect
 	github.com/cometbft/cometbft-db v0.14.1 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -354,7 +354,7 @@ replace (
 	github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1
 	github.com/cometbft/cometbft => github.com/0xPolygon/cometbft v0.3.8-polygon
 	github.com/cometbft/cometbft-db => github.com/0xPolygon/cometbft-db v0.14.1-polygon
-	github.com/cosmos/cosmos-sdk => github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715053728-c70ef2ad19ac
+	github.com/cosmos/cosmos-sdk => github.com/0xPolygon/cosmos-sdk v0.2.8-polygon
 	github.com/ethereum/go-ethereum => github.com/0xPolygon/bor v1.14.14-0.20260219070410-6b0405c0a5ca
 	github.com/ethereum/go-ethereum/common/math => github.com/0xPolygon/bor/common/math v1.5.5
 	go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -354,7 +354,7 @@ replace (
 	github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1
 	github.com/cometbft/cometbft => github.com/0xPolygon/cometbft v0.3.8-polygon
 	github.com/cometbft/cometbft-db => github.com/0xPolygon/cometbft-db v0.14.1-polygon
-	github.com/cosmos/cosmos-sdk => github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715060632-d5213f0685ae
+	github.com/cosmos/cosmos-sdk => github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715080111-ed2455f86da0
 	github.com/ethereum/go-ethereum => github.com/0xPolygon/bor v1.14.14-0.20260219070410-6b0405c0a5ca
 	github.com/ethereum/go-ethereum/common/math => github.com/0xPolygon/bor/common/math v1.5.5
 	go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -354,7 +354,7 @@ replace (
 	github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1
 	github.com/cometbft/cometbft => github.com/0xPolygon/cometbft v0.3.8-polygon
 	github.com/cometbft/cometbft-db => github.com/0xPolygon/cometbft-db v0.14.1-polygon
-	github.com/cosmos/cosmos-sdk => github.com/0xPolygon/cosmos-sdk v0.2.8-polygon
+	github.com/cosmos/cosmos-sdk => github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715053728-c70ef2ad19ac
 	github.com/ethereum/go-ethereum => github.com/0xPolygon/bor v1.14.14-0.20260219070410-6b0405c0a5ca
 	github.com/ethereum/go-ethereum/common/math => github.com/0xPolygon/bor/common/math v1.5.5
 	go.mongodb.org/mongo-driver => go.mongodb.org/mongo-driver v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/0xPolygon/cometbft v0.3.8-polygon h1:0VAu6he3OA6ilaPD+MJIq21EZ6SXjzrd
 github.com/0xPolygon/cometbft v0.3.8-polygon/go.mod h1:u1LC4f7ZoB5nVGLzGVCn90c6G9eZCQ0uY03Bi2sA3NE=
 github.com/0xPolygon/cometbft-db v0.14.1-polygon h1:sMlEPISgW0Wm9bC3bnLVPiPnyZ9EOuWJxoAV8ujrN3o=
 github.com/0xPolygon/cometbft-db v0.14.1-polygon/go.mod h1:KHP1YghilyGV/xjD5DP3+2hyigWx0WTp9X+0Gnx0RxQ=
-github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715053728-c70ef2ad19ac h1:wViTiDRSShecu7MGgcdoNjbZGfsTlOT8YGYh8CTW4s4=
-github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715053728-c70ef2ad19ac/go.mod h1:qSFfQMi5ceBpDX4NZGJKbMwG7798v8awCmv4ByVWsIo=
+github.com/0xPolygon/cosmos-sdk v0.2.8-polygon h1:laS7/tnOmzM4l77TWlQTbkwQVY3QWa6JdjE/PwLDTZc=
+github.com/0xPolygon/cosmos-sdk v0.2.8-polygon/go.mod h1:Ogbng4keGEJeMj4KPlQzhfn4hf/G+CjqBqmvBKEB0jY=
 github.com/0xPolygon/cosmos-sdk/client/v2 v2.0.0-beta.6 h1:+6AxZcMTWHaRHV0HILf/rADWexzB4FJckdO/DnUlk+s=
 github.com/0xPolygon/cosmos-sdk/client/v2 v2.0.0-beta.6/go.mod h1:4p0P6o0ro+FizakJUYS9SeM94RNbv0thLmkHRw5o5as=
 github.com/0xPolygon/crand v1.0.3 h1:BYYflmgLhmGPEgqtopG4muq6wV6DOkwD8uPymNz5WeQ=
@@ -263,8 +263,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d h1:77cEq6EriyTZ0g/qfRdp61a3Uu/AWrgIq2s0ClJV1g0=
 github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d/go.mod h1:8EPpVsBuRksnlj1mLy4AWzRNQYxauNi62uWcE3to6eA=
-github.com/chenzhuoyu/iasm v0.9.1 h1:tUHQJXo3NhBqw6s33wkGn9SP3bvrWLdlVIJ3hQBL7P0=
-github.com/chenzhuoyu/iasm v0.9.1/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
+github.com/chenzhuoyu/iasm v0.9.0 h1:9fhXjVzq5hUy2gkhhgHl95zG2cEAhw9OSGs8toWWAwo=
+github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
@@ -451,8 +451,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
-github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
+github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
+github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/gballet/go-libpcsclite v0.0.0-20250918194357-1ec6f2e601c6 h1:ko+DlyhLqUHpgrvwqs5ybydoGAqjpJQTXpAS7vUqVlM=
 github.com/gballet/go-libpcsclite v0.0.0-20250918194357-1ec6f2e601c6/go.mod h1:3IVE7v4II2gS2V5amIH7F7NeYQtbbORtQtjdflgS1vk=
 github.com/getsentry/sentry-go v0.39.0 h1:uhnexj8PNCyCve37GSqxXOeXHh4cJNLNNB4w70Jtgo0=

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20260104020744-7268a54d0358 h1:B6uGMdZ4maUTJm+LYgBwEIDuJxgOUACw8K0Yg6jpNbY=
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20260104020744-7268a54d0358/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
+github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
+github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae h1:DcFpTQBYQ9Ct2d6sC7ol0/ynxc2pO1cpGUM+f4t5adg=
 github.com/RichardKnop/logging v0.0.0-20190827224416-1a693bdd4fae/go.mod h1:rJJ84PyA/Wlmw1hO+xTzV2wsSUon6J5ktg0g8BF2PuU=
@@ -279,6 +281,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cloudflare/cloudflare-go v0.114.0 h1:ucoti4/7Exo0XQ+rzpn1H+IfVVe++zgiM+tyKtf0HUA=
 github.com/cloudflare/cloudflare-go v0.114.0/go.mod h1:O7fYfFfA6wKqKFn2QIR9lhj7FDw6VQCGOY6hd2TBtd0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/0xPolygon/cometbft v0.3.8-polygon h1:0VAu6he3OA6ilaPD+MJIq21EZ6SXjzrd
 github.com/0xPolygon/cometbft v0.3.8-polygon/go.mod h1:u1LC4f7ZoB5nVGLzGVCn90c6G9eZCQ0uY03Bi2sA3NE=
 github.com/0xPolygon/cometbft-db v0.14.1-polygon h1:sMlEPISgW0Wm9bC3bnLVPiPnyZ9EOuWJxoAV8ujrN3o=
 github.com/0xPolygon/cometbft-db v0.14.1-polygon/go.mod h1:KHP1YghilyGV/xjD5DP3+2hyigWx0WTp9X+0Gnx0RxQ=
-github.com/0xPolygon/cosmos-sdk v0.2.8-polygon h1:laS7/tnOmzM4l77TWlQTbkwQVY3QWa6JdjE/PwLDTZc=
-github.com/0xPolygon/cosmos-sdk v0.2.8-polygon/go.mod h1:Ogbng4keGEJeMj4KPlQzhfn4hf/G+CjqBqmvBKEB0jY=
+github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715053728-c70ef2ad19ac h1:wViTiDRSShecu7MGgcdoNjbZGfsTlOT8YGYh8CTW4s4=
+github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715053728-c70ef2ad19ac/go.mod h1:qSFfQMi5ceBpDX4NZGJKbMwG7798v8awCmv4ByVWsIo=
 github.com/0xPolygon/cosmos-sdk/client/v2 v2.0.0-beta.6 h1:+6AxZcMTWHaRHV0HILf/rADWexzB4FJckdO/DnUlk+s=
 github.com/0xPolygon/cosmos-sdk/client/v2 v2.0.0-beta.6/go.mod h1:4p0P6o0ro+FizakJUYS9SeM94RNbv0thLmkHRw5o5as=
 github.com/0xPolygon/crand v1.0.3 h1:BYYflmgLhmGPEgqtopG4muq6wV6DOkwD8uPymNz5WeQ=
@@ -263,8 +263,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d h1:77cEq6EriyTZ0g/qfRdp61a3Uu/AWrgIq2s0ClJV1g0=
 github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d/go.mod h1:8EPpVsBuRksnlj1mLy4AWzRNQYxauNi62uWcE3to6eA=
-github.com/chenzhuoyu/iasm v0.9.0 h1:9fhXjVzq5hUy2gkhhgHl95zG2cEAhw9OSGs8toWWAwo=
-github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
+github.com/chenzhuoyu/iasm v0.9.1 h1:tUHQJXo3NhBqw6s33wkGn9SP3bvrWLdlVIJ3hQBL7P0=
+github.com/chenzhuoyu/iasm v0.9.1/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
@@ -451,8 +451,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
-github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
+github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
+github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gballet/go-libpcsclite v0.0.0-20250918194357-1ec6f2e601c6 h1:ko+DlyhLqUHpgrvwqs5ybydoGAqjpJQTXpAS7vUqVlM=
 github.com/gballet/go-libpcsclite v0.0.0-20250918194357-1ec6f2e601c6/go.mod h1:3IVE7v4II2gS2V5amIH7F7NeYQtbbORtQtjdflgS1vk=
 github.com/getsentry/sentry-go v0.39.0 h1:uhnexj8PNCyCve37GSqxXOeXHh4cJNLNNB4w70Jtgo0=

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/0xPolygon/cometbft v0.3.8-polygon h1:0VAu6he3OA6ilaPD+MJIq21EZ6SXjzrd
 github.com/0xPolygon/cometbft v0.3.8-polygon/go.mod h1:u1LC4f7ZoB5nVGLzGVCn90c6G9eZCQ0uY03Bi2sA3NE=
 github.com/0xPolygon/cometbft-db v0.14.1-polygon h1:sMlEPISgW0Wm9bC3bnLVPiPnyZ9EOuWJxoAV8ujrN3o=
 github.com/0xPolygon/cometbft-db v0.14.1-polygon/go.mod h1:KHP1YghilyGV/xjD5DP3+2hyigWx0WTp9X+0Gnx0RxQ=
-github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715053728-c70ef2ad19ac h1:wViTiDRSShecu7MGgcdoNjbZGfsTlOT8YGYh8CTW4s4=
-github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715053728-c70ef2ad19ac/go.mod h1:qSFfQMi5ceBpDX4NZGJKbMwG7798v8awCmv4ByVWsIo=
+github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715060632-d5213f0685ae h1:P/wMxIL1GurOt4vgklOeb3ya6eI9QIinMkOPK2i8820=
+github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715060632-d5213f0685ae/go.mod h1:qSFfQMi5ceBpDX4NZGJKbMwG7798v8awCmv4ByVWsIo=
 github.com/0xPolygon/cosmos-sdk/client/v2 v2.0.0-beta.6 h1:+6AxZcMTWHaRHV0HILf/rADWexzB4FJckdO/DnUlk+s=
 github.com/0xPolygon/cosmos-sdk/client/v2 v2.0.0-beta.6/go.mod h1:4p0P6o0ro+FizakJUYS9SeM94RNbv0thLmkHRw5o5as=
 github.com/0xPolygon/crand v1.0.3 h1:BYYflmgLhmGPEgqtopG4muq6wV6DOkwD8uPymNz5WeQ=

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/0xPolygon/cometbft v0.3.8-polygon h1:0VAu6he3OA6ilaPD+MJIq21EZ6SXjzrd
 github.com/0xPolygon/cometbft v0.3.8-polygon/go.mod h1:u1LC4f7ZoB5nVGLzGVCn90c6G9eZCQ0uY03Bi2sA3NE=
 github.com/0xPolygon/cometbft-db v0.14.1-polygon h1:sMlEPISgW0Wm9bC3bnLVPiPnyZ9EOuWJxoAV8ujrN3o=
 github.com/0xPolygon/cometbft-db v0.14.1-polygon/go.mod h1:KHP1YghilyGV/xjD5DP3+2hyigWx0WTp9X+0Gnx0RxQ=
-github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715060632-d5213f0685ae h1:P/wMxIL1GurOt4vgklOeb3ya6eI9QIinMkOPK2i8820=
-github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715060632-d5213f0685ae/go.mod h1:qSFfQMi5ceBpDX4NZGJKbMwG7798v8awCmv4ByVWsIo=
+github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715080111-ed2455f86da0 h1:1HHLgL4pqf5P3tVqQI0lWNizf6wBhDJPsgLuXBfNe1A=
+github.com/0xPolygon/cosmos-sdk v0.50.13-0.20260715080111-ed2455f86da0/go.mod h1:qSFfQMi5ceBpDX4NZGJKbMwG7798v8awCmv4ByVWsIo=
 github.com/0xPolygon/cosmos-sdk/client/v2 v2.0.0-beta.6 h1:+6AxZcMTWHaRHV0HILf/rADWexzB4FJckdO/DnUlk+s=
 github.com/0xPolygon/cosmos-sdk/client/v2 v2.0.0-beta.6/go.mod h1:4p0P6o0ro+FizakJUYS9SeM94RNbv0thLmkHRw5o5as=
 github.com/0xPolygon/crand v1.0.3 h1:BYYflmgLhmGPEgqtopG4muq6wV6DOkwD8uPymNz5WeQ=

--- a/internal/build/pgp.go
+++ b/internal/build/pgp.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"os"
 
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
 // PGPSignFile parses a PGP private key from the specified string and creates a


### PR DESCRIPTION
## Summary

Replaces Bor's unmaintained OpenPGP release-signing dependency with the maintained ProtonMail implementation, updates Go build surfaces to 1.26.5, and moves GitHub Actions caches to the Node 24-compatible release. The branch temporarily points Bor at the patched Polygon Cosmos SDK branch and enables govulncheck on feature-branch pushes so the complete dependency chain can be validated. With these changes, `make vulncheck` reports zero reachable vulnerabilities.

## Executed tests

- `make vulncheck` — passed with zero reachable vulnerabilities.
- `go test ./internal/build ./consensus/bor/heimdall/... ./internal/cli/server` — passed.
- Polygon Cosmos SDK: `GOTOOLCHAIN=go1.26.5 go test ./crypto/...` — passed.
- Polygon Cosmos SDK: `GOTOOLCHAIN=go1.26.5 make vulncheck` — passed with zero reachable vulnerabilities.
- `git diff --check` — passed.

`diffguard` was unavailable in the local environment and was not run.

## Rollout notes

This change is not consensus-affecting and does not require a coordinated network upgrade. Release signing remains backward-compatible, and the Cosmos SDK change preserves legacy CRC24 validation for armored keys. Before merge, replace the temporary Cosmos SDK pseudo-version with the released Polygon SDK tag and remove the feature-branch-only govulncheck push trigger so the workflow returns to its normal nightly schedule.