### PR TITLE
.github: bump codegenie to v0.5.1 and model to opus-5

### DIFF
--- a/.github/workflows/codegenie-review.yml
+++ b/.github/workflows/codegenie-review.yml
@@ -52,9 +52,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: 0xPolygon/codegenie@v0.4.2
+      - uses: 0xPolygon/codegenie@v0.5.1
         with:
-          model: "anthropic/claude-opus-4-8:high"
+          model: "anthropic/claude-opus-5:high"
           llm-api-key: ${{ secrets.CLAUDE_API_KEY }}
           trigger-phrase: "codegenie review"
           post-inline-comments: "true"


### PR DESCRIPTION
## Summary
Bumps the CodeGenie review workflow to the latest release and model:
- `0xPolygon/codegenie@v0.4.2` → `@v0.5.1`
- `model: anthropic/claude-opus-4-8:high` → `anthropic/claude-opus-5:high`

**v0.5.1 includes the `issue_comment` gh-auth fix** ([0xPolygon/codegenie#10](https://github.com/0xPolygon/codegenie/pull/10)), so bor's comment-only lane (`codegenie review`) now works — previously it failed with `gh_auth_failed` because the older `gh auth status` preflight rejected the Actions installation token. Model bump follows Peter's updated upstream template.

Unchanged and intentional for bor: `CLAUDE_API_KEY` (the secret provisioned/working here), `actions/checkout@v5` (repo convention), the key preflight guard, and the comment-only trigger.

## Executed tests
None yet — CI-only workflow bump. Validation plan after merge: comment `codegenie review` on an open PR and confirm a review posts (comment triggers resolve from the default branch, so this is inert until merged). The comment lane was previously blocked only by the gh-auth bug now fixed in v0.5.1.

## Rollout notes
Not consensus-affecting. Non-blocking review lane; no required check added. Assumes the `CLAUDE_API_KEY` account has `opus-5` access — first run confirms.