### PR TITLE
core/vm, params: gate SSTORE committed-state read ordering behind Hampi

### DIFF
--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -337,6 +337,7 @@ func GatherForks(config *params.ChainConfig, genesisTime uint64) (heightForks []
 			config.Bor.GiuglianoBlock,
 			config.Bor.ChicagoBlock,
 			config.Bor.ValenciaBlock,
+			config.Bor.HampiBlock,
 		} {
 			if fork != nil {
 				heightForks = append(heightForks, fork.Uint64())

--- a/core/vm/contracts_continuity_test.go
+++ b/core/vm/contracts_continuity_test.go
@@ -92,6 +92,9 @@ func TestBorHardforkPrecompileContinuityProfiles(t *testing.T) {
 		{name: "Lisovo", rules: params.Rules{IsLisovo: true}, profile: borPrecompileProfileLisovo},
 		{name: "LisovoPro", rules: params.Rules{IsLisovoPro: true}, profile: borPrecompileProfileLisovoPro},
 		{name: "Chicago", rules: params.Rules{IsChicago: true}, profile: borPrecompileProfileChicago},
+		// Hampi gates only the SSTORE committed-state read ordering, so it carries
+		// Chicago's profile unchanged. At a post-Hampi block IsChicago is also set.
+		{name: "Hampi", rules: params.Rules{IsChicago: true, IsHampi: true}, profile: borPrecompileProfileChicago},
 	}
 
 	for _, tc := range cases {

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -638,32 +638,6 @@ func TestKZGPointEvaluationPrecompileRemoval(t *testing.T) {
 	}
 }
 
-// TestHampiPrecompileParityWithChicago pins Hampi's intended precompile delta over
-// Chicago: none. Hampi gates only the SSTORE committed-state read ordering, so the
-// active set at a post-Hampi block must be identical to Chicago's. Asserting set
-// identity (rather than probing a single address) is what gives this teeth if a
-// future change hands Hampi its own precompile set.
-func TestHampiPrecompileParityWithChicago(t *testing.T) {
-	t.Parallel()
-
-	chicago := ActivePrecompiledContracts(params.Rules{IsChicago: true})
-	hampi := ActivePrecompiledContracts(params.Rules{IsChicago: true, IsHampi: true})
-
-	if len(chicago) != len(hampi) {
-		t.Fatalf("precompile count differs: chicago=%d hampi=%d", len(chicago), len(hampi))
-	}
-	for addr, want := range chicago {
-		got, exists := hampi[addr]
-		if !exists {
-			t.Errorf("precompile %s present under Chicago but missing under Hampi", addr)
-			continue
-		}
-		if got.Name() != want.Name() {
-			t.Errorf("precompile %s differs: chicago=%s hampi=%s", addr, want.Name(), got.Name())
-		}
-	}
-}
-
 // TestPIP88PrecompileGasCosts verifies pre- and post-PIP-88 gas for every
 // precompile repriced by the Chicago fork.
 func TestPIP88PrecompileGasCosts(t *testing.T) {

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -540,6 +540,7 @@ func TestReinforceMultiClientPreCompilesTest(t *testing.T) {
 		"IsLisovo",
 		"IsLisovoPro",
 		"IsChicago",
+		"IsHampi",
 	}
 
 	if len(actual) != len(expected) {
@@ -619,6 +620,9 @@ func TestKZGPointEvaluationPrecompileRemoval(t *testing.T) {
 		{name: "Lisovo", rules: params.Rules{IsLisovo: true}, shouldHaveKzg: true},
 		{name: "LisovoPro", rules: params.Rules{IsLisovoPro: true}, shouldHaveKzg: false},
 		{name: "Chicago", rules: params.Rules{IsChicago: true}, shouldHaveKzg: false},
+		// Hampi introduces no precompile delta over Chicago; it only gates the SSTORE
+		// committed-state read ordering.
+		{name: "Hampi", rules: params.Rules{IsHampi: true}, shouldHaveKzg: false},
 	}
 	for _, tc := range cases {
 		precompiles := ActivePrecompiledContracts(tc.rules)

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -620,9 +620,8 @@ func TestKZGPointEvaluationPrecompileRemoval(t *testing.T) {
 		{name: "Lisovo", rules: params.Rules{IsLisovo: true}, shouldHaveKzg: true},
 		{name: "LisovoPro", rules: params.Rules{IsLisovoPro: true}, shouldHaveKzg: false},
 		{name: "Chicago", rules: params.Rules{IsChicago: true}, shouldHaveKzg: false},
-		// Hampi introduces no precompile delta over Chicago; it only gates the SSTORE
-		// committed-state read ordering.
-		{name: "Hampi", rules: params.Rules{IsHampi: true}, shouldHaveKzg: false},
+		// At a post-Hampi block IsChicago is also set, so the fixture carries both.
+		{name: "Hampi", rules: params.Rules{IsChicago: true, IsHampi: true}, shouldHaveKzg: false},
 	}
 	for _, tc := range cases {
 		precompiles := ActivePrecompiledContracts(tc.rules)
@@ -635,6 +634,32 @@ func TestKZGPointEvaluationPrecompileRemoval(t *testing.T) {
 		}
 		if exists && pc.Name() != kzgPointEvaluationPrecompile.Name() {
 			t.Errorf("invalid precompile loaded instead of kzgPointEvaluation (0x0a). expected name: %s, got name: %s, test case: %s", kzgPointEvaluationPrecompile.Name(), pc.Name(), tc.name)
+		}
+	}
+}
+
+// TestHampiPrecompileParityWithChicago pins Hampi's intended precompile delta over
+// Chicago: none. Hampi gates only the SSTORE committed-state read ordering, so the
+// active set at a post-Hampi block must be identical to Chicago's. Asserting set
+// identity (rather than probing a single address) is what gives this teeth if a
+// future change hands Hampi its own precompile set.
+func TestHampiPrecompileParityWithChicago(t *testing.T) {
+	t.Parallel()
+
+	chicago := ActivePrecompiledContracts(params.Rules{IsChicago: true})
+	hampi := ActivePrecompiledContracts(params.Rules{IsChicago: true, IsHampi: true})
+
+	if len(chicago) != len(hampi) {
+		t.Fatalf("precompile count differs: chicago=%d hampi=%d", len(chicago), len(hampi))
+	}
+	for addr, want := range chicago {
+		got, exists := hampi[addr]
+		if !exists {
+			t.Errorf("precompile %s present under Chicago but missing under Hampi", addr)
+			continue
+		}
+		if got.Name() != want.Name() {
+			t.Errorf("precompile %s differs: chicago=%s hampi=%s", addr, want.Name(), got.Name())
 		}
 	}
 }

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -206,29 +206,52 @@ func (c *readCountingStateDB) GetStateAndCommittedState(addr common.Address, has
 	return c.StateDB.GetStateAndCommittedState(addr, hash)
 }
 
+// hampiTestChainConfig copies the shared test chain config with Hampi scheduled at
+// forkBlock, so a test can exercise both sides of the gate without mutating globals.
+func hampiTestChainConfig(forkBlock *big.Int) *params.ChainConfig {
+	cfg := *params.AllEthashProtocolChanges
+	bor := *params.AllEthashProtocolChanges.Bor
+	bor.HampiBlock = forkBlock
+	cfg.Bor = &bor
+
+	return &cfg
+}
+
 // TestPIP88SStoreAccessCheck pins the ordering invariant of the PIP-88 SSTORE gas
 // function: the cold access cost exceeds the reentrancy sentry, so clearing the
-// sentry does not imply the caller can afford a cold slot access. The committed
-// state read must not happen until affordability is confirmed. The wantReads
+// sentry does not imply the caller can afford a cold slot access. From Hampi the
+// committed state read must not happen until affordability is confirmed, and
+// before Hampi the pre-existing ordering must be preserved exactly. The wantReads
 // column is the load-bearing assertion — an error-string check alone would not
 // catch a read performed before the guard.
 func TestPIP88SStoreAccessCheck(t *testing.T) {
 	addr := common.BytesToAddress([]byte("victim"))
 	sentry := params.SstoreSentryGasEIP2200 // 2300
 	cold := params.ColdSstoreCostPIP88      // 2940
+	const forkBlock = 100
 
 	tests := []struct {
 		name      string
 		warm      bool
 		gas       uint64
+		block     int64
 		wantErr   string
 		wantReads int
 	}{
-		{"cold, at sentry, rejected before read", false, sentry, "not enough gas for reentrancy sentry", 0},
-		{"cold, above sentry below access, rejected before read", false, sentry + 1, "not enough gas for slot access", 0},
-		{"cold, one below access, rejected before read", false, cold - 1, "not enough gas for slot access", 0},
-		{"cold, at access, reads", false, cold, "", 1},
-		{"warm, above sentry, reads", true, sentry + 1, "", 1},
+		// At and after activation the read is deferred behind the affordability check.
+		{"at fork, cold, at sentry, rejected before read", false, sentry, forkBlock, "not enough gas for reentrancy sentry", 0},
+		{"at fork, cold, above sentry below access, rejected before read", false, sentry + 1, forkBlock, "not enough gas for slot access", 0},
+		{"at fork, cold, one below access, rejected before read", false, cold - 1, forkBlock, "not enough gas for slot access", 0},
+		{"at fork, cold, at access, reads", false, cold, forkBlock, "", 1},
+		{"at fork, warm, above sentry, reads", true, sentry + 1, forkBlock, "", 1},
+		{"after fork, cold, in window, rejected before read", false, cold - 1, forkBlock + 1, "not enough gas for slot access", 0},
+
+		// Before activation the gate is inert: the read still happens inside the
+		// window and the new error is never surfaced.
+		{"before fork, cold, in window, still reads", false, cold - 1, forkBlock - 1, "", 1},
+		{"before fork, cold, just above sentry, still reads", false, sentry + 1, forkBlock - 1, "", 1},
+		{"before fork, cold, at sentry, rejected by sentry", false, sentry, forkBlock - 1, "not enough gas for reentrancy sentry", 0},
+		{"before fork, cold, at access, reads", false, cold, forkBlock - 1, "", 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -238,7 +261,8 @@ func TestPIP88SStoreAccessCheck(t *testing.T) {
 				inner.AddSlotToAccessList(addr, common.Hash{})
 			}
 			sdb := &readCountingStateDB{StateDB: inner}
-			evm := NewEVM(BlockContext{}, sdb, params.AllEthashProtocolChanges, Config{})
+			blockCtx := BlockContext{BlockNumber: big.NewInt(tt.block)}
+			evm := NewEVM(blockCtx, sdb, hampiTestChainConfig(big.NewInt(forkBlock)), Config{})
 
 			contract := NewContract(common.Address{}, addr, uint256.NewInt(0), tt.gas, nil)
 			stack := newstack()

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -106,10 +106,9 @@ func makeGasSStoreFuncPIP88(clearingRefund uint64) gasFunc {
 			slot = common.Hash(x.Bytes32())
 			cost = uint64(0)
 		)
-		// Resolve the slot's access cost and warm it before reading. The reentrancy
-		// sentry only guarantees SstoreSentryGasEIP2200, which no longer covers a
-		// cold access once ColdSstoreCostPIP88 exceeds it, so affordability is
-		// checked here rather than implied by the sentry.
+		// Resolve the slot's access cost and warm it before reading. Warming ahead of
+		// the read is unobservable — the read does not consult the access list — so
+		// this ordering is shared by both sides of the Hampi gate below.
 		access := params.WarmStorageReadCostEIP2929
 		if _, slotPresent := evm.StateDB.SlotInAccessList(contract.Address(), slot); !slotPresent {
 			// PIP-88: charge ColdSstoreCostPIP88. Must match the constant
@@ -120,8 +119,14 @@ func makeGasSStoreFuncPIP88(clearingRefund uint64) gasFunc {
 			// If the caller cannot afford the cost, this change will be rolled back
 			evm.StateDB.AddSlotToAccessList(contract.Address(), slot)
 		}
-		// Only read the slot once the caller can pay for the access.
-		if contract.Gas < access {
+		// From Hampi, only read the slot once the caller can pay for the access. The
+		// reentrancy sentry only guarantees SstoreSentryGasEIP2200, which no longer
+		// covers a cold access once ColdSstoreCostPIP88 exceeds it. Every caller
+		// rejected here fails the charge below anyway (the cheapest cold total,
+		// ColdSstoreCostPIP88+WarmStorageReadCostEIP2929, exceeds access), so gas and
+		// the ErrOutOfGas outcome are unchanged across the fork; only the committed
+		// state read — and therefore witness composition — differs.
+		if evm.chainRules.IsHampi && contract.Gas < access {
 			return 0, errors.New("not enough gas for slot access")
 		}
 		current, original := evm.StateDB.GetStateAndCommittedState(contract.Address(), slot)

--- a/internal/cli/server/chains/amoy.go
+++ b/internal/cli/server/chains/amoy.go
@@ -44,6 +44,8 @@ var amoyTestnet = &Chain{
 				GiuglianoBlock:    big.NewInt(35573500),
 				ChicagoBlock:      big.NewInt(38358000),
 				ValenciaBlock:     big.NewInt(40776000),
+				HampiBlock:        nil, // unscheduled
+
 				StateSyncConfirmationDelay: map[string]uint64{
 					"0": 128,
 				},

--- a/internal/cli/server/chains/mainnet.go
+++ b/internal/cli/server/chains/mainnet.go
@@ -45,6 +45,8 @@ var mainnetBor = &Chain{
 				GiuglianoBlock:    big.NewInt(85268500),
 				ChicagoBlock:      big.NewInt(87218600),
 				ValenciaBlock:     big.NewInt(89531000),
+				HampiBlock:        nil, // unscheduled
+
 				StateSyncConfirmationDelay: map[string]uint64{
 					"44934656": 128,
 				},

--- a/params/config.go
+++ b/params/config.go
@@ -348,6 +348,8 @@ var (
 			GiuglianoBlock:    big.NewInt(35573500),
 			ChicagoBlock:      big.NewInt(38358000),
 			ValenciaBlock:     big.NewInt(40776000),
+			HampiBlock:        nil, // unscheduled
+
 			StateSyncConfirmationDelay: map[string]uint64{
 				"0": 128,
 			},
@@ -437,6 +439,8 @@ var (
 			GiuglianoBlock:    big.NewInt(85268500),
 			ChicagoBlock:      big.NewInt(87218600),
 			ValenciaBlock:     big.NewInt(89531000),
+			HampiBlock:        nil, // unscheduled
+
 			StateSyncConfirmationDelay: map[string]uint64{
 				"44934656": 128,
 			},
@@ -744,6 +748,7 @@ var (
 			LisovoProBlock:    big.NewInt(0),
 			ChicagoBlock:      big.NewInt(0),
 			ValenciaBlock:     big.NewInt(0),
+			HampiBlock:        big.NewInt(0),
 		},
 	}
 
@@ -962,6 +967,7 @@ type BorConfig struct {
 	GiuglianoBlock             *big.Int          `json:"giuglianoBlock"`             // Giugliano switch block (nil = no fork, 0 = already on giugliano)
 	ChicagoBlock               *big.Int          `json:"chicagoBlock"`               // Chicago switch block (nil = no fork, 0 = already on chicago)
 	ValenciaBlock              *big.Int          `json:"valenciaBlock"`              // Valencia switch block (nil = no fork, 0 = already on valencia)
+	HampiBlock                 *big.Int          `json:"hampiBlock"`                 // Hampi switch block (nil = no fork, 0 = already on hampi)
 }
 
 // String implements the stringer interface, returning the consensus engine details.
@@ -1043,6 +1049,10 @@ func (c *BorConfig) IsChicago(number *big.Int) bool {
 
 func (c *BorConfig) IsValencia(number *big.Int) bool {
 	return isBlockForked(c.ValenciaBlock, number)
+}
+
+func (c *BorConfig) IsHampi(number *big.Int) bool {
+	return isBlockForked(c.HampiBlock, number)
 }
 
 // GetTargetGasPercentage returns the target gas percentage for gas limit calculation.
@@ -1258,6 +1268,9 @@ func (c *ChainConfig) Description() string {
 		}
 		if c.Bor.ValenciaBlock != nil {
 			banner += fmt.Sprintf(" - Valencia:                  #%-8v\n", c.Bor.ValenciaBlock)
+		}
+		if c.Bor.HampiBlock != nil {
+			banner += fmt.Sprintf(" - Hampi:                     #%-8v\n", c.Bor.HampiBlock)
 		}
 		return banner
 	}
@@ -1898,6 +1911,7 @@ type Rules struct {
 	IsLisovo                                                bool
 	IsLisovoPro                                             bool
 	IsChicago                                               bool
+	IsHampi                                                 bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1934,5 +1948,6 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, _ uint64) Rules {
 		IsLisovo:         c.Bor != nil && c.Bor.IsLisovo(num),
 		IsLisovoPro:      c.Bor != nil && c.Bor.IsLisovoPro(num),
 		IsChicago:        c.Bor != nil && c.Bor.IsChicago(num),
+		IsHampi:          c.Bor != nil && c.Bor.IsHampi(num),
 	}
 }

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -238,6 +238,33 @@ func TestIsValencia(t *testing.T) {
 	}
 }
 
+func TestIsHampi(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		fork   *big.Int
+		number int64
+		want   bool
+	}{
+		{"unset fork never active", nil, 0, false},
+		{"unset fork never active at height", nil, 1_000_000, false},
+		{"genesis activation at 0", big.NewInt(0), 0, true},
+		{"genesis activation above 0", big.NewInt(0), 1, true},
+		{"scheduled fork before activation", big.NewInt(100), 99, false},
+		{"scheduled fork at activation", big.NewInt(100), 100, true},
+		{"scheduled fork after activation", big.NewInt(100), 101, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &BorConfig{HampiBlock: tt.fork}
+			assert.Equal(t, c.IsHampi(big.NewInt(tt.number)), tt.want)
+		})
+	}
+}
+
 func TestOverrideStateSyncRecordsInRange(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Introduces the **Hampi** fork, wired dormant, and moves the PIP-88 SSTORE
committed-state read ordering (#2356) behind it.
Thanks to @cholakovvv for reaching out, and the discussion that led to this

#2356 defers the committed-state read until the caller is known to afford the
slot access. That is gas- and outcome-neutral — gas charged, the `ErrOutOfGas`
outcome, receipts and state roots are identical either way — but it also shrinks
the block witness, because the deferred read no longer contributes trie nodes.

The witness is not committed in any header field, so this is invisible to
consensus. It is not invisible to **stateless consumers**, which reconstruct
state from the witness: a producer emitting a smaller witness than an older
consumer expects leaves that consumer without a node it still reads, and its
import fails (`InsertChain` errors — see the `"witness missing required trie
nodes"` case in `core/blockchain_test.go`). Un-gated, that transition happens at
whatever moment each operator upgrades, in whatever order.

Gating it means the change lands at a single coordinated height instead. Note
the asymmetry that makes this safe in one direction: an older (superset) witness
read by a newer consumer is fine — only the reverse breaks.

**Hampi ships dormant.** `HampiBlock` is `nil` on every preset, so it gates no
behaviour and, because `forkid` skips nil forks, contributes nothing to fork ID.
Shipping this changes nothing operationally until a block is scheduled.

### Wiring

| Surface | Change |
| --- | --- |
| `params/config.go` | `HampiBlock` field, `IsHampi()`, `Rules.IsHampi` + population, explicit `nil` on mainnet/amoy presets, `0` in `MergedTestChainConfig`, startup banner |
| `core/forkid/forkid.go` | added to the gather list |
| `internal/cli/server/chains/{mainnet,amoy}.go` | `HampiBlock: nil` (unscheduled) |
| `core/vm/operations_acl.go` | the gate |

The gate is a single condition, so the pre/post-fork delta is one line:

```go
if evm.chainRules.IsHampi && contract.Gas < access {
```

Access-list warming moves above the read so both sides share one path. The read
never consults the access list, so pre-fork behaviour is byte-identical to
today's.

## Executed tests

- `TestPIP88SStoreAccessCheck` reworked into a fork-boundary table covering
  N-1 / N / N+1: before activation the read still happens below the access cost
  (old behaviour preserved); at and after activation it is skipped. The
  read-counting `StateDB` remains the load-bearing assertion — an error-string
  check alone would not catch a read performed before the guard.
- `TestIsHampi` — standard activation table.
- Both fork meta-guards updated/checked: `TestReinforceMultiClientPreCompilesTest`
  (the `Rules` field list needs `IsHampi`) and the precompile-continuity case
  asserting Hampi introduces **no precompile delta** over Chicago.
  `TestV2ForkParity` needs no entry — it reflects over `*params.ChainConfig`
  methods, and `IsHampi` is on `*BorConfig`, like `IsChicago`.
- `go build ./...`, `gofmt`, `go vet` clean. `params`, `core/forkid`, and `core`
  (272s) all pass. `core/vm` passes except `TestInterruptDuringExecution`, which
  is **pre-existing**: it fails 5/5 on clean `develop` with a byte-identical
  signature (verified in a throwaway worktree), independent of this change.

## Rollout notes

- **Not consensus-affecting as shipped.** Dormant fork, no behaviour gated, no
  fork ID contribution while `HampiBlock` is nil.
- **When scheduling the block**, set it in *both* the Go runtime presets and the
  packaged genesis JSON (`builder/files/genesis-mainnet-v1.json`,
  `genesis-amoy.json`). This PR deliberately adds it to neither, since it is
  unscheduled — a value present in genesis but missing from the runtime preset
  is the known activation-miss failure class.
- Activation should be gated on confirmed upgrade adoption across the validator
  set rather than a date, with Amoy first.
- This will need cascading into the open upstream-sync stack once merged.
