### PR TITLE
p2p/discover: delay revalidation in UDPv5 tests

### DIFF
--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -1011,6 +1011,7 @@ func newUDPV5Test(t *testing.T) *udpV5Test {
 		PrivateKey:   test.localkey,
 		Log:          testlog.Logger(t, log.LvlTrace),
 		ValidSchemes: enode.ValidSchemesForTesting,
+		PingInterval: 1000 * time.Hour,
 	})
 	test.udp.codec = &testCodec{test: test, id: ln.ID()}
 	test.table = test.udp.tab


### PR DESCRIPTION
## Summary
Backports [ethereum/go-ethereum#34109](https://github.com/ethereum/go-ethereum/pull/34109) to fix the upstream UDPv5 test-harness flake seen in [nightly race run 31070233940](https://github.com/0xPolygon/bor/actions/runs/31070233940).

The virtual UDPv5 harness used the production 3-second table revalidation interval. Because the first revalidation is randomized from zero to that interval, it fired while `TestUDPv5_lookup` was completing under the race detector. A legitimate background `PING` was queued just as the lookup goroutine closed the transport, and teardown reported it as an unmatched packet.

This is an inherited upstream test flake, not a Bor runtime bug, data race, CI/infrastructure failure, or external dependency failure. The fix sets the test harness revalidation interval to 1000 hours, matching upstream commit [e1fe4a1a9](https://github.com/ethereum/go-ethereum/commit/e1fe4a1a98e531ded82805dd1724b189b3f22037). Production discovery timing and the unmatched-packet assertion are unchanged.

## Executed tests
- `go test -race ./p2p/discover -run '^TestUDPv5_lookup$' -shuffle=1785993086613164091 -count=1000` (pass)
- `go test -race ./p2p/discover -shuffle=1785993086613164091 -count=5` (pass)
- `go vet ./p2p/discover` (pass)
- `make lint` (0 issues)
- Diffguard with mutation enabled exited 0; the test-only configuration diff produced no mutation targets.

## Rollout notes
Test-only change. No consensus, runtime, operator, or rollout impact.

The same upstream commit is already included in the pending v1.17.x merge stack. The source change is identical, so that merge should remain clean. The upstream solution uses a very long interval rather than fully disabling revalidation; an immediate timer draw remains theoretically possible but is negligible, and any future deterministic-clock improvement should be taken from upstream.