### PR TITLE
consensus/bor, internal/ethapi: skip span and state-sync commits in simulated blocks

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1387,26 +1387,10 @@ func (c *Bor) finalizeAndAssemble(chain consensus.ChainHeaderReader, header *typ
 	)
 
 	if !simulated && IsSprintStart(headerNumber, c.config.CalculateSprint(headerNumber)) {
-		borStart := time.Now()
-		cx := statefull.ChainContext{Chain: chain, Bor: c}
-
-		// check and commit span
-		if !c.config.IsRio(header.Number) {
-			if err = c.checkAndCommitSpan(state, header, cx); err != nil {
-				log.Error("Error while committing span", "error", err)
-				return nil, nil, 0, err
-			}
+		stateSyncData, err = c.commitSprintWork(chain, header, state)
+		if err != nil {
+			return nil, nil, 0, err
 		}
-
-		if c.HeimdallClient != nil {
-			// commit states
-			stateSyncData, err = c.CommitStates(state, header, cx)
-			if err != nil {
-				log.Error("Error while committing states", "error", err)
-				return nil, nil, 0, err
-			}
-		}
-		state.BorConsensusTime = time.Since(borStart)
 	}
 
 	if err = c.changeContractCodeIfNeeded(headerNumber, state); err != nil {
@@ -1439,6 +1423,37 @@ func (c *Bor) finalizeAndAssemble(chain consensus.ChainHeaderReader, header *typ
 
 	// return the final block for sealing
 	return block, receipts, commitTime, nil
+}
+
+// commitSprintWork commits the span (pre-Rio) and state-sync data at a
+// sprint-start block during block assembly.
+func (c *Bor) commitSprintWork(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB) ([]*types.StateSyncData, error) {
+	borStart := time.Now()
+	cx := statefull.ChainContext{Chain: chain, Bor: c}
+
+	// check and commit span
+	if !c.config.IsRio(header.Number) {
+		if err := c.checkAndCommitSpan(state, header, cx); err != nil {
+			log.Error("Error while committing span", "error", err)
+			return nil, err
+		}
+	}
+
+	var stateSyncData []*types.StateSyncData
+
+	if c.HeimdallClient != nil {
+		// commit states
+		var err error
+		stateSyncData, err = c.CommitStates(state, header, cx)
+		if err != nil {
+			log.Error("Error while committing states", "error", err)
+			return nil, err
+		}
+	}
+
+	state.BorConsensusTime = time.Since(borStart)
+
+	return stateSyncData, nil
 }
 
 // Authorize injects a private key into the consensus engine to mint new blocks

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1358,6 +1358,21 @@ func (c *Bor) changeContractCodeIfNeeded(headerNumber uint64, state vm.StateDB) 
 // FinalizeAndAssemble implements consensus.Engine, ensuring no uncles are set,
 // nor block rewards given, and returns the final block.
 func (c *Bor) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt) (*types.Block, []*types.Receipt, time.Duration, error) {
+	return c.finalizeAndAssemble(chain, header, state, body, receipts, false)
+}
+
+// FinalizeAndAssembleForSimulation is FinalizeAndAssemble for simulated blocks
+// (eth_simulateV1). It skips the sprint-start span and state-sync commits:
+// their internal genesis contract calls resolve the parent header by hash from
+// the database, but a simulated block's parent may be a phantom header that is
+// never persisted (the pending block, or an earlier simulated block). The
+// skipped data is external Heimdall input that cannot be known for a future
+// block anyway.
+func (c *Bor) FinalizeAndAssembleForSimulation(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt) (*types.Block, []*types.Receipt, time.Duration, error) {
+	return c.finalizeAndAssemble(chain, header, state, body, receipts, true)
+}
+
+func (c *Bor) finalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt, simulated bool) (*types.Block, []*types.Receipt, time.Duration, error) {
 	headerNumber := header.Number.Uint64()
 	if body.Withdrawals != nil || header.WithdrawalsHash != nil {
 		return nil, nil, 0, consensus.ErrUnexpectedWithdrawals
@@ -1371,7 +1386,7 @@ func (c *Bor) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *typ
 		err           error
 	)
 
-	if IsSprintStart(headerNumber, c.config.CalculateSprint(headerNumber)) {
+	if !simulated && IsSprintStart(headerNumber, c.config.CalculateSprint(headerNumber)) {
 		borStart := time.Now()
 		cx := statefull.ChainContext{Chain: chain, Bor: c}
 

--- a/consensus/bor/bor_test.go
+++ b/consensus/bor/bor_test.go
@@ -5956,3 +5956,47 @@ func TestApplyMessage_StateSyncTxContext(t *testing.T) {
 	gotGasprice := statedb.GetState(addr, common.BigToHash(big.NewInt(1)))
 	require.Equal(t, common.Hash{}, gotGasprice, "GASPRICE must be 0")
 }
+
+func TestFinalizeAndAssembleForSimulationSkipsSprintCommits(t *testing.T) {
+	t.Parallel()
+
+	cfg := &params.BorConfig{
+		Sprint:   map[string]uint64{"0": 16},
+		Period:   map[string]uint64{"0": 1},
+		RioBlock: big.NewInt(math.MaxInt64),
+	}
+
+	validatorAddr := common.HexToAddress("0x9")
+	sp := &fakeSpanner{vals: []*valset.Validator{{Address: validatorAddr, VotingPower: 100}}}
+
+	ch, borEngine := newChainAndBorForTest(t, sp, cfg, true, validatorAddr, uint64(time.Now().Unix()))
+	borEngine.HeimdallClient = &failingHeimdallClient{}
+	borEngine.GenesisContractsClient = &failingGenesisContract{}
+
+	genesisHeader := ch.HeaderChain().GetHeaderByNumber(0)
+	require.NotNil(t, genesisHeader)
+
+	newState := func() *state.StateDB {
+		db := rawdb.NewMemoryDatabase()
+		st, err := state.New(genesisHeader.Root, state.NewDatabase(triedb.NewDatabase(db, triedb.HashDefaults), nil))
+		require.NoError(t, err)
+		return st
+	}
+
+	// Block 16 is a sprint start. Its parent is a phantom header that is not
+	// in the database, as happens when eth_simulateV1 builds on the pending
+	// block or on an earlier simulated block.
+	hdr := createTestHeader(genesisHeader, 16, cfg.Period["0"])
+	hdr.ParentHash = common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+
+	// The regular path attempts the sprint-start state-sync commit.
+	_, _, _, err := borEngine.FinalizeAndAssemble(ch, types.CopyHeader(hdr), newState(), &types.Body{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "last state id failed")
+
+	// The simulation path skips span and state-sync commits and assembles the block.
+	block, _, _, err := borEngine.FinalizeAndAssembleForSimulation(ch, types.CopyHeader(hdr), newState(), &types.Body{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, block)
+	require.Equal(t, uint64(16), block.NumberU64())
+}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1014,6 +1014,9 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 			} else {
 				log.Warn("Error fetching header on CallWithState", "err", err)
 			}
+			if err == nil {
+				err = fmt.Errorf("header not found for hash %v", *blockNrOrHash.BlockHash)
+			}
 			return nil, err
 		}
 	}

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -5564,3 +5564,38 @@ func TestCallWithStateMissingHeader(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "header not found for hash")
 }
+
+// simFinalizingEngine wraps an engine with the simulation finalization hook so
+// tests can exercise the simulationFinalizer dispatch in eth_simulateV1.
+type simFinalizingEngine struct {
+	consensus.Engine
+	simFinalized bool
+}
+
+func (e *simFinalizingEngine) FinalizeAndAssembleForSimulation(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt) (*types.Block, []*types.Receipt, time.Duration, error) {
+	e.simFinalized = true
+	return e.Engine.FinalizeAndAssemble(chain, header, state, body, receipts)
+}
+
+func TestSimulateV1DispatchesSimulationFinalize(t *testing.T) {
+	t.Parallel()
+
+	accounts := newAccounts(2)
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc:  types.GenesisAlloc{accounts[0].addr: {Balance: big.NewInt(params.Ether)}},
+	}
+	engine := &simFinalizingEngine{Engine: ethash.NewFaker()}
+	api := NewBlockChainAPI(newTestBackend(t, 1, genesis, engine, func(i int, b *core.BlockGen) {}))
+
+	latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+	opts := simOpts{BlockStateCalls: []simBlock{{Calls: []TransactionArgs{{
+		From:  &accounts[0].addr,
+		To:    &accounts[1].addr,
+		Value: (*hexutil.Big)(big.NewInt(1)),
+	}}}}}
+	res, err := api.SimulateV1(context.Background(), opts, &latest)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.True(t, engine.simFinalized, "simulation finalization hook was not used")
+}

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -5540,3 +5540,27 @@ func TestAccountAt(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled)
 	})
 }
+
+func TestCallWithStateMissingHeader(t *testing.T) {
+	t.Parallel()
+
+	accounts := newAccounts(1)
+	genesis := &core.Genesis{
+		Config: params.MergedTestChainConfig,
+		Alloc:  types.GenesisAlloc{accounts[0].addr: {Balance: big.NewInt(params.Ether)}},
+	}
+	backend := newTestBackend(t, 1, genesis, beacon.New(ethash.NewFaker()), func(i int, b *core.BlockGen) { b.SetPoS() })
+	api := NewBlockChainAPI(backend)
+
+	statedb, _, err := backend.StateAndHeaderByNumberOrHash(context.Background(), rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
+	require.NoError(t, err)
+
+	// A block ref carrying both number and hash resolves by hash on the
+	// consensus-internal path; an unknown hash must be a clear error, not a
+	// nil result.
+	blockNr := rpc.BlockNumber(1)
+	phantom := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	_, err = api.CallWithState(context.Background(), TransactionArgs{From: &accounts[0].addr, To: &accounts[0].addr}, &rpc.BlockNumberOrHash{BlockNumber: &blockNr, BlockHash: &phantom}, statedb, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "header not found for hash")
+}

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -119,6 +119,15 @@ type simOpts struct {
 	ReturnFullTransactions bool
 }
 
+// simulationFinalizer is implemented by consensus engines that need a
+// side-effect-free finalization path for simulated blocks. Bor's regular
+// FinalizeAndAssemble commits span and state-sync data at sprint starts,
+// which requires the parent header to exist in the database — not true for
+// blocks simulated on top of the pending block or another simulated block.
+type simulationFinalizer interface {
+	FinalizeAndAssembleForSimulation(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt) (*types.Block, []*types.Receipt, time.Duration, error)
+}
+
 // simChainHeadReader implements ChainHeaderReader which is needed as input for FinalizeAndAssemble.
 type simChainHeadReader struct {
 	context.Context
@@ -430,13 +439,24 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	}
 	blockBody := &types.Body{Transactions: txes, Withdrawals: withdrawals}
 	chainHeadReader := &simChainHeadReader{ctx, sim.b}
-	b, receipts, _, err := sim.b.Engine().FinalizeAndAssemble(chainHeadReader, header, sim.state, blockBody, receipts)
-	_ = receipts // mark unused
+	b, err := sim.finalizeAndAssemble(chainHeadReader, header, blockBody, receipts)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	repairLogs(callResults, b.Hash())
 	return b, callResults, senders, nil
+}
+
+// finalizeAndAssemble runs the engine finalization for a simulated block,
+// preferring the side-effect-free simulation path when the engine provides
+// one (see simulationFinalizer).
+func (sim *simulator) finalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, body *types.Body, receipts []*types.Receipt) (*types.Block, error) {
+	if engine, ok := sim.b.Engine().(simulationFinalizer); ok {
+		b, _, _, err := engine.FinalizeAndAssembleForSimulation(chain, header, sim.state, body, receipts)
+		return b, err
+	}
+	b, _, _, err := sim.b.Engine().FinalizeAndAssemble(chain, header, sim.state, body, receipts)
+	return b, err
 }
 
 // repairLogs updates the block hash in the logs present in the result of


### PR DESCRIPTION
## Summary

`eth_simulateV1` runs simulated blocks through Bor's `FinalizeAndAssemble`, which at sprint-start blocks commits span and state-sync data. Those commits make internal genesis contract calls that resolve the parent header by hash from the database — but a simulated block's parent can be a phantom header that is never persisted: the pending block when simulating on top of the `pending` tag, or an earlier simulated block in a multi-block request. The lookup returns no header, and the request fails with `-32000: DoCall returned nil result with no error (block=0x...)` whenever the first simulated block lands on a sprint boundary — every 16th block on mainnet, i.e. ~6% of `pending`-based requests. (Both failing blocks reported by users confirm the pattern: `0x5637f0f` and `0x5637d5f`, each `(multiple of 16) - 1`, so the simulated block `+1` is a sprint start.)

This adds `FinalizeAndAssembleForSimulation`, which skips the sprint-start span and state-sync commits, and dispatches to it from the simulator (via an interface assertion, so non-Bor engines keep the regular path). The skipped data is external Heimdall input that cannot be known for a future block anyway; skipping also removes an RPC-triggered synchronous Heimdall call (`waitUntilHeimdallIsSynced` + `StateSyncEvents`) from the public `eth_simulateV1` path. This matches upstream geth semantics, where simulate runs no consensus side effects.

Also hardens `DoCall`: a missing header on the by-hash path now returns an explicit `header not found for hash 0x...` error instead of a nil result with no error.

Behavioral note: simulated sprint-start blocks no longer contain state-sync transactions that the eventual real block might include. This is intentional — those events are unknowable ahead of production time, and callers who want them can model them deterministically via `stateOverrides`.

## Executed tests

- New regression test `TestFinalizeAndAssembleForSimulationSkipsSprintCommits`: a sprint-start block with a non-persisted parent fails through the regular path (state-sync commit attempted) and assembles cleanly through the simulation path.
- New `TestCallWithStateMissingHeader` covering the explicit `DoCall` error.
- Full `consensus/bor`, `internal/ethapi`, and `ethclient` (`TestSimulateV1*`) suites pass locally.
- Diffguard with mutation testing: 100% kill rate (13/13), no dependency cycles, no dead code. One surfaced pre-existing size violation: `(Bor).finalizeAndAssemble` (68 lines, the renamed existing `FinalizeAndAssemble` body) — not refactored here to keep the consensus diff minimal.

## Rollout notes

Not consensus-affecting: the change only alters the `eth_simulateV1` execution path (simulated blocks are never sealed or imported) and an internal error message. Real block production, verification, and import paths are untouched — `FinalizeAndAssemble` behavior is unchanged for them. Backwards-compatible, no coordinated upgrade needed. Operator-facing change: `eth_simulateV1` with `pending` (or multi-block requests) no longer fails sporadically at sprint boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)