### PR TITLE
miner: avoid recursive worker read lock

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -607,7 +607,11 @@ func (w *worker) setGasCeil(ceil uint64) {
 func (w *worker) calculateDesiredGasLimit(parent *types.Header) uint64 {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
+	return w.calculateDesiredGasLimitLocked(parent)
+}
 
+// calculateDesiredGasLimitLocked requires w.mu to be held for reading.
+func (w *worker) calculateDesiredGasLimitLocked(parent *types.Header) uint64 {
 	// If dynamic gas limit is not enabled, use the static GasCeil
 	if !w.config.EnableDynamicGasLimit {
 		return w.config.GasCeil
@@ -1930,7 +1934,8 @@ type generateParams struct {
 	planWg                    sync.WaitGroup          // Tracks sendPlan goroutines; must reach zero before builderPlanCh is closed
 }
 
-// makeHeader creates a new block header for sealing.
+// makeHeader creates a new block header for sealing. The caller must hold w.mu
+// for reading because the header includes mutable worker configuration.
 func (w *worker) makeHeader(genParams *generateParams, waitOnPrepare bool) (*types.Header, common.Address, error) {
 	// Find the parent block for sealing task
 	parent := w.chain.CurrentBlock()
@@ -1968,7 +1973,7 @@ func (w *worker) makeHeader(genParams *generateParams, waitOnPrepare bool) (*typ
 	}
 
 	// Calculate desired gas limit (may be dynamically adjusted based on base fee)
-	desiredGasLimit := w.calculateDesiredGasLimit(parent)
+	desiredGasLimit := w.calculateDesiredGasLimitLocked(parent)
 
 	// Construct the sealing block header.
 	header := &types.Header{

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -1913,6 +1913,57 @@ func TestCalculateDesiredGasLimit_BufferUnderflow(t *testing.T) {
 	}
 }
 
+func TestMakeHeaderWithQueuedWriter(t *testing.T) {
+	chainConfig := borUnittestChainConfigWithGiugliano()
+	engine, ctrl := getFakeBorFromConfig(t, chainConfig)
+	defer engine.Close()
+	defer ctrl.Finish()
+
+	w, _, cleanup := newTestWorker(t, DefaultTestConfig(), chainConfig, engine, rawdb.NewMemoryDatabase(), false, 0)
+	defer cleanup()
+
+	w.mu.RLock()
+	lockHeld := true
+	defer func() {
+		if lockHeld {
+			w.mu.RUnlock()
+		}
+	}()
+
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		w.setExtra([]byte("queued writer"))
+	}()
+	require.Eventually(t, func() bool {
+		if w.mu.TryRLock() {
+			w.mu.RUnlock()
+			return false
+		}
+		return true
+	}, 5*time.Second, time.Millisecond, "writer did not wait for worker lock")
+
+	headerDone := make(chan error, 1)
+	params := &generateParams{timestamp: uint64(time.Now().Unix()), coinbase: testBankAddress}
+	go func() {
+		_, _, err := w.makeHeader(params, false)
+		headerDone <- err
+	}()
+	select {
+	case err := <-headerDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		w.mu.RUnlock()
+		lockHeld = false
+		<-writerDone
+		require.NoError(t, <-headerDone)
+		t.Fatal("makeHeader blocked behind a writer while the caller held the read lock")
+	}
+	w.mu.RUnlock()
+	lockHeld = false
+	<-writerDone
+}
+
 // TestCommitMetrics tests that the commit function properly tracks metrics
 // by verifying the code executes without errors through the full commit path
 func TestCommitMetrics(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes the miner timeout in [nightly race run 31292744499](https://github.com/0xPolygon/bor/actions/runs/31292744499), where `TestPrefetchRaceWithSetExtra` ran until the package's 15-minute timeout.

This was a real Bor block-production concurrency bug exposed by the test, not a flaky assertion, CI instability, or an external dependency failure. `prepareWork` and `runPrefetcher` hold `worker.mu` for reading while calling `makeHeader`. The dynamic gas-limit helper attempted to acquire the same read lock again. When `SetExtra` queued for the write lock, Go's writer-preferring `RWMutex` blocked the nested reader; the writer could not proceed until the outer reader released, creating a deadlock.

The fix keeps the lock-taking gas-limit helper for standalone callers and adds a lock-held helper for `makeHeader`. A deterministic regression test queues a writer, confirms it is waiting, and verifies that header construction completes while its caller retains the read lock.

## Executed tests
- Pre-fix regression: `TestMakeHeaderWithQueuedWriter` failed with the expected blocked-header assertion.
- `go test -race ./miner -run '^TestMakeHeaderWithQueuedWriter$' -count=20`
- `go test -race ./miner -run '^TestPrefetchRaceWithSetExtra$' -shuffle=1786249703675931145 -count=5`
- `go test -race ./miner -run '^TestCalculateDesiredGasLimit' -count=10`
- `go test -race ./miner -shuffle=1786249703675931145 -count=1 -timeout=15m`
- `go vet ./miner`
- `make lint` (0 issues)
- Diffguard using the PR workflow configuration with mutation testing: 100% (1/1 killed)
- `gosec ./miner/...` found no issue on changed lines; it exited non-zero for 22 pre-existing findings elsewhere in `miner`.
- PR CI: unit tests, integration tests, both e2e variants, lint, CodeQL, Diffguard, and Codecov passed.

## Rollout notes
Backward-compatible locking fix. It does not change gas-limit calculation, header contents, consensus rules, configuration, or operator behavior.

The current `develop` dependency set has an unrelated `govulncheck` failure for `GO-2026-6061` in `google.golang.org/grpc v1.79.3`; recent nightly govulncheck runs already fail on the same base SHA. That dependency update remains separate from this PR.

Remaining risk is limited to future call paths invoking `makeHeader` without holding `worker.mu`; all current production and test call sites were audited and hold the read lock. CI unit, integration, and both e2e variants passed.
