### PR TITLE
core/vm: check SSTORE access affordability before reading committed state

### DIFF
--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -193,3 +193,68 @@ func TestCreateGas(t *testing.T) {
 		}
 	}
 }
+
+// readCountingStateDB counts committed-state reads so a test can assert whether
+// the SSTORE gas path performed the slot read.
+type readCountingStateDB struct {
+	StateDB
+	reads int
+}
+
+func (c *readCountingStateDB) GetStateAndCommittedState(addr common.Address, hash common.Hash) (common.Hash, common.Hash) {
+	c.reads++
+	return c.StateDB.GetStateAndCommittedState(addr, hash)
+}
+
+// TestPIP88SStoreAccessCheck pins the ordering invariant of the PIP-88 SSTORE gas
+// function: the cold access cost exceeds the reentrancy sentry, so clearing the
+// sentry does not imply the caller can afford a cold slot access. The committed
+// state read must not happen until affordability is confirmed. The wantReads
+// column is the load-bearing assertion — an error-string check alone would not
+// catch a read performed before the guard.
+func TestPIP88SStoreAccessCheck(t *testing.T) {
+	addr := common.BytesToAddress([]byte("victim"))
+	sentry := params.SstoreSentryGasEIP2200 // 2300
+	cold := params.ColdSstoreCostPIP88      // 2940
+
+	tests := []struct {
+		name      string
+		warm      bool
+		gas       uint64
+		wantErr   string
+		wantReads int
+	}{
+		{"cold, at sentry, rejected before read", false, sentry, "not enough gas for reentrancy sentry", 0},
+		{"cold, above sentry below access, rejected before read", false, sentry + 1, "not enough gas for slot access", 0},
+		{"cold, one below access, rejected before read", false, cold - 1, "not enough gas for slot access", 0},
+		{"cold, at access, reads", false, cold, "", 1},
+		{"warm, above sentry, reads", true, sentry + 1, "", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+			inner.CreateAccount(addr)
+			if tt.warm {
+				inner.AddSlotToAccessList(addr, common.Hash{})
+			}
+			sdb := &readCountingStateDB{StateDB: inner}
+			evm := NewEVM(BlockContext{}, sdb, params.AllEthashProtocolChanges, Config{})
+
+			contract := NewContract(common.Address{}, addr, uint256.NewInt(0), tt.gas, nil)
+			stack := newstack()
+			stack.push(uint256.NewInt(1)) // value  (Back(1))
+			stack.push(new(uint256.Int))  // key    (peek) -> slot 0
+			_, err := gasSStorePIP88(evm, contract, stack, nil, 0)
+
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			case tt.wantErr != "" && (err == nil || err.Error() != tt.wantErr):
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
+			if sdb.reads != tt.wantReads {
+				t.Fatalf("committed-state reads = %d, want %d", sdb.reads, tt.wantReads)
+			}
+		})
+	}
+}

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -102,20 +102,29 @@ func makeGasSStoreFuncPIP88(clearingRefund uint64) gasFunc {
 		}
 		// Gas sentry honoured, do the actual gas calculation based on the stored value
 		var (
-			y, x              = stack.Back(1), stack.peek()
-			slot              = common.Hash(x.Bytes32())
-			current, original = evm.StateDB.GetStateAndCommittedState(contract.Address(), slot)
-			cost              = uint64(0)
+			y, x = stack.Back(1), stack.peek()
+			slot = common.Hash(x.Bytes32())
+			cost = uint64(0)
 		)
-		// Check slot presence in the access list
+		// Resolve the slot's access cost and warm it before reading. The reentrancy
+		// sentry only guarantees SstoreSentryGasEIP2200, which no longer covers a
+		// cold access once ColdSstoreCostPIP88 exceeds it, so affordability is
+		// checked here rather than implied by the sentry.
+		access := params.WarmStorageReadCostEIP2929
 		if _, slotPresent := evm.StateDB.SlotInAccessList(contract.Address(), slot); !slotPresent {
 			// PIP-88: charge ColdSstoreCostPIP88. Must match the constant
 			// subtracted in the SSTORE_RESET formula below so the EIP-2929
 			// invariant `cold + (RESET - cold) == RESET` (5000) still holds.
 			cost = params.ColdSstoreCostPIP88
+			access = params.ColdSstoreCostPIP88
 			// If the caller cannot afford the cost, this change will be rolled back
 			evm.StateDB.AddSlotToAccessList(contract.Address(), slot)
 		}
+		// Only read the slot once the caller can pay for the access.
+		if contract.Gas < access {
+			return 0, errors.New("not enough gas for slot access")
+		}
+		current, original := evm.StateDB.GetStateAndCommittedState(contract.Address(), slot)
 
 		value := common.Hash(y.Bytes32())
 


### PR DESCRIPTION
## Summary

The PIP-88 SSTORE gas function (`makeGasSStoreFuncPIP88`, `core/vm/operations_acl.go`)
performed the committed-state read **before** it knew the slot's access cost. Because
the cold access cost (`ColdSstoreCostPIP88` = 2940) exceeds the reentrancy sentry
(`SstoreSentryGasEIP2200` = 2300), clearing the sentry no longer guarantees the caller
can pay for a cold access — so the read could be performed for a call that then runs out
of gas, i.e. work the gas schedule does not charge for. On bor this path is live behind
Chicago (mainnet, Amoy).

This PR resolves the access cost and warms the slot first, verifies the caller can afford
the access, and only then reads — matching the ordering go-ethereum adopted for its
EIP-8037/8038 SSTORE handler in ethereum/go-ethereum#35261.

**Outcome-neutral.** The guard only rejects callers that already fail the subsequent
charge — the minimum cold total (3040 = 2940 + 100) exceeds the 2940 guard — so no
transaction changes success/failure or gas used; both routes surface `ErrOutOfGas`. Every
returned gas value is byte-identical. Not a hardfork.

Verified on a devnet built from this branch (Chicago active), against the same devnet
built from `develop`:

| | develop | this branch |
| --- | ---: | ---: |
| attack tx `gasUsed` | 454349 | **454349 (identical)** |
| block witness under attack | 21,788 B | **4,243 B (back to baseline)** |

The identical `gasUsed` is the outcome-neutrality check on a live chain — same gas, same
OOG outcome; only the block witness (non-consensus) shrinks, because the reverted read no
longer populates the trie-fetch path that feeds witness collection.

## Executed tests

- `go test ./core/vm/` — new `TestPIP88SStoreAccessCheck` passes (5 boundary cases). It
  uses a read-counting `StateDB` to assert the committed-state read does **not** happen
  once gas is above the sentry but below the access cost — the boundary an error-string
  check alone would miss.
- Full `core/vm` suite unchanged (no gas-value test flips). The one intermittent failure,
  `TestAbortDuringJump/JUMP`, is a pre-existing timing-race flake — it fails identically
  on `develop` with this change stashed out and passes in isolation.
- `go build ./...`, `gofmt`, `go vet ./core/vm/` clean.
- **Devnet (Kurtosis, bor from this branch):** opcode-level `debug_traceCall` sweep on a
  cold slot flips only in the intended window — at 2600 gas the SSTORE now rejects with
  `not enough gas for slot access` before the read, while ≤2300 and ≥2940 are unchanged.
  Baseline-vs-attack witness windows show the witness back at baseline (table above); the
  chain produced blocks normally throughout.

## Rollout notes

- **Not consensus-affecting; no coordinated upgrade required.** Gas charged, transaction
  success/failure, receipts, and state roots are identical before and after — a full-sync
  node produces the same blocks. The only change is a smaller block witness for the
  affected calls.
- **No hardfork.** The fix is a bug fix within the already-active Chicago/PIP-88 behavior,
  not a schedule change.
- **Witness / stateless-sync note for reviewers:** because the fix removes a read, a fixed
  producer emits a slightly smaller witness. Full-sync nodes are unaffected; witness
  producers and stateless-sync consumers should move together during rollout. The witness
  is not committed in the block header on the current (pre-Amsterdam) chain, so there is no
  consensus impact — worth a reviewer confirming against the target release.
