### PR TITLE
ci: focus codegenie on Bor production paths

### DIFF
--- a/codegenie.toml
+++ b/codegenie.toml
@@ -40,11 +40,62 @@ pattern = "docs/cli/**"
 processingMode = "skip"
 reason = "generated CLI reference (make docs)"
 
+[[classification.pathRules]]
+pattern = "build/checksums.txt"
+processingMode = "skip"
+reason = "generated release checksum manifest"
+
+# Inherited geth components that Bor does not use in production. Keep a
+# lightweight compatibility review because shared interfaces still compile
+# into Bor and are used by tests and developer tooling.
+
+[[classification.pathRules]]
+pattern = "beacon/**"
+reviewPriority = "low"
+reason = "geth beacon-client functionality is not used by Bor production"
+
+[[classification.pathRules]]
+pattern = "consensus/beacon/**"
+reviewPriority = "low"
+reason = "geth beacon consensus engine is not used by Bor production"
+
+[[classification.pathRules]]
+pattern = "consensus/clique/**"
+reviewPriority = "low"
+reason = "Clique consensus is not used by Bor production"
+
+[[classification.pathRules]]
+pattern = "consensus/ethash/**"
+reviewPriority = "low"
+reason = "Ethash consensus is not used by Bor production"
+
+[[classification.pathRules]]
+pattern = "eth/catalyst/**"
+reviewPriority = "low"
+reason = "Beacon Engine API is not used by Bor production consensus"
+
+# Standalone upstream developer tools outside normal Bor operation.
+
+[[classification.pathRules]]
+pattern = "cmd/evm/**"
+reviewPriority = "low"
+reason = "standalone geth EVM developer tool"
+
+[[classification.pathRules]]
+pattern = "cmd/devp2p/**"
+reviewPriority = "low"
+reason = "standalone geth networking developer tool"
+
+[[classification.pathRules]]
+pattern = "cmd/blsync/**"
+reviewPriority = "low"
+reason = "standalone beacon light-sync tool"
+
 # Consensus-critical zones, mirroring the scopes in .claude/rules. Bugs here
 # can halt the chain, split consensus, or lose funds.
 
 [[classification.pathRules]]
-pattern = "consensus/**"
+pattern = "consensus/bor/**"
 reviewPriority = "critical"
 labels = ["consensus"]
 reason = "validator auth, sprint/span block production, Heimdall trust, fork choice"

--- a/codegenie.toml
+++ b/codegenie.toml
@@ -101,6 +101,12 @@ labels = ["consensus"]
 reason = "validator auth, sprint/span block production, Heimdall trust, fork choice"
 
 [[classification.pathRules]]
+pattern = "consensus/misc/**"
+reviewPriority = "critical"
+labels = ["consensus"]
+reason = "shared base-fee, blob-gas, and gas-limit validation used by Bor production"
+
+[[classification.pathRules]]
 pattern = "miner/**"
 reviewPriority = "critical"
 labels = ["consensus"]


### PR DESCRIPTION
## Summary

Focus CodeGini's review budget on Bor production paths during large upstream merges. Narrow consensus-critical classification to `consensus/bor/**`, assign low priority to inherited geth consensus/beacon components and standalone developer tools, and skip the generated release checksum manifest.

Applied to #2325, this policy affects 27 of 102 changed files: one generated manifest is skipped and 26 inherited/tool files are reviewed at low priority. Core execution, state, VM, txpool, trie, miner, networking, RPC, and hardfork paths retain their existing normal or critical review.

## Executed tests

- Parsed `codegenie.toml` with Python `tomllib`
- Ran `git diff --check`
- Verified rule ordering against CodeGini v0.5.5 classification behavior
- Compared the rules against all changed paths in #2325

## Rollout notes

CI review-policy only. No consensus, runtime, or operator impact. Inherited components are demoted rather than skipped so CodeGini still checks shared-interface and build compatibility.
