### PR TITLE
chore: update log level from Debug to Warn for phantomblock errors

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -1149,7 +1149,7 @@ func (f *BlockFetcher) importHeaders(peer string, header *types.Header) {
 		}
 		// Validate the header and if something went wrong, drop the peer
 		if err := f.verifyHeader(header); err != nil && err != consensus.ErrFutureBlock {
-			log.Debug("Propagated header verification failed", "peer", peer, "number", header.Number, "hash", hash, "err", err)
+			log.Warn("Propagated header verification failed", "peer", peer, "number", header.Number, "hash", hash, "err", err)
 			f.dropPeer(peer)
 
 			return
@@ -1197,7 +1197,7 @@ func (f *BlockFetcher) importBlocks(peer string, block *types.Block, witness *st
 
 		default:
 			// Something went very wrong, drop the peer
-			log.Debug("Propagated block verification failed", "peer", peer, "number", block.Number(), "hash", hash, "err", err)
+			log.Warn("Propagated block verification failed", "peer", peer, "number", block.Number(), "hash", hash, "err", err)
 			f.dropPeer(peer)
 
 			return


### PR DESCRIPTION
## Summary 
Bumps the two propagated-block verification-failure logs in the fetcher (importHeaders / importBlocks) from log.Debug to log.Warn. These fire when a peer gossips a block whose header fails consensus verification (e.g. a mis-signed / "phantom" block — signer not in the producer set) and the peer is dropped. This is a logging-only change: 

## Executed tests
Beyond CI unit/integration:

Built this branch and ran it live against Amoy (`posv1-devnodes-amoy-bor-val-1)`. Drove the fake-peer harness's phantomblock and fakeblocks scenarios `(invalid propagated blocks) `and confirmed the drop now surfaces in Datadog as WARN Propagated block verification failed; dropping peer and is verifiable: [Amoy logs](https://app.datadoghq.eu/logs?query=host%3Aposv1-devnodes-amoy-bor-val-1%2A%20%22Propagated%20block%20verification%20failed%22&from_ts=1784789020000&to_ts=1784789395000&live=false).

## Executed tests
Not consensus-affecting — logging-level change only; no block/state/validation behaviour changes.
No coordinated upgrade required; fully backwards-compatible; no config or API change.
Operator-facing: adds WARN lines when peers propagate consensus-invalid blocks. Volume is low and bounded (only on invalid-block propagation) and is the intended visibility improvement. No log-volume concern at normal rates.