### PR TITLE
accounts/keystore: serialize scans with deletion

### DIFF
--- a/accounts/keystore/account_cache.go
+++ b/accounts/keystore/account_cache.go
@@ -73,6 +73,7 @@ type accountCache struct {
 	throttle *time.Timer
 	notify   chan struct{}
 	fileC    fileCache
+	scanMu   sync.Mutex
 }
 
 func newAccountCache(keydir string) (*accountCache, chan struct{}) {
@@ -131,6 +132,17 @@ func (ac *accountCache) delete(removed accounts.Account) {
 	} else {
 		ac.byAddr[removed.Address] = ba
 	}
+}
+
+func (ac *accountCache) deleteFile(removed accounts.Account) error {
+	ac.scanMu.Lock()
+	defer ac.scanMu.Unlock()
+
+	if err := os.Remove(removed.URL.Path); err != nil {
+		return err
+	}
+	ac.delete(removed)
+	return nil
 }
 
 // deleteByFile removes an account referenced by the given path.
@@ -253,6 +265,9 @@ func (ac *accountCache) close() {
 // scanAccounts checks if any changes have occurred on the filesystem, and
 // updates the account cache accordingly
 func (ac *accountCache) scanAccounts() error {
+	ac.scanMu.Lock()
+	defer ac.scanMu.Unlock()
+
 	// Scan the entire folder metadata for file changes
 	creates, deletes, updates, err := ac.fileC.scan(ac.keydir)
 	if err != nil {

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -25,7 +25,6 @@ import (
 	crand "crypto/rand"
 	"errors"
 	"math/big"
-	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -251,16 +250,11 @@ func (ks *KeyStore) Delete(a accounts.Account, passphrase string) error {
 	if err != nil {
 		return err
 	}
-	// The order is crucial here. The key is dropped from the
-	// cache after the file is gone so that a reload happening in
-	// between won't insert it into the cache again.
-	err = os.Remove(a.URL.Path)
-	if err == nil {
-		ks.cache.delete(a)
-		ks.refreshWallets()
+	if err := ks.cache.deleteFile(a); err != nil {
+		return err
 	}
-
-	return err
+	ks.refreshWallets()
+	return nil
 }
 
 // SignHash calculates a ECDSA signature for the given hash. The produced

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -78,6 +78,36 @@ func TestKeyStore(t *testing.T) {
 	}
 }
 
+type removeKeyOnReadStore struct {
+	keyStore
+}
+
+func (s *removeKeyOnReadStore) GetKey(addr common.Address, filename, auth string) (*Key, error) {
+	key, err := s.keyStore.GetKey(addr, filename, auth)
+	if err != nil {
+		return key, err
+	}
+	if err := os.Remove(filename); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func TestDeleteFileDisappearsAfterKeyLookup(t *testing.T) {
+	t.Parallel()
+	_, ks := tmpKeyStore(t)
+
+	account, err := ks.NewAccount("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ks.storage = &removeKeyOnReadStore{keyStore: ks.storage}
+
+	if err := ks.Delete(account, ""); !os.IsNotExist(err) {
+		t.Fatalf("Delete error = %v, want file-not-found", err)
+	}
+}
+
 func TestSign(t *testing.T) {
 	t.Parallel()
 	_, ks := tmpKeyStore(t)


### PR DESCRIPTION
## Summary

The nightly race run [30603502369](https://github.com/0xPolygon/bor/actions/runs/30603502369) failed in `accounts/keystore.TestWalletNotifications` because a filesystem scan could race with `KeyStore.Delete`: the scan could read an account before deletion, then reinsert it into the cache after the file and cached entry were removed. This left a stale wallet and emitted an out-of-order `WalletArrived` event.

This behavior is inherited from upstream go-ethereum and is tracked in [ethereum/go-ethereum#29830](https://github.com/ethereum/go-ethereum/issues/29830) and the open fix attempt [ethereum/go-ethereum#30053](https://github.com/ethereum/go-ethereum/pull/30053). The fix serializes complete account scans with file deletion inside `accountCache`, so either the scan completes before deletion or it observes the post-deletion filesystem state. The strict event-order assertion remains unchanged. A regression test covers the error path where a key file disappears after successful key lookup.

## Executed tests

- Before the fix: `go test -race ./accounts/keystore -run '^TestWalletNotifications$' -count=200` reproduced two failures.
- After the fix: the same command passed 200/200 iterations.
- `go test -race ./accounts/keystore -shuffle=1785471185402047521 -count=10`
- `go test -race ./accounts/keystore -run '^TestDeleteFileDisappearsAfterKeyLookup$' -count=20`
- `go test ./accounts/keystore`
- `go vet ./accounts/keystore`
- `make lint` (`0 issues`)
- `diffguard --base origin/develop .` (100% mutation score, 10/10 killed)

`gosec ./accounts/keystore/...` could not build a complete SSA representation with the repository's Go 1.26 toolchain. Its reported findings were pre-existing and outside the changed lines.

## Rollout notes

This is a backward-compatible keystore synchronization fix. It does not affect consensus, configuration, key formats, or persisted chain data. A deletion may briefly wait for an in-progress keystore scan; no coordinated rollout is required.
