### PR TITLE
ci: run E2E tests for every PR base

### DIFF
--- a/.github/workflows/kurtosis-e2e.yml
+++ b/.github/workflows/kurtosis-e2e.yml
@@ -6,9 +6,6 @@ on:
       - 'master'
       - 'develop'
   pull_request:
-    branches:
-      - 'master'
-      - 'develop'
     types: [opened, synchronize]
 
 concurrency:

--- a/.github/workflows/kurtosis-stateless-e2e.yml
+++ b/.github/workflows/kurtosis-stateless-e2e.yml
@@ -6,9 +6,6 @@ on:
       - 'master'
       - 'develop'
   pull_request:
-    branches:
-      - 'master'
-      - 'develop'
     types: [opened, synchronize]
 
 concurrency:


### PR DESCRIPTION
## Summary
Remove the pull_request base-branch filters from the Kurtosis E2E and Kurtosis Stateless E2E workflows. Both workflows will now run for opened and synchronized PRs regardless of the target branch, while push triggers remain limited to master and develop.

## Executed tests
- Parsed both modified workflow files as YAML.
- Ran git diff --check.
- Verified the commit GPG signature.

The workflows themselves will run through CI on this PR.

## Rollout notes
CI-only change. No consensus, runtime, or operator-facing behavior changes.